### PR TITLE
[18] Add support for unicode sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           echo "Checking PR description for semver selection..."
 
           # Count how many semver checkboxes are selected
-          SELECTED_COUNT=$(echo "$PR_BODY" | grep -cE "\[x\] \*\*(MAJOR|MINOR|PATCH)\*\*" || true)
+          SELECTED_COUNT=$(echo "$PR_BODY" | grep -cE "\[[xX]\] \*\*(MAJOR|MINOR|PATCH)\*\*" || true)
 
           if [ "$SELECTED_COUNT" -eq 0 ]; then
             echo "❌ Error: No semver checkbox selected in PR description"
@@ -136,7 +136,7 @@ jobs:
             echo "Multiple selections create ambiguous version intent."
             echo ""
             echo "Current selections:"
-            echo "$PR_BODY" | grep -E "\[x\] \*\*(MAJOR|MINOR|PATCH)\*\*"
+            echo "$PR_BODY" | grep -E "\[[xX]\] \*\*(MAJOR|MINOR|PATCH)\*\*"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Determine version bump from merged PRs
         id: version
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Get the latest tag, default to v0.0.0 if no tags exist
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -68,7 +70,7 @@ jobs:
           fi
 
           # Initialize semver bump level (0=none, 1=patch, 2=minor, 3=major)
-          MAX_BUMP=1  # Default to patch if no explicit selection found
+          MAX_BUMP=0  # Must be explicitly set by PR checkbox
 
           # Parse each commit to find semver selections
           while IFS= read -r line; do
@@ -77,18 +79,49 @@ jobs:
             fi
             
             COMMIT_HASH=$(echo "$line" | awk '{print $1}')
+            COMMIT_MESSAGE=${line#* }
             
-            COMMIT_BODY=$(git log -1 --pretty=format:"%b" $COMMIT_HASH)
+            # Extract PR number from squash merge format: "Title (#123)"
+            PR_NUMBER=$(echo "$COMMIT_MESSAGE" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+')
             
-            # Check for semver selections in commit body (look for checked boxes)
-            if echo "$COMMIT_BODY" | grep -q "\[x\] \*\*MAJOR\*\*"; then
-              echo "Found MAJOR bump in commit $COMMIT_HASH"
+            if [ -z "$PR_NUMBER" ]; then
+              echo "❌ Error: No PR number found in commit $COMMIT_HASH"
+              echo "Commit message: $COMMIT_MESSAGE"
+              echo "All commits must be from merged PRs with format 'Title (#123)'"
+              exit 1
+            fi
+            
+            echo "Checking PR #$PR_NUMBER for commit $COMMIT_HASH"
+            
+            # Fetch PR body using GitHub CLI
+            GH_OUTPUT=$(gh pr view "$PR_NUMBER" --json body --jq '.body' 2>&1)
+            GH_EXIT_CODE=$?
+            if [ $GH_EXIT_CODE -ne 0 ] || [ -z "$GH_OUTPUT" ]; then
+              echo "❌ Error: Could not fetch PR body for #$PR_NUMBER"
+              echo "gh CLI error output:"
+              echo "$GH_OUTPUT"
+              exit 1
+            fi
+            
+            # Check for semver selections in PR body (look for checked boxes)
+            PR_BODY="$GH_OUTPUT"
+            if echo "$PR_BODY" | grep -q "\[[xX]\] \*\*MAJOR\*\*"; then
+              echo "Found MAJOR bump in PR #$PR_NUMBER"
               MAX_BUMP=3
-            elif echo "$COMMIT_BODY" | grep -q "\[x\] \*\*MINOR\*\*"; then
-              echo "Found MINOR bump in commit $COMMIT_HASH"
+            elif echo "$PR_BODY" | grep -q "\[[xX]\] \*\*MINOR\*\*"; then
+              echo "Found MINOR bump in PR #$PR_NUMBER"
               if [ $MAX_BUMP -lt 2 ]; then
                 MAX_BUMP=2
               fi
+            elif echo "$PR_BODY" | grep -q "\[[xX]\] \*\*PATCH\*\*"; then
+              echo "Found PATCH bump in PR #$PR_NUMBER"
+              if [ $MAX_BUMP -lt 1 ]; then
+                MAX_BUMP=1
+              fi
+            else
+              echo "❌ Error: No version bump checkbox selected in PR #$PR_NUMBER"
+              echo "Please select MAJOR, MINOR, or PATCH in the PR description"
+              exit 1
             fi
           done <<< "$COMMITS"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for [`unicodeSets`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) in the regex search strategy, via upgrade to [Version 0.2.0 of `regex-partial-match`](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.2.0)
+- Link to codeql runs on `main` from the `README.md`
+
+### Fixed
+
+- Release pipeline updated to properly support semver selection in PR bodies
+- Updated stylesheet transclusion examples in `README.md` for proper typing and realistic replacement
+
 ## [0.1.3] - 2025-12-22
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Release pipeline updated to properly support semver selection in PR bodies
+- Release pipeline updated to properly support semver selection in PR bodies, and updated ci pipeline to support valid casings, to match
 - Updated stylesheet transclusion examples in `README.md` for proper typing and realistic replacement
 
 ## [0.1.3] - 2025-12-22

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "test/benchmarks"
       ],
       "dependencies": {
-        "regex-partial-match": "^0.1.13"
+        "regex-partial-match": "^0.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -3815,9 +3815,9 @@
       }
     },
     "node_modules/regex-partial-match": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/regex-partial-match/-/regex-partial-match-0.1.13.tgz",
-      "integrity": "sha512-uc6K4BHoFk9G1pLb43GAqPhb7ghrr1zLIgxKea0FgXJbWAcJVhpTnWXv3T8zgEK/9O8bmIXV0wpVAXTWqw5y3w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regex-partial-match/-/regex-partial-match-0.2.0.tgz",
+      "integrity": "sha512-rmBE4cMjAMJpOfhqmWgkpO55ej1gQ6aNP2nfTQ73adgEbZkyiuy/t8Qal8rglJzDrZhvmlaAJvic/RfYdwTtdg==",
       "license": "ISC"
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "rimraf lib &&  tsc -p tsconfig.build.json",
+    "build": "rimraf lib && tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:ci": "vitest run --coverage",
     "test:watch": "vitest",
@@ -89,7 +89,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "regex-partial-match": "^0.1.13"
+    "regex-partial-match": "^0.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/search-strategies/regex/README.md
+++ b/src/search-strategies/regex/README.md
@@ -262,7 +262,7 @@ Quantifier will be satisfied eagerly, thus multiple matches will occur. e.g. chu
 - [Character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class): `/[a-z]/`
 - [Character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape): `/\w+/`, `/\d{3}/`
 - [Unicode character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape): `/\p{Script_Extensions=Latin}+/gu`
-- [Disjunctions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction): `/cat|dog/`
+- 🧮 [Unicode sets (`v` flag)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) (`/[\p{Lowercase}&&\p{Script=Greek}]/v`)- [Disjunctions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction): `/cat|dog/`
 - [Non-capturing groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group): `/(?:hello)+/`
 - Capturing groups ([unnamed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) and [named](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group)): `/(hello|hi) there (?<name>.+?)/`
 - [Multiline](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline): `/^.+?$/ms`

--- a/src/search-strategies/regex/README.md
+++ b/src/search-strategies/regex/README.md
@@ -256,17 +256,19 @@ Quantifier will be satisfied eagerly, thus multiple matches will occur. e.g. chu
 
 ### ✅ Supported Features
 
-- [Literal characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character) / simple patterns: `/test/`
-- [Lookahead assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) (positive only): `/foo(?=bar)/`
-- [Quantifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet#quantifiers): `/a{2,4}/`, `/b*?/`, `/c+/` (with caveats above for potential split matching, etc.)
-- [Character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class): `/[a-z]/`
-- [Character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape): `/\w+/`, `/\d{3}/`
-- [Unicode character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape): `/\p{Script_Extensions=Latin}+/gu`
-- 🧮 [Unicode sets (`v` flag)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) (`/[\p{Lowercase}&&\p{Script=Greek}]/v`)- [Disjunctions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction): `/cat|dog/`
-- [Non-capturing groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group): `/(?:hello)+/`
-- Capturing groups ([unnamed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) and [named](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group)): `/(hello|hi) there (?<name>.+?)/`
-- [Multiline](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline): `/^.+?$/ms`
-- Boundary assertions ([input](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion), [word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion)): `/\b.+?\b/`, `/^t/m`
+- 🔤 [Literal characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character) / simple patterns: `/test/`
+- 👀 [Lookahead assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) (positive only): `/foo(?=bar)/`
+- 🔢 [Quantifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet#quantifiers): `/a{2,4}/`, `/b*?/`, `/c+/` (with caveats above for potential split matching, etc.)
+- 📋 [Character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class): `/[a-z]/`
+- 🔣 [Character escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape) (`\n`, `\t`, `\x61`, `\u0061`, `\u{1F600}`)
+- 🧩 [Character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape): `/\w+/`, `/\d{3}/`
+- 🌐 [Unicode character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape): `/\p{Script_Extensions=Latin}+/gu`
+- 🧮 [Unicode sets (`v` flag)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) (`/[\p{Lowercase}&&\p{Script=Greek}]/v`)
+- 🔀 [Disjunctions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction): `/cat|dog/`
+- 👥 [Non-capturing groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group): `/(?:hello)+/`
+- 👪 Capturing groups (🫥 [unnamed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) and 📛 [named](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group)): `/(hello|hi) there (?<name>.+?)/`
+- 三 [Multiline](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline): `/^.+?$/ms`
+- 🚧 Boundary assertions (⚓ [input](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion), 🆒 [word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion)): `/\b.+?\b/`, `/^t/m`
 
 ## Credits
 

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -268,13 +268,91 @@ describe("RegexSearchStrategy", () => {
         ]
       },
       {
-        name: "handles patterns with unicode character classes",
+        name: "handles patterns with unicode character class escapes",
         pattern: /\p{Script=Hiragana}+/u,
         chunks: ["Say こんにちは to everyone"],
         expected: [
           { content: "Say ", match: false },
           { content: "こんにちは", match: true },
           { content: " to everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet character classes",
+        pattern: /[\p{Script=Hiragana}]+/v,
+        chunks: ["Say こんにちは to everyone"],
+        expected: [
+          { content: "Say ", match: false },
+          { content: "こんにちは", match: true },
+          { content: " to everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet inverse character classes",
+        pattern: /[\p{Script=Hiragana}]+/v,
+        chunks: ["Say konnichiwa to everyone"],
+        expected: [{ content: "Say konnichiwa to everyone", match: false }]
+      },
+      {
+        name: "handles patterns with unicodeSet character classes with intersections",
+        pattern: /[\p{Script=Hiragana}&&\p{Alphabetic}]+/v,
+        chunks: ["Say こんにちは to everyone"],
+        expected: [
+          { content: "Say ", match: false },
+          { content: "こんにちは", match: true },
+          { content: " to everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with complement unicodeSet character classes with intersections",
+        pattern: /[\P{Script=Hiragana}&&\P{Alphabetic}]+/v,
+        chunks: ["Say こんにちは123 to everyone"],
+        expected: [
+          { content: "Say", match: false },
+          { content: " ", match: true },
+          { content: "こんにちは", match: false },
+          { content: "123 ", match: true },
+          { content: "to", match: false },
+          { content: " ", match: true },
+          { content: "everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet union character classes",
+        pattern: /[\p{Script=Hiragana}\p{Alphabetic}]+/v,
+        chunks: ["Say こんにちは to everyone"],
+        expected: [
+          { content: "Say", match: true },
+          { content: " ", match: false },
+          { content: "こんにちは", match: true },
+          { content: " ", match: false },
+          { content: "to", match: true },
+          { content: " ", match: false },
+          { content: "everyone", match: true }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet union character classes, negated",
+        pattern: /[^\p{Script=Hiragana}\p{Alphabetic}]+/v,
+        chunks: ["Say こんにちは to everyone"],
+        expected: [
+          { content: "Say", match: false },
+          { content: " ", match: true },
+          { content: "こんにちは", match: false },
+          { content: " ", match: true },
+          { content: "to", match: false },
+          { content: " ", match: true },
+          { content: "everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet character classes with subtraction",
+        pattern: /[\p{Script=Hiragana}--[ちは]]+/v,
+        chunks: ["Say こんにちは to everyone"],
+        expected: [
+          { content: "Say ", match: false },
+          { content: "こんに", match: true },
+          { content: "ちは to everyone", match: false }
         ]
       },
       {
@@ -661,7 +739,7 @@ describe("RegexSearchStrategy", () => {
         ]
       },
       {
-        name: "handles patterns with match groups, across chunks (with caveat that multiple matches may occur)",
+        name: "handles patterns with character classes, across chunks (with caveat that multiple matches may occur)",
         pattern: /[A-Z]+/,
         chunks: ["find PAT", "TERN here"],
         expected: [
@@ -683,7 +761,7 @@ describe("RegexSearchStrategy", () => {
         ]
       },
       {
-        name: "handles patterns with unicode character classes, across chunks (with caveat that multiple matches may occur)",
+        name: "handles patterns with unicode character class escapes, across chunks (with caveat that multiple matches may occur)",
         pattern: /\p{Script=Hiragana}+/u,
         chunks: ["Say こんに", "ちは to everyone"],
         expected: [

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -288,7 +288,7 @@ describe("RegexSearchStrategy", () => {
         ]
       },
       {
-        name: "handles patterns with unicodeSet inverse character classes",
+        name: "handles patterns with unicodeSet character classes (inverse scenario)",
         pattern: /[\p{Script=Hiragana}]+/v,
         chunks: ["Say konnichiwa to everyone"],
         expected: [{ content: "Say konnichiwa to everyone", match: false }]
@@ -783,7 +783,7 @@ describe("RegexSearchStrategy", () => {
         ]
       },
       {
-        name: "handles patterns with unicodeSet inverse character classes, across chunks (with caveat that multiple matches may occur)",
+        name: "handles patterns with unicodeSet character classes (inverse scenario), across chunks (with caveat that multiple matches may occur)",
         pattern: /[\p{Script=Hiragana}]+/v,
         chunks: ["Say konn", "ichiwa to everyone"],
         expected: [

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -750,7 +750,7 @@ describe("RegexSearchStrategy", () => {
         ]
       },
       {
-        name: "handles patterns with Unicode characters and emojis, across chunks",
+        name: "handles patterns with unicode characters and emojis, across chunks",
         pattern: /(こんにちは|👋)/,
         chunks: ["Say こん", "にちは to everyone ", "👋"],
         expected: [
@@ -769,6 +769,94 @@ describe("RegexSearchStrategy", () => {
           { content: "こんに", match: true },
           { content: "ちは", match: true },
           { content: " to everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet character classes, across chunks (with caveat that multiple matches may occur)",
+        pattern: /[\p{Script=Hiragana}]+/v,
+        chunks: ["Say こん", "にちは to everyone"],
+        expected: [
+          { content: "Say ", match: false },
+          { content: "こん", match: true },
+          { content: "にちは", match: true },
+          { content: " to everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet inverse character classes, across chunks (with caveat that multiple matches may occur)",
+        pattern: /[\p{Script=Hiragana}]+/v,
+        chunks: ["Say konn", "ichiwa to everyone"],
+        expected: [
+          { content: "Say konn", match: false },
+          { content: "ichiwa to everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet character classes with intersections, across chunks (with caveat that multiple matches may occur)",
+        pattern: /[\p{Script=Hiragana}&&\p{Alphabetic}]+/v,
+        chunks: ["Say こんに", "ちは to everyone"],
+        expected: [
+          { content: "Say ", match: false },
+          { content: "こんに", match: true },
+          { content: "ちは", match: true },
+          { content: " to everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with complement unicodeSet character classes with intersections, across chunks (with caveat that multiple matches may occur)",
+        pattern: /[\P{Script=Hiragana}&&\P{Alphabetic}]+/v,
+        chunks: ["Say こんに", "ちは12", "3 to everyone"],
+        expected: [
+          { content: "Say", match: false },
+          { content: " ", match: true },
+          { content: "こんに", match: false },
+          { content: "ちは", match: false },
+          { content: "12", match: true },
+          { content: "3 ", match: true },
+          { content: "to", match: false },
+          { content: " ", match: true },
+          { content: "everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet union character classes, across chunks (with caveat that multiple matches may occur)",
+        pattern: /[\p{Script=Hiragana}\p{Alphabetic}]+/v,
+        chunks: ["Say こん", "にちは to everyone"],
+        expected: [
+          { content: "Say", match: true },
+          { content: " ", match: false },
+          { content: "こん", match: true },
+          { content: "にちは", match: true },
+          { content: " ", match: false },
+          { content: "to", match: true },
+          { content: " ", match: false },
+          { content: "everyone", match: true }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet union character classes, negated, across chunks (with caveat that multiple matches may occur)",
+        pattern: /[^\p{Script=Hiragana}\p{Alphabetic}]+/v,
+        chunks: ["Say こんに", "ちは to everyone"],
+        expected: [
+          { content: "Say", match: false },
+          { content: " ", match: true },
+          { content: "こんに", match: false },
+          { content: "ちは", match: false },
+          { content: " ", match: true },
+          { content: "to", match: false },
+          { content: " ", match: true },
+          { content: "everyone", match: false }
+        ]
+      },
+      {
+        name: "handles patterns with unicodeSet character classes with subtraction, across chunks (with caveat that multiple matches may occur)",
+        pattern: /[\p{Script=Hiragana}--[ちは]]+/v,
+        chunks: ["Say こん", "にちは to everyone"],
+        expected: [
+          { content: "Say ", match: false },
+          { content: "こん", match: true },
+          { content: "に", match: true },
+          { content: "ちは to everyone", match: false }
         ]
       },
       {


### PR DESCRIPTION
## Issue

resolves #18

## Details

- Upgraded to [Version 0.2.0 of `regex-partial-match`](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.2.0) to support [`unicodeSets`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets).
  - Ran timeseries algorithm benchmarks (before/after) to ensure no regression of performance.

## Scout rule

- Fixed `release.yml` to ensure semver selection properly identified from PR bodies, and updated ci pipeline to support valid casings, to match
- Updated stylesheet transclusion examples in `README.md` for proper typing and realistic replacement
- Link to codeql runs on `main` from the `README.md`

## Semantic Version Impact

<!-- Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/ -->

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [x] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
