### PR TITLE
[21] Allow consumers of RegexSearchStrategy can receive full RegExpExecArray when matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -483,14 +483,14 @@ Processors accept chunks from the `Transformer` (web) / `stream.Transform` (node
 ```typescript
 // sync or async, dependent on asynchronicity of the replacement needed
 *processChunk(chunk: string): Generator<string, void, undefined> {
-  for (const result of this.searchStrategy.processChunk(
+  for (const { isMatch, content } of this.searchStrategy.processChunk(
     chunk,
     this.searchState
   )) {
-    if (result.isMatch) {
+    if (isMatch) {
       yield /* some replacement form (static, functional, iterator, async...) */
     } else {
-      yield result.content;
+      yield content;
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ const transformer = new ReplaceContentTransformer<Promise<string>>(
 );
 ```
 
-> [!NOTE]
+> [!TIP]
 > If promise-concurrency needs control, consider a replacement function that limits in-flight promises via pooling:
 
 ```typescript
@@ -419,21 +419,23 @@ It has separated concerns:
 Pluggable strategies implement the `SearchStrategy` interface:
 
 ```typescript
-interface MatchResult {
-  content: string;
-  match: boolean;
-}
-interface SearchStrategy<TState> {
+type MatchResult<T = string> =
+  | { isMatch: false; content: string }
+  | { isMatch: true; content: T };
+
+interface SearchStrategy<TState, TMatch = string> {
   createState(): TState;
   processChunk(
     haystack: string,
     state: TState
-  ): Generator<MatchResult, void, undefined>;
+  ): Generator<MatchResult<TMatch>, void, undefined>;
   flush(state: TState): string;
 }
 ```
 
 The `TState` type is specific to the strategy, managed by the consuming processor / stream, to keep the strategies stateless. This means any construction cost can be reduced, with strategies re-used across multiple streams.
+
+The `TMatch` type (defaulting to `string`) allows strategies like `RegexSearchStrategy` to return richer match data (e.g., `RegExpExecArray`) that includes capture groups.
 
 The `flush` is called by the processor to extract anything buffered from the search strategy. This also re-sets the provided state parameter for re-use.
 
@@ -485,10 +487,10 @@ Processors accept chunks from the `Transformer` (web) / `stream.Transform` (node
     chunk,
     this.searchState
   )) {
-    if (result.match) {
+    if (result.isMatch) {
       yield /* some replacement form (static, functional, iterator, async...) */
     } else {
-      return result.content
+      yield result.content;
     }
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `RegexSearchStrategy` replacement functions now receive `RegExpExecArray` instead of `string`. This enables direct access to capture groups (`match[1]`, `match.groups`), but existing code using string methods like `match.toUpperCase()` must change to `match[0].toUpperCase()`
+- `MatchResult` type refactored to a discriminated union with boolean discriminant: `{ isMatch: false; content: string } | { isMatch: true; content: T }`. This is a breaking change for custom `SearchStrategy` implementations or direct `processChunk()` consumers. Use `if (result.isMatch)` to check for matches and access the typed content via `result.content`
+- `SearchStrategy` interface now accepts a second type parameter for match type: `SearchStrategy<TState, TMatch = string>`
+- Replacement processors now use `<TState, TMatch>` type parameters directly for improved type inference
+
+### Added
+
+- Exported `StringAnchorSearchState` type alias for typed processor declarations
+
+### Fixed
+
+- Added explicit `read` permission to the `ci.yml` GitHub actions workflow
+- Various `README.md` typos
+
 ## [0.2.0] - 2025-12-25
 
 ### Added

--- a/src/adapters/web/sync-transformer.integration.test.ts
+++ b/src/adapters/web/sync-transformer.integration.test.ts
@@ -9,7 +9,7 @@ describe("ReplaceContentTransformer + StringAnchorSearchStrategy + Promise-retur
 
     const searchStrategy = new StringAnchorSearchStrategy(["{{", "}}"]);
 
-    const processor = new FunctionReplacementProcessor<Promise<string>>({
+    const processor = new FunctionReplacementProcessor({
       searchStrategy,
       replacement: async (match: string, index: number): Promise<string> => {
         await vi.waitFor(() => Promise.resolve(), { timeout: 10 });
@@ -17,7 +17,7 @@ describe("ReplaceContentTransformer + StringAnchorSearchStrategy + Promise-retur
       }
     });
 
-    const transformer = new ReplaceContentTransformer<Promise<string>>(
+    const transformer = new ReplaceContentTransformer(
       processor
     );
 
@@ -71,7 +71,7 @@ describe("ReplaceContentTransformer + StringAnchorSearchStrategy + Promise-retur
     });
 
     let callCount = 0;
-    const processor = new FunctionReplacementProcessor<Promise<string>>({
+    const processor = new FunctionReplacementProcessor({
       searchStrategy,
       replacement: (): Promise<string> => {
         callCount++;
@@ -79,7 +79,7 @@ describe("ReplaceContentTransformer + StringAnchorSearchStrategy + Promise-retur
       }
     });
 
-    const transformer = new ReplaceContentTransformer<Promise<string>>(
+    const transformer = new ReplaceContentTransformer(
       processor
     );
 

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -6,9 +6,9 @@ import { inspect } from "node:util";
 describe("AsyncFunctionReplacementProcessor", () => {
   it("calls async replacement function with matched content and index", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "MATCH", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "MATCH" },
+      { isMatch: false, content: " world" }
     );
 
     const asyncReplacementFn = vi.fn().mockResolvedValue("ASYNC_RESULT");
@@ -29,9 +29,9 @@ describe("AsyncFunctionReplacementProcessor", () => {
 
   it("increments match index for subsequent async matches", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "MATCH", match: true },
-      { content: " and ", match: false },
-      { content: "MATCH", match: true }
+      { isMatch: true, content: "MATCH" },
+      { isMatch: false, content: " and " },
+      { isMatch: true, content: "MATCH" }
     );
 
     const asyncReplacementFn = vi.fn().mockResolvedValue("ASYNC");
@@ -53,9 +53,9 @@ describe("AsyncFunctionReplacementProcessor", () => {
 
   it("handles string replacement with async processor", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "OLD", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " world" }
     );
 
     const processor = new AsyncFunctionReplacementProcessor({
@@ -78,10 +78,10 @@ describe("AsyncFunctionReplacementProcessor", () => {
       processChunk: vi.fn().mockImplementation(function* () {
         callCount++;
         if (callCount === 1) {
-          yield { content: "text ", match: false };
+          yield { isMatch: false, content: "text " };
         } else {
-          yield { content: "OLD", match: true };
-          yield { content: " end", match: false };
+          yield { isMatch: true, content: "OLD" };
+          yield { isMatch: false, content: " end" };
         }
       }),
       flush: vi.fn().mockReturnValue("")
@@ -114,9 +114,9 @@ describe("AsyncFunctionReplacementProcessor", () => {
     });
 
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "OLD", match: true },
-      { content: " and ", match: false },
-      { content: "OLD", match: true }
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " and " },
+      { isMatch: true, content: "OLD" }
     );
 
     const processor = new AsyncFunctionReplacementProcessor({
@@ -144,8 +144,8 @@ describe("AsyncFunctionReplacementProcessor", () => {
 describe("flush", () => {
   it("returns buffered content when called", async () => {
     const mockStrategy = mockSearchStrategyFactory({
-      content: "text ",
-      match: false
+      isMatch: false,
+      content: "text "
     });
     mockStrategy.flush.mockReturnValue("OL");
 

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -1,14 +1,28 @@
-import { ReplacementProcessorBase } from "./replacement-processor.base.ts";
-import { type FunctionReplacementProcessorOptions } from "./function-replacement-processor.ts";
+import {
+  ReplacementProcessorBase,
+  type ReplacementProcessorOptions
+} from "./replacement-processor.base.ts";
 import { type AsyncProcessor } from "./types.ts";
 
 /**
  * Configuration options for {@link AsyncFunctionReplacementProcessor}.
  * 
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  */
-type AsyncFunctionReplacementProcessorOptions<T> =
-  FunctionReplacementProcessorOptions<Promise<string>, T>;
+export type AsyncFunctionReplacementProcessorOptions<
+  TState,
+  TMatch = string
+> = ReplacementProcessorOptions<TState, TMatch> & {
+  /**
+   * Async function called for each match to generate the replacement content.
+   * 
+   * @param match - The matched content
+   * @param index - Zero-based index of this match
+   * @returns Promise resolving to the replacement string
+   */
+  replacement: (match: TMatch, index: number) => Promise<string>;
+};
 
 /**
  * A replacement processor that uses an async function to generate replacement values.
@@ -22,14 +36,15 @@ type AsyncFunctionReplacementProcessorOptions<T> =
  * - When replacements must be processed in strict sequential order
  * - For simpler async patterns without needing early discovery
  * 
- * **Comparison with FunctionReplacementProcessor<Promise<string>>**:
+ * **Comparison with FunctionReplacementProcessor with async replacement**:
  * - `AsyncFunctionReplacementProcessor`: Awaits each replacement sequentially (serial execution)
- * - `FunctionReplacementProcessor<Promise<string>>`: Calls all functions immediately (parallel execution)
+ * - `FunctionReplacementProcessor` with async: Calls all functions immediately (parallel execution)
  * 
  * The sequential behavior ensures matches are replaced in order and works with Node.js streams,
  * but may be slower than the parallel Promise pattern available in WHATWG Streams.
  * 
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  * 
  * @example Node.js async replacements
  * ```typescript
@@ -49,31 +64,31 @@ type AsyncFunctionReplacementProcessorOptions<T> =
  * pipeline(Readable.from(['User: {{user}}']), transform, process.stdout);
  * ```
  */
-export class AsyncFunctionReplacementProcessor<T>
-  extends ReplacementProcessorBase<T>
-  implements AsyncProcessor
-{
-  private readonly replacementFn: AsyncFunctionReplacementProcessorOptions<T>["replacement"];
+export class AsyncFunctionReplacementProcessor<
+  TState,
+  TMatch = string
+> extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
+  private readonly replacementFn: (match: TMatch, index: number) => Promise<string>;
   private matchIndex: number = 0;
 
   constructor({
     searchStrategy,
     replacement
-  }: AsyncFunctionReplacementProcessorOptions<T>) {
+  }: AsyncFunctionReplacementProcessorOptions<TState, TMatch>) {
     super({ searchStrategy });
     this.replacementFn = replacement;
   }
 
   async *processChunk(chunk: string): AsyncGenerator<string, void, undefined> {
-    for (const { match, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!match) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield await this.replacementFn(content, this.matchIndex++);
+      yield await this.replacementFn(result.content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -80,15 +80,15 @@ export class AsyncFunctionReplacementProcessor<
   }
 
   async *processChunk(chunk: string): AsyncGenerator<string, void, undefined> {
-    for (const result of this.searchStrategy.processChunk(
+    for (const { isMatch, content } of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!result.isMatch) {
-        yield result.content;
+      if (!isMatch) {
+        yield content;
         continue;
       }
-      yield await this.replacementFn(result.content, this.matchIndex++);
+      yield await this.replacementFn(content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
@@ -5,9 +5,9 @@ import { AsyncIterableFunctionReplacementProcessor } from "./async-iterable-func
 describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("yields stream content chunk-by-chunk without buffering", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "OLD", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " world" }
     );
 
     const streamChunks = ["chunk1", "chunk2", "chunk3"];
@@ -41,9 +41,9 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
 
   it("handles multiple matches with different stream replacements", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "OLD", match: true },
-      { content: " and ", match: false },
-      { content: "OLD", match: true }
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " and " },
+      { isMatch: true, content: "OLD" }
     );
 
     const stream1Chunks = ["A1", "A2"];
@@ -77,9 +77,9 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
 
   it("handles empty stream replacement", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "OLD", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " world" }
     );
 
     const emptyStream = new ReadableStream({
@@ -102,13 +102,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   });
 
   it("handles stream replacement with match context and index", async () => {
-    const mockStrategy = {
-      createState: vi.fn().mockReturnValue({}),
-      processChunk: vi.fn().mockImplementation(function* () {
-        yield { content: "MATCH", match: true };
-      }),
-      flush: vi.fn().mockReturnValue("")
-    };
+    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH" });
 
     const streamFactory = async (matchedContent: string, index: number) => {
       return new ReadableStream({
@@ -142,10 +136,10 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
       processChunk: vi.fn().mockImplementation(function* () {
         callCount++;
         if (callCount === 1) {
-          yield { content: "text ", match: false };
+          yield { isMatch: false, content: "text " };
         } else {
-          yield { content: "OLD", match: true };
-          yield { content: " end", match: false };
+          yield { isMatch: true, content: "OLD" };
+          yield { isMatch: false, content: " end" };
         }
       }),
       flush: vi.fn().mockReturnValue("")
@@ -183,8 +177,8 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
 describe("flush", () => {
   it("returns buffered content when called", async () => {
     const mockStrategy = mockSearchStrategyFactory({
-      content: "text ",
-      match: false
+      isMatch: false,
+      content: "text "
     });
     mockStrategy.flush.mockReturnValue("OL");
 

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -103,15 +103,15 @@ export class AsyncIterableFunctionReplacementProcessor<
   }
 
   async *processChunk(chunk: string): AsyncGenerator<string, void, undefined> {
-    for (const result of this.searchStrategy.processChunk(
+    for (const { isMatch, content } of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!result.isMatch) {
-        yield result.content;
+      if (!isMatch) {
+        yield content;
         continue;
       }
-      yield* await this.replacementFn(result.content, this.matchIndex++);
+      yield* await this.replacementFn(content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -1,14 +1,28 @@
-import { ReplacementProcessorBase } from "./replacement-processor.base.ts";
-import { type FunctionReplacementProcessorOptions } from "./function-replacement-processor.ts";
+import {
+  ReplacementProcessorBase,
+  type ReplacementProcessorOptions
+} from "./replacement-processor.base.ts";
 import { type AsyncProcessor } from "./types.ts";
 
 /**
  * Configuration options for {@link AsyncIterableFunctionReplacementProcessor}.
  * 
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  */
-type AsyncIterableFunctionReplacementProcessorOptions<T> =
-  FunctionReplacementProcessorOptions<Promise<AsyncIterable<string>>, T>;
+export type AsyncIterableFunctionReplacementProcessorOptions<
+  TState,
+  TMatch = string
+> = ReplacementProcessorOptions<TState, TMatch> & {
+  /**
+   * Async function called for each match that returns an async iterable of replacement strings.
+   * 
+   * @param match - The matched content (type inferred from search strategy)
+   * @param index - Zero-based index of this match
+   * @returns Promise resolving to an async iterable of replacement strings
+   */
+  replacement: (match: TMatch, index: number) => Promise<AsyncIterable<string>>;
+};
 
 /**
  * A replacement processor that uses an async function returning an async iterable.
@@ -24,7 +38,8 @@ type AsyncIterableFunctionReplacementProcessorOptions<T> =
  * - Lazy generation of replacement content with async dependencies
  * - Node.js streams requiring multi-value async replacements
  * 
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  * 
  * @example Streaming replacement from async source
  * ```typescript
@@ -72,31 +87,31 @@ type AsyncIterableFunctionReplacementProcessorOptions<T> =
  * });
  * ```
  */
-export class AsyncIterableFunctionReplacementProcessor<T>
-  extends ReplacementProcessorBase<T>
-  implements AsyncProcessor
-{
-  private readonly replacementFn: AsyncIterableFunctionReplacementProcessorOptions<T>["replacement"];
+export class AsyncIterableFunctionReplacementProcessor<
+  TState,
+  TMatch = string
+> extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
+  private readonly replacementFn: (match: TMatch, index: number) => Promise<AsyncIterable<string>>;
   private matchIndex: number = 0;
 
   constructor({
     searchStrategy,
     replacement
-  }: AsyncIterableFunctionReplacementProcessorOptions<T>) {
+  }: AsyncIterableFunctionReplacementProcessorOptions<TState, TMatch>) {
     super({ searchStrategy });
     this.replacementFn = replacement;
   }
 
   async *processChunk(chunk: string): AsyncGenerator<string, void, undefined> {
-    for (const { match, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!match) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield* await this.replacementFn(content, this.matchIndex++);
+      yield* await this.replacementFn(result.content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/function-replacement-processor.integration.test.ts
+++ b/src/replacement-processors/function-replacement-processor.integration.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { StringAnchorSearchStrategy } from "../search-strategies/index.ts";
+import {
+  StringAnchorSearchStrategy,
+  RegexSearchStrategy
+} from "../search-strategies/index.ts";
 import { FunctionReplacementProcessor } from "./function-replacement-processor.ts";
 
 describe("FunctionReplacementProcessor + StringAnchorSearchStrategy", () => {
@@ -48,5 +51,82 @@ describe("FunctionReplacementProcessor + StringAnchorSearchStrategy", () => {
     ];
 
     expect(results.join("")).toEqual("{xREPLACEDy");
+  });
+});
+
+describe("FunctionReplacementProcessor + RegexSearchStrategy", () => {
+  it("provides full match via index [0]", () => {
+    const processor = new FunctionReplacementProcessor({
+      searchStrategy: new RegexSearchStrategy(/\{\{(\w+)\}\}/),
+      replacement: (match) => {
+        return `[FULL:${match[0]}]`;
+      }
+    });
+
+    const results = [
+      ...Array.from(processor.processChunk("before {{name}} after")),
+      processor.flush()
+    ];
+
+    expect(results.join("")).toEqual("before [FULL:{{name}}] after");
+  });
+
+  it("provides numbered capture groups via indices [1], [2], etc.", () => {
+    const processor = new FunctionReplacementProcessor({
+      searchStrategy: new RegexSearchStrategy(/\{\{(\w+):(\w+)\}\}/),
+      replacement: (match) => {
+        return `[GROUP1:${match[1]}|GROUP2:${match[2]}]`;
+      }
+    });
+
+    const results = [
+      ...Array.from(processor.processChunk("value is {{type:value}} here")),
+      processor.flush()
+    ];
+
+    expect(results.join("")).toEqual(
+      "value is [GROUP1:type|GROUP2:value] here"
+    );
+  });
+
+  it("provides named capture groups via .groups property", () => {
+    const processor = new FunctionReplacementProcessor({
+      searchStrategy: new RegexSearchStrategy(
+        /\{\{(?<key>\w+):(?<val>\w+)\}\}/
+      ),
+      replacement: (match) => {
+        return `[KEY:${match.groups?.key}|VAL:${match.groups?.val}]`;
+      }
+    });
+
+    const results = [
+      ...Array.from(processor.processChunk("data is {{name:john}} here")),
+      processor.flush()
+    ];
+
+    expect(results.join("")).toEqual("data is [KEY:name|VAL:john] here");
+  });
+
+  it("handles multiple matches with different capture group values", () => {
+    const matchedGroups: Array<{ full: string; group1: string }> = [];
+
+    const processor = new FunctionReplacementProcessor({
+      searchStrategy: new RegexSearchStrategy(/\[(\w+)\]/),
+      replacement: (match) => {
+        matchedGroups.push({ full: match[0], group1: match[1] });
+        return `<${match[1]}>`;
+      }
+    });
+
+    const results = [
+      ...Array.from(processor.processChunk("test [alpha] and [beta] end")),
+      processor.flush()
+    ];
+
+    expect(results.join("")).toEqual("test <alpha> and <beta> end");
+    expect(matchedGroups).toEqual([
+      { full: "[alpha]", group1: "alpha" },
+      { full: "[beta]", group1: "beta" }
+    ]);
   });
 });

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -6,8 +6,8 @@ describe("FunctionReplacementProcessor", () => {
   describe("processChunk", () => {
     it("yields input directly when search strategy finds no match", () => {
       const mockStrategy = mockSearchStrategyFactory({
-        content: "test input",
-        match: false
+        isMatch: false,
+        content: "test input"
       });
 
       const processor = new FunctionReplacementProcessor({
@@ -26,9 +26,9 @@ describe("FunctionReplacementProcessor", () => {
 
     it("yields content before match and replacement when complete match found", () => {
       const mockStrategy = mockSearchStrategyFactory(
-        { content: "Hello ", match: false },
-        { content: "OLD", match: true },
-        { content: " world", match: false }
+        { isMatch: false, content: "Hello " },
+        { isMatch: true, content: "OLD" },
+        { isMatch: false, content: " world" }
       );
 
       const processor = new FunctionReplacementProcessor({
@@ -50,8 +50,8 @@ describe("FunctionReplacementProcessor", () => {
 
     it("buffers incomplete match and yields nothing", () => {
       const mockStrategy = mockSearchStrategyFactory({
-        content: "text ",
-        match: false
+        isMatch: false,
+        content: "text "
       });
 
       const processor = new FunctionReplacementProcessor({
@@ -81,12 +81,12 @@ describe("FunctionReplacementProcessor", () => {
           callCount++;
           if (callCount === 1) {
             // First chunk: yield non-match content before buffered partial
-            yield { content: "text ", match: false };
+            yield { isMatch: false, content: "text " };
             // "OL" is buffered (not yielded)
           } else if (callCount === 2) {
             // Second chunk completes the match
-            yield { content: "OLD", match: true };
-            yield { content: " end", match: false };
+            yield { isMatch: true, content: "OLD" };
+            yield { isMatch: false, content: " end" };
           }
         }),
         flush: vi.fn().mockReturnValue("")
@@ -112,9 +112,9 @@ describe("FunctionReplacementProcessor", () => {
 
     it("calls replacement function with matched content and index", () => {
       const mockStrategy = mockSearchStrategyFactory(
-        { content: "Hello ", match: false },
-        { content: "MATCH", match: true },
-        { content: " world", match: false }
+        { isMatch: false, content: "Hello " },
+        { isMatch: true, content: "MATCH" },
+        { isMatch: false, content: " world" }
       );
 
       const replacementFn = vi.fn().mockReturnValue("RESULT");
@@ -140,9 +140,9 @@ describe("FunctionReplacementProcessor", () => {
         processChunk: vi.fn().mockImplementation(function* () {
           callCount++;
           if (callCount === 1) {
-            yield { content: "MATCH", match: true };
+            yield { isMatch: true, content: "MATCH" };
           } else if (callCount === 2) {
-            yield { content: "MATCH", match: true };
+            yield { isMatch: true, content: "MATCH" };
           }
         }),
         flush: vi.fn().mockReturnValue("")
@@ -170,9 +170,9 @@ describe("FunctionReplacementProcessor", () => {
 
     it("continues processing after match to find subsequent matches", () => {
       const mockStrategy = mockSearchStrategyFactory(
-        { content: "OLD", match: true },
-        { content: " and ", match: false },
-        { content: "OLD", match: true }
+        { isMatch: true, content: "OLD" },
+        { isMatch: false, content: " and " },
+        { isMatch: true, content: "OLD" }
       );
 
       const processor = new FunctionReplacementProcessor({
@@ -197,12 +197,12 @@ describe("FunctionReplacementProcessor", () => {
       });
 
       const mockStrategy = mockSearchStrategyFactory(
-        { content: "OLD", match: true },
-        { content: " and ", match: false },
-        { content: "OLD", match: true }
+        { isMatch: true, content: "OLD" },
+        { isMatch: false, content: " and " },
+        { isMatch: true, content: "OLD" }
       );
 
-      const processor = new FunctionReplacementProcessor<Promise<string>>({
+      const processor = new FunctionReplacementProcessor({
         searchStrategy: mockStrategy,
         replacement: asyncReplacementFn
       });
@@ -225,8 +225,8 @@ describe("FunctionReplacementProcessor", () => {
   describe("flush", () => {
     it("returns buffered content when called", () => {
       const mockStrategy = mockSearchStrategyFactory({
-        content: "text ",
-        match: false
+        isMatch: false,
+        content: "text "
       });
       mockStrategy.flush = vi.fn().mockReturnValue("OL");
 
@@ -246,8 +246,8 @@ describe("FunctionReplacementProcessor", () => {
 
     it("returns empty string when no buffered content", () => {
       const mockStrategy = mockSearchStrategyFactory({
-        content: "test",
-        match: false
+        isMatch: false,
+        content: "test"
       });
       mockStrategy.flush = vi.fn().mockReturnValue("");
 

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -6,27 +6,31 @@ import {
 /**
  * Configuration options for {@link FunctionReplacementProcessor}.
  * 
- * @typeParam T - The return type of the replacement function (string or Promise<string>)
- * @typeParam U - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
+ * @typeParam R - The return type of the replacement function (string or Promise<string>)
  */
-export type FunctionReplacementProcessorOptions<T, U> =
-  ReplacementProcessorOptions<U> & {
-    /**
-     * Function called for each match to generate the replacement content.
-     * 
-     * @param matchedContent - The matched text to be replaced
-     * @param index - Zero-based index of this match (increments with each match)
-     * @returns The replacement string, or a Promise<string> for async operations
-     */
-    replacement: (matchedContent: string, index: number) => T;
-  };
+export type FunctionReplacementProcessorOptions<
+  TState,
+  TMatch = string,
+  R extends string | Promise<string> = string
+> = ReplacementProcessorOptions<TState, TMatch> & {
+  /**
+   * Function called for each match to generate the replacement content.
+   * 
+   * @param match - The matched content (type inferred from search strategy)
+   * @param index - Zero-based index of this match (increments with each match)
+   * @returns The replacement string, or a Promise<string> for async operations
+   */
+  replacement: (match: TMatch, index: number) => R;
+};
 
 /**
  * A replacement processor that uses a function to generate replacement values for each match.
  * 
  * This processor supports both synchronous and asynchronous (Promise-based) replacement functions:
- * - `FunctionReplacementProcessor<string>`: Synchronous replacements (default)
- * - `FunctionReplacementProcessor<Promise<string>>`: Async replacements with early discovery
+ * - Synchronous: `replacement: (match) => string`
+ * - Async with early discovery: `replacement: async (match) => string`
  * 
  * The Promise variant is particularly powerful - it calls all replacement functions immediately
  * as matches are discovered, allowing parallel async operations. Promises are enqueued and
@@ -35,8 +39,9 @@ export type FunctionReplacementProcessorOptions<T, U> =
  * **IMPORTANT**: The Promise<string> pattern only works with WHATWG Streams (web adapters).
  * For Node.js streams, use {@link AsyncFunctionReplacementProcessor} instead.
  * 
- * @typeParam T - The return type of the replacement function (string or Promise<string>)
- * @typeParam U - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
+ * @typeParam R - The return type of the replacement function (string or Promise<string>)
  * 
  * @example Synchronous replacements
  * ```typescript
@@ -45,7 +50,7 @@ export type FunctionReplacementProcessorOptions<T, U> =
  * 
  * const processor = new FunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory(/{{(\w+)}}/g),
- *   replacement: (match, index) => `Replacement #${index}: ${match}`
+ *   replacement: (match, index) => `Replacement #${index}: ${match[1]}`
  * });
  * 
  * const transformer = new ReplaceContentTransformer(processor);
@@ -56,7 +61,7 @@ export type FunctionReplacementProcessorOptions<T, U> =
  * import { FunctionReplacementProcessor, searchStrategyFactory } from 'replace-content-transformer';
  * import { ReplaceContentTransformer } from 'replace-content-transformer/web';
  * 
- * const processor = new FunctionReplacementProcessor<Promise<string>>({
+ * const processor = new FunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{id}}'),
  *   replacement: async (match, index) => {
  *     const data = await fetch(`/api/data/${index}`);
@@ -65,34 +70,35 @@ export type FunctionReplacementProcessorOptions<T, U> =
  * });
  * 
  * // All API calls start immediately as matches are found
- * const transformer = new ReplaceContentTransformer<Promise<string>>(processor);
+ * const transformer = new ReplaceContentTransformer(processor);
  * ```
  */
 export class FunctionReplacementProcessor<
-  T extends string | Promise<string> = string,
-  U = unknown
-> extends ReplacementProcessorBase<U> {
-  private readonly replacementFn: (matchedContent: string, index: number) => T;
+  TState,
+  TMatch = string,
+  R extends string | Promise<string> = string
+> extends ReplacementProcessorBase<TState, TMatch> {
+  private readonly replacementFn: (match: TMatch, index: number) => R;
   private matchIndex: number = 0;
 
   constructor({
     searchStrategy,
     replacement
-  }: FunctionReplacementProcessorOptions<T, U>) {
+  }: FunctionReplacementProcessorOptions<TState, TMatch, R>) {
     super({ searchStrategy });
     this.replacementFn = replacement;
   }
 
-  *processChunk(input: string): Generator<T | string, void, undefined> {
-    for (const { match, content } of this.searchStrategy.processChunk(
+  *processChunk(input: string): Generator<R | string, void, undefined> {
+    for (const result of this.searchStrategy.processChunk(
       input,
       this.searchState
     )) {
-      if (!match) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield this.replacementFn(content, this.matchIndex++);
+      yield this.replacementFn(result.content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -90,15 +90,15 @@ export class FunctionReplacementProcessor<
   }
 
   *processChunk(input: string): Generator<R | string, void, undefined> {
-    for (const result of this.searchStrategy.processChunk(
+    for (const { isMatch, content } of this.searchStrategy.processChunk(
       input,
       this.searchState
     )) {
-      if (!result.isMatch) {
-        yield result.content;
+      if (!isMatch) {
+        yield content;
         continue;
       }
-      yield this.replacementFn(result.content, this.matchIndex++);
+      yield this.replacementFn(content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.test.ts
@@ -7,9 +7,9 @@ describe("IterableFunctionReplacementProcessor", () => {
 
   it("yields iterable content chunk-by-chunk without buffering", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "OLD", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " world" }
     );
     const iterableChunks = ["chunk1", "chunk2", "chunk3"];
 
@@ -35,9 +35,9 @@ describe("IterableFunctionReplacementProcessor", () => {
 
   it("handles multiple matches with different iterable replacements", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "OLD", match: true },
-      { content: " and ", match: false },
-      { content: "OLD", match: true }
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " and " },
+      { isMatch: true, content: "OLD" }
     );
 
     const iterable1Chunks = ["A1", "A2"];
@@ -64,9 +64,9 @@ describe("IterableFunctionReplacementProcessor", () => {
 
   it("handles empty iterable replacement", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "OLD", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " world" }
     );
 
     const emptyIterable: string[] = [];
@@ -85,13 +85,7 @@ describe("IterableFunctionReplacementProcessor", () => {
   });
 
   it("handles iterable replacement with match context and index", async () => {
-    const mockStrategy = {
-      createState: vi.fn().mockReturnValue({}),
-      processChunk: vi.fn().mockImplementation(function* () {
-        yield { content: "MATCH", match: true };
-      }),
-      flush: vi.fn().mockReturnValue("")
-    };
+    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH" });
 
     const iterableFactory = (matchedContent: string, index: number) => {
       return [`[${matchedContent}:${index}]`];
@@ -123,10 +117,10 @@ describe("IterableFunctionReplacementProcessor", () => {
       processChunk: vi.fn().mockImplementation(function* () {
         callCount++;
         if (callCount === 1) {
-          yield { content: "text ", match: false };
+          yield { isMatch: false, content: "text " };
         } else {
-          yield { content: "OLD", match: true };
-          yield { content: " end", match: false };
+          yield { isMatch: true, content: "OLD" };
+          yield { isMatch: false, content: " end" };
         }
       }),
       flush: vi.fn().mockReturnValue("")
@@ -158,8 +152,8 @@ describe("IterableFunctionReplacementProcessor", () => {
   describe("flush", () => {
   it("returns buffered content when called", async () => {
     const mockStrategy = mockSearchStrategyFactory({
-      content: "text ",
-      match: false
+      isMatch: false,
+      content: "text "
     });
     mockStrategy.flush.mockReturnValue("OL");
 

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -81,15 +81,15 @@ export class IterableFunctionReplacementProcessor<
   }
 
   *processChunk(chunk: string): Generator<string, void, undefined> {
-    for (const result of this.searchStrategy.processChunk(
+    for (const { isMatch, content } of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!result.isMatch) {
-        yield result.content;
+      if (!isMatch) {
+        yield content;
         continue;
       }
-      yield* this.replacementFn(result.content, this.matchIndex++);
+      yield* this.replacementFn(content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -1,14 +1,28 @@
-import { ReplacementProcessorBase } from "./replacement-processor.base.ts";
-import { type FunctionReplacementProcessorOptions } from "./function-replacement-processor.ts";
+import {
+  ReplacementProcessorBase,
+  type ReplacementProcessorOptions
+} from "./replacement-processor.base.ts";
 import { type SyncProcessor } from "./types.ts";
 
 /**
  * Configuration options for {@link IterableFunctionReplacementProcessor}.
  *
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  */
-type IterableFunctionReplacementProcessorOptions<T> =
-  FunctionReplacementProcessorOptions<Iterable<string>, T>;
+export type IterableFunctionReplacementProcessorOptions<
+  TState,
+  TMatch = string
+> = ReplacementProcessorOptions<TState, TMatch> & {
+  /**
+   * Function called for each match that returns an iterable of replacement strings.
+   *
+   * @param match - The matched content (type inferred from search strategy)
+   * @param index - Zero-based index of this match
+   * @returns An iterable of replacement strings
+   */
+  replacement: (match: TMatch, index: number) => Iterable<string>;
+};
 
 /**
  * A replacement processor that uses a function returning an iterable to generate replacement values.
@@ -23,7 +37,8 @@ type IterableFunctionReplacementProcessorOptions<T> =
  * - Generate replacement content lazily using a generator function
  * - Expand matches into structured text output
  *
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  *
  * @example Replace with multiple strings
  * ```typescript
@@ -50,31 +65,31 @@ type IterableFunctionReplacementProcessorOptions<T> =
  * });
  * ```
  */
-export class IterableFunctionReplacementProcessor<T>
-  extends ReplacementProcessorBase<T>
-  implements SyncProcessor
-{
-  private readonly replacementFn: IterableFunctionReplacementProcessorOptions<T>["replacement"];
+export class IterableFunctionReplacementProcessor<
+  TState,
+  TMatch = string
+> extends ReplacementProcessorBase<TState, TMatch> implements SyncProcessor {
+  private readonly replacementFn: (match: TMatch, index: number) => Iterable<string>;
   private matchIndex: number = 0;
 
   constructor({
     searchStrategy,
     replacement
-  }: IterableFunctionReplacementProcessorOptions<T>) {
+  }: IterableFunctionReplacementProcessorOptions<TState, TMatch>) {
     super({ searchStrategy });
     this.replacementFn = replacement;
   }
 
   *processChunk(chunk: string): Generator<string, void, undefined> {
-    for (const { match, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!match) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield* this.replacementFn(content, this.matchIndex++);
+      yield* this.replacementFn(result.content, this.matchIndex++);
     }
   }
 }

--- a/src/replacement-processors/replacement-processor.base.ts
+++ b/src/replacement-processors/replacement-processor.base.ts
@@ -1,14 +1,22 @@
 import type { SearchStrategy } from "../search-strategies/types";
 
-export type ReplacementProcessorOptions<T> = {
-  searchStrategy: SearchStrategy<T>;
+/**
+ * Base options for all replacement processors.
+ * Uses separate generics for state and match to preserve type information.
+ */
+export type ReplacementProcessorOptions<TState, TMatch> = {
+  searchStrategy: SearchStrategy<TState, TMatch>;
 };
 
-export abstract class ReplacementProcessorBase<T> {
-  protected readonly searchStrategy: SearchStrategy<T>;
-  protected searchState: T;
+/**
+ * Base class for replacement processors.
+ * Uses separate generics for state and match to avoid type casts.
+ */
+export abstract class ReplacementProcessorBase<TState, TMatch> {
+  protected readonly searchStrategy: SearchStrategy<TState, TMatch>;
+  protected searchState: TState;
 
-  constructor({ searchStrategy }: ReplacementProcessorOptions<T>) {
+  constructor({ searchStrategy }: ReplacementProcessorOptions<TState, TMatch>) {
     this.searchStrategy = searchStrategy;
     this.searchState = searchStrategy.createState();
   }

--- a/src/replacement-processors/static-replacement-processor.test.ts
+++ b/src/replacement-processors/static-replacement-processor.test.ts
@@ -7,8 +7,8 @@ describe("StaticReplacementProcessor", () => {
 
   it("yields input directly when search strategy finds no match", () => {
     const mockStrategy = mockSearchStrategyFactory({
-      content: "test output",
-      match: false
+      isMatch: false,
+      content: "test output"
     });
 
     const processor = new StaticReplacementProcessor({
@@ -27,9 +27,9 @@ describe("StaticReplacementProcessor", () => {
 
   it("yields content before match and replacement when complete match found", () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "OLD", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " world" }
     );
 
     const processor = new StaticReplacementProcessor({
@@ -48,11 +48,11 @@ describe("StaticReplacementProcessor", () => {
 
   it("handles multiple replacements in single chunk", () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello ", match: false },
-      { content: "OLD", match: true },
-      { content: " ", match: false },
-      { content: "OLD", match: true },
-      { content: " world", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " " },
+      { isMatch: true, content: "OLD" },
+      { isMatch: false, content: " world" }
     );
 
     const processor = new StaticReplacementProcessor({
@@ -71,8 +71,8 @@ describe("StaticReplacementProcessor", () => {
 
   it("buffers incomplete match at chunk boundary", () => {
     const mockStrategy = mockSearchStrategyFactory({
-      content: "Hello wor",
-      match: false
+      isMatch: false,
+      content: "Hello wor"
     });
     mockStrategy.flush.mockReturnValue("ld");
 
@@ -94,8 +94,8 @@ describe("StaticReplacementProcessor", () => {
 
   it("handles replacement at start of chunk", () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { content: "Hello", match: true },
-      { content: " world", match: false }
+      { isMatch: true, content: "Hello" },
+      { isMatch: false, content: " world" }
     );
 
     const processor = new StaticReplacementProcessor({
@@ -115,8 +115,8 @@ describe("StaticReplacementProcessor", () => {
   describe("flush", () => {
     it("returns buffered content", () => {
       const mockStrategy = mockSearchStrategyFactory({
-        content: "test ",
-        match: false
+        isMatch: false,
+        content: "test "
       });
       mockStrategy.flush.mockReturnValue("input");
 

--- a/src/replacement-processors/static-replacement-processor.ts
+++ b/src/replacement-processors/static-replacement-processor.ts
@@ -7,13 +7,16 @@ import { type SyncProcessor } from "./types.ts";
 /**
  * Configuration options for {@link StaticReplacementProcessor}.
  * 
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  */
-export type StaticReplacementProcessorOptions<T> =
-  ReplacementProcessorOptions<T> & {
-    /** The static string that will replace all matched patterns */
-    replacement: string;
-  };
+export type StaticReplacementProcessorOptions<
+  TState,
+  TMatch = string
+> = ReplacementProcessorOptions<TState, TMatch> & {
+  /** The static string that will replace all matched patterns */
+  replacement: string;
+};
 
 /**
  * A replacement processor that replaces all matches with a static string value.
@@ -22,7 +25,8 @@ export type StaticReplacementProcessorOptions<T> =
  * should be replaced with the same constant value. It processes chunks synchronously
  * and is compatible with both WHATWG Streams and Node.js Transform streams.
  * 
- * @typeParam T - The search state type used by the search strategy
+ * @typeParam TState - The search strategy's state type
+ * @typeParam TMatch - The search strategy's match type (defaults to string)
  * 
  * @example
  * ```typescript
@@ -38,26 +42,26 @@ export type StaticReplacementProcessorOptions<T> =
  * const stream = new TransformStream(transformer);
  * ```
  */
-export class StaticReplacementProcessor<T>
-  extends ReplacementProcessorBase<T>
-  implements SyncProcessor
-{
+export class StaticReplacementProcessor<
+  TState,
+  TMatch = string
+> extends ReplacementProcessorBase<TState, TMatch> implements SyncProcessor {
   private readonly replacement: string;
 
   constructor({
     searchStrategy,
     replacement
-  }: StaticReplacementProcessorOptions<T>) {
+  }: StaticReplacementProcessorOptions<TState, TMatch>) {
     super({ searchStrategy });
     this.replacement = replacement;
   }
 
   *processChunk(chunk: string): Generator<string, void, undefined> {
-    for (const { match, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      yield match ? this.replacement : content;
+      yield result.isMatch ? this.replacement : result.content;
     }
   }
 }

--- a/src/replacement-processors/static-replacement-processor.ts
+++ b/src/replacement-processors/static-replacement-processor.ts
@@ -57,11 +57,11 @@ export class StaticReplacementProcessor<
   }
 
   *processChunk(chunk: string): Generator<string, void, undefined> {
-    for (const result of this.searchStrategy.processChunk(
+    for (const { isMatch, content } of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      yield result.isMatch ? this.replacement : result.content;
+      yield isMatch ? this.replacement : content;
     }
   }
 }

--- a/src/search-strategies/benchmarking/anchor-sequence/README.md
+++ b/src/search-strategies/benchmarking/anchor-sequence/README.md
@@ -42,7 +42,7 @@ Cancellable strategies use `finally` blocks to preserve state when iteration sto
 
 ```typescript
 for (const result of subStrategy.processChunk(chunk, state)) {
-  if (result.match) {
+  if (result.isMatch) {
     // Found the needle! Exit iteration (triggers finally block)
     const matched = result.content;
     break; // or return - both trigger finally block

--- a/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
@@ -15,9 +15,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { content: "Hello ", match: false },
-      { content: "{{name}}", match: true },
-      { content: " worl", match: false }
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "{{name}}" },
+      { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
   });
@@ -32,10 +32,10 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const results = Array.from(strategy.processChunk("Hello {{na", state));
     const results2 = Array.from(strategy.processChunk("me}} world", state));
 
-    expect(results).toEqual([{ content: "Hello ", match: false }]);
+    expect(results).toEqual([{ isMatch: false, content: "Hello " }]);
     expect(results2).toEqual([
-      { content: "{{name}}", match: true },
-      { content: " worl", match: false }
+      { isMatch: true, content: "{{name}}" },
+      { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
   });
@@ -70,7 +70,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
       strategy.processChunk('<img src="/photo.jpg" alt="sunset"> text', state)
     );
     expect(results).toEqual([
-      { content: '<img src="/photo.jpg" alt="sunset">', match: true }
+      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' }
     ]);
     expect(strategy.flush(state)).toEqual(" text");
   });
@@ -100,8 +100,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r1 = Array.from(strategy.processChunk("Hello {", state));
     const r2 = Array.from(strategy.processChunk("{name}}", state));
 
-    expect(r1).toEqual([{ content: "Hello ", match: false }]);
-    expect(r2).toEqual([{ content: "{{name}}", match: true }]);
+    expect(r1).toEqual([{ isMatch: false, content: "Hello " }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{name}}" }]);
   });
 
   it("closing delimiter split across chunks", () => {
@@ -116,8 +116,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([]);
     expect(r2).toEqual([
-      { content: "{{name}}", match: true },
-      { content: " worl", match: false }
+      { isMatch: true, content: "{{name}}" },
+      { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
   });
@@ -138,8 +138,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
     expect(r4).toEqual([
-      { content: "{{hello}}", match: true },
-      { content: " ther", match: false }
+      { isMatch: true, content: "{{hello}}" },
+      { isMatch: false, content: " ther" }
     ]);
     expect(strategy.flush(state)).toEqual("e");
   });
@@ -158,7 +158,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     // The "{" is buffered by BufferedIndexOfCancellableSearchStrategy, then " " breaks it
     // BufferedIndexOfCancellableSearchStrategy outputs the whole thing as one non-match
     expect(r1).toEqual([]);
-    expect(r2).toEqual([{ content: "{ {hi}", match: false }]);
+    expect(r2).toEqual([{ isMatch: false, content: "{ {hi}" }]);
     expect(strategy.flush(state)).toEqual("}");
   });
 
@@ -174,8 +174,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([]);
     expect(r2).toEqual([
-      { content: "{x ", match: false },
-      { content: "{{name}}", match: true }
+      { isMatch: false, content: "{x " },
+      { isMatch: true, content: "{{name}}" }
     ]);
   });
 
@@ -193,9 +193,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { content: "{{first}}", match: true },
-      { content: " ", match: false },
-      { content: "{{second}}", match: true }
+      { isMatch: true, content: "{{first}}" },
+      { isMatch: false, content: " " },
+      { isMatch: true, content: "{{second}}" }
     ]);
   });
 
@@ -209,8 +209,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r1 = Array.from(strategy.processChunk("{{first}}", state));
     const r2 = Array.from(strategy.processChunk("{{second}}", state));
 
-    expect(r1).toEqual([{ content: "{{first}}", match: true }]);
-    expect(r2).toEqual([{ content: "{{second}}", match: true }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{first}}" }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{second}}" }]);
   });
 
   it("sequence completes and next begins in same chunk", () => {
@@ -223,8 +223,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r1 = Array.from(strategy.processChunk("{{first}}", state));
     const r2 = Array.from(strategy.processChunk(" {{partial", state));
 
-    expect(r1).toEqual([{ content: "{{first}}", match: true }]);
-    expect(r2).toEqual([{ content: " ", match: false }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{first}}" }]);
+    expect(r2).toEqual([{ isMatch: false, content: " " }]);
 
     const r3 = strategy.flush(state);
     expect(r3).toEqual("{{partial");
@@ -241,9 +241,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r2 = Array.from(strategy.processChunk(" {", state));
     const r3 = Array.from(strategy.processChunk("{b}}", state));
 
-    expect(r1).toEqual([{ content: "{{a}}", match: true }]);
-    expect(r2).toEqual([{ content: " ", match: false }]);
-    expect(r3).toEqual([{ content: "{{b}}", match: true }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{a}}" }]);
+    expect(r2).toEqual([{ isMatch: false, content: " " }]);
+    expect(r3).toEqual([{ isMatch: true, content: "{{b}}" }]);
   });
 
   // ===== Edge Cases =====
@@ -257,7 +257,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     const results = Array.from(strategy.processChunk("{{}}", state));
 
-    expect(results).toEqual([{ content: "{{}}", match: true }]);
+    expect(results).toEqual([{ isMatch: true, content: "{{}}" }]);
   });
 
   it("consecutive sequences with no content between", () => {
@@ -270,8 +270,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const results = Array.from(strategy.processChunk("{{a}}{{b}}", state));
 
     expect(results).toEqual([
-      { content: "{{a}}", match: true },
-      { content: "{{b}}", match: true }
+      { isMatch: true, content: "{{a}}" },
+      { isMatch: true, content: "{{b}}" }
     ]);
   });
 
@@ -287,7 +287,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([]);
     // The first "{{" matches, then accumulates "incomplete {{complete", then finds "}}" - valid match!
-    expect(r2).toEqual([{ content: "{{incomplete {{complete}}", match: true }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{incomplete {{complete}}" }]);
   });
 
   it("nested-looking but sequential delimiters", () => {
@@ -302,8 +302,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     // Should match "{{{{stuff}}" as first sequence, then "}}" is non-match
     expect(results).toEqual([
-      { content: "{{{{stuff}}", match: true },
-      { content: "}", match: false }
+      { isMatch: true, content: "{{{{stuff}}" },
+      { isMatch: false, content: "}" }
     ]);
     expect(strategy.flush(state)).toEqual("}");
   });
@@ -325,7 +325,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
     expect(r4).toEqual([
-      { content: '<img src="/photo.jpg" alt="sunset">', match: true }
+      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' }
     ]);
     expect(strategy.flush(state)).toEqual(" text");
   });
@@ -346,8 +346,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { content: '<img src="a.jpg" alt="first">', match: true },
-      { content: '<img src="b.jpg" alt="second">', match: true }
+      { isMatch: true, content: '<img src="a.jpg" alt="first">' },
+      { isMatch: true, content: '<img src="b.jpg" alt="second">' }
     ]);
   });
 
@@ -366,7 +366,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r1).toEqual([]);
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
-    expect(r4).toEqual([{ content: "{{part1part2part3part4}}", match: true }]);
+    expect(r4).toEqual([{ isMatch: true, content: "{{part1part2part3part4}}" }]);
   });
 
   it("delimiter appears in content between delimiters", () => {
@@ -382,7 +382,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { content: "{{content with {{ inside}}", match: true }
+      { isMatch: true, content: "{{content with {{ inside}}" }
     ]);
   });
 
@@ -397,9 +397,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r2 = Array.from(strategy.processChunk("dd", state));
     const r3 = Array.from(strategy.processChunk("le] after", state));
 
-    expect(r1).toEqual([{ content: "before ", match: false }]);
+    expect(r1).toEqual([{ isMatch: false, content: "before " }]);
     expect(r2).toEqual([]);
-    expect(r3).toEqual([{ content: "[middle]", match: true }]);
+    expect(r3).toEqual([{ isMatch: true, content: "[middle]" }]);
     expect(strategy.flush(state)).toEqual(" after");
   });
 });

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
@@ -16,28 +16,28 @@ describe("AnchorSequenceSearchStrategy", () => {
         name: "returns null when start delimiter not found",
         delimiters: ["{{", "}}"],
         haystack: "No delimiters here",
-        expectedResults: [{ content: "No delimiters here", match: false }],
+        expectedResults: [{ isMatch: false, content: "No delimiters here" }],
         expectedFlush: ""
       },
       {
         name: "returns incomplete match when end delimiter missing",
         delimiters: ["{{", "}}"],
         haystack: "Start {{incomplete",
-        expectedResults: [{ content: "Start ", match: false }],
+        expectedResults: [{ isMatch: false, content: "Start " }],
         expectedFlush: "{{incomplete"
       },
       {
         name: "returns incomplete match for partial start delimiter at end",
         delimiters: ["{{", "}}"],
         haystack: "text {",
-        expectedResults: [{ content: "text ", match: false }],
+        expectedResults: [{ isMatch: false, content: "text " }],
         expectedFlush: "{"
       },
       {
         name: "handles cross-boundary pattern (opening delimiter split)",
         delimiters: ["{{", "}}"],
         haystack: "Start {{na",
-        expectedResults: [{ content: "Start ", match: false }],
+        expectedResults: [{ isMatch: false, content: "Start " }],
         expectedFlush: "{{na"
       },
       {
@@ -52,7 +52,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         haystack: "text { single brace } more",
         expectedResults: [
-          { content: "text { single brace } more", match: false }
+          { isMatch: false, content: "text { single brace } more" }
         ],
         expectedFlush: ""
       },
@@ -67,14 +67,14 @@ describe("AnchorSequenceSearchStrategy", () => {
         name: "partial start delimiter with longer pattern",
         delimiters: ["BEGIN", "END"],
         haystack: "text BEG",
-        expectedResults: [{ content: "text ", match: false }],
+        expectedResults: [{ isMatch: false, content: "text " }],
         expectedFlush: "BEG"
       },
       {
         name: "no partial match when end doesn't match any delimiter prefix",
         delimiters: ["{{", "}}"],
         haystack: "text xyz",
-        expectedResults: [{ content: "text xyz", match: false }],
+        expectedResults: [{ isMatch: false, content: "text xyz" }],
         expectedFlush: ""
       }
     ];
@@ -113,9 +113,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "Hello {{name}} world" }],
         expectedResults: [
-          { content: "Hello ", match: false },
-          { content: "{{name}}", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: "{{name}}" },
+          { isMatch: false, content: " world" }
         ],
         expectedFlush: ""
       },
@@ -124,8 +124,8 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{value}} text" }],
         expectedResults: [
-          { content: "{{value}}", match: true },
-          { content: " text", match: false }
+          { isMatch: true, content: "{{value}}" },
+          { isMatch: false, content: " text" }
         ],
         expectedFlush: ""
       },
@@ -134,8 +134,8 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "text {{value}}" }],
         expectedResults: [
-          { content: "text ", match: false },
-          { content: "{{value}}", match: true }
+          { isMatch: false, content: "text " },
+          { isMatch: true, content: "{{value}}" }
         ],
         expectedFlush: ""
       },
@@ -144,9 +144,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}} and {{second}}" }],
         expectedResults: [
-          { content: "{{first}}", match: true },
-          { content: " and ", match: false },
-          { content: "{{second}}", match: true }
+          { isMatch: true, content: "{{first}}" },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: "{{second}}" }
         ],
         expectedFlush: ""
       },
@@ -155,9 +155,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "text {{}} more" }],
         expectedResults: [
-          { content: "text ", match: false },
-          { content: "{{}}", match: true },
-          { content: " more", match: false }
+          { isMatch: false, content: "text " },
+          { isMatch: true, content: "{{}}" },
+          { isMatch: false, content: " more" }
         ],
         expectedFlush: ""
       },
@@ -166,8 +166,8 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ['<img src="', '" alt="', '">'],
         calls: [{ haystack: '<img src="/photo.jpg" alt="sunset"> text' }],
         expectedResults: [
-          { content: '<img src="/photo.jpg" alt="sunset">', match: true },
-          { content: " text", match: false }
+          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' },
+          { isMatch: false, content: " text" }
         ],
         expectedFlush: ""
       },
@@ -176,9 +176,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["[", "]"],
         calls: [{ haystack: "text [value] more" }],
         expectedResults: [
-          { content: "text ", match: false },
-          { content: "[value]", match: true },
-          { content: " more", match: false }
+          { isMatch: false, content: "text " },
+          { isMatch: true, content: "[value]" },
+          { isMatch: false, content: " more" }
         ],
         expectedFlush: ""
       },
@@ -188,8 +188,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "{{this is a very long string with many words}}" }],
         expectedResults: [
           {
-            content: "{{this is a very long string with many words}}",
-            match: true
+            isMatch: true, content: "{{this is a very long string with many words}}"
           }
         ],
         expectedFlush: ""
@@ -199,9 +198,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}}" }, { haystack: " and {{second}}" }],
         expectedResults: [
-          { content: "{{first}}", match: true },
-          { content: " and ", match: false },
-          { content: "{{second}}", match: true }
+          { isMatch: true, content: "{{first}}" },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: "{{second}}" }
         ],
         expectedFlush: ""
       }
@@ -244,14 +243,14 @@ describe("AnchorSequenceSearchStrategy", () => {
         name: "start delimiter split across two chunks: '{' + '{name}}'",
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{" }, { haystack: "{name}}" }],
-        expectedResults: [{ content: "{{name}}", match: true }],
+        expectedResults: [{ isMatch: true, content: "{{name}}" }],
         expectedFlush: ""
       },
       {
         name: "end delimiter split across two chunks: '{{name}' + '}'",
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{name}" }, { haystack: "}" }],
-        expectedResults: [{ content: "{{name}}", match: true }],
+        expectedResults: [{ isMatch: true, content: "{{name}}" }],
         expectedFlush: ""
       },
       {
@@ -262,7 +261,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: '" alt="sunset">' }
         ],
         expectedResults: [
-          { content: '<img src="/photo.jpg" alt="sunset">', match: true }
+          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' }
         ],
         expectedFlush: ""
       },
@@ -277,7 +276,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: "}" },
           { haystack: "}" }
         ],
-        expectedResults: [{ content: "{{name}}", match: true }],
+        expectedResults: [{ isMatch: true, content: "{{name}}" }],
         expectedFlush: ""
       },
       {
@@ -285,9 +284,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{name}}" }, { haystack: " {{value}}" }],
         expectedResults: [
-          { content: "{{name}}", match: true },
-          { content: " ", match: false },
-          { content: "{{value}}", match: true }
+          { isMatch: true, content: "{{name}}" },
+          { isMatch: false, content: " " },
+          { isMatch: true, content: "{{value}}" }
         ],
         expectedFlush: ""
       },
@@ -296,8 +295,8 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "text " }, { haystack: "{{name}}" }],
         expectedResults: [
-          { content: "text ", match: false },
-          { content: "{{name}}", match: true }
+          { isMatch: false, content: "text " },
+          { isMatch: true, content: "{{name}}" }
         ],
         expectedFlush: ""
       },
@@ -309,7 +308,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: "IN content E" },
           { haystack: "ND" }
         ],
-        expectedResults: [{ content: "BEGIN content END", match: true }],
+        expectedResults: [{ isMatch: true, content: "BEGIN content END" }],
         expectedFlush: ""
       },
       {
@@ -317,10 +316,10 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}} and {{se" }, { haystack: "cond}} end" }],
         expectedResults: [
-          { content: "{{first}}", match: true },
-          { content: " and ", match: false },
-          { content: "{{second}}", match: true },
-          { content: " end", match: false }
+          { isMatch: true, content: "{{first}}" },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: "{{second}}" },
+          { isMatch: false, content: " end" }
         ],
         expectedFlush: ""
       }
@@ -366,15 +365,15 @@ describe("AnchorSequenceSearchStrategy", () => {
       );
       for (const match of iterator) {
         results.push(match);
-        if (match.match) {
+        if (match.isMatch) {
           break;
         }
       }
       const flushed = strategy.flush(state);
 
       expect(results).toEqual([
-        { content: "First ", match: false },
-        { content: "{{OLD}}", match: true }
+        { isMatch: false, content: "First " },
+        { isMatch: true, content: "{{OLD}}" }
       ]);
       expect(flushed).toEqual(" and second {{OLD}}");
     });

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
@@ -7,19 +7,27 @@ export interface AnchorSequenceSearchState<TState> extends StringBufferState {
   strategyStates: TState[];
 }
 
+// Helper to extract match content as string
+function extractMatchContent<TMatch>(match: TMatch): string {
+  if (Array.isArray(match)) {
+    return match[0]; // RegExpExecArray
+  }
+  return String(match);
+}
+
 /**
  * Search strategy for delimiter token patterns.
  * Matches content between sequential delimiter tokens, e.g., ["{{", "}}"] matches "{{name}}"
  * Supports multi-token patterns like ['<img src="', '" alt="', '">']
  * State is externally owned to allow strategy reuse across multiple streams.
  */
-export class AnchorSequenceSearchStrategy<TState>
+export class AnchorSequenceSearchStrategy<TState, TMatch = string>
   extends StringBufferStrategyBase
-  implements SearchStrategy<AnchorSequenceSearchState<TState>>
+  implements SearchStrategy<AnchorSequenceSearchState<TState>, string>
 {
-  private readonly subStrategies: SearchStrategy<TState>[];
+  private readonly subStrategies: SearchStrategy<TState, TMatch>[];
 
-  constructor(subStrategies: SearchStrategy<TState>[]) {
+  constructor(subStrategies: SearchStrategy<TState, TMatch>[]) {
     super();
     this.subStrategies = subStrategies;
   }
@@ -48,8 +56,8 @@ export class AnchorSequenceSearchStrategy<TState>
           haystack,
           subStrategyState
         )) {
-          if (matchResult.match) {
-            matched = matchResult.content;
+          if (matchResult.isMatch) {
+            matched = extractMatchContent(matchResult.content);
             break;
           }
           if (isMidMatch) {
@@ -71,9 +79,9 @@ export class AnchorSequenceSearchStrategy<TState>
           (state.currentNeedleIndex + 1) % this.subStrategies.length;
         isMidMatch = state.currentNeedleIndex !== 0;
         if (!isMidMatch) {
-          const content = state.buffer;
+          const match = state.buffer;
           state.buffer = "";
-          yield { content, match: true };
+          yield { isMatch: true, content: match };
         }
       }
     } finally {

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect } from "vitest";
 import { BufferedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
 import { MatchResult } from "../../types.ts";
 
+// Helper function to extract string value from MatchResult
+function getValue(result: MatchResult): string {
+  return result.content;
+}
+
 describe("BufferedIndexOfAnchoredSearchStrategy", () => {
   function processChunks(
     strategy: BufferedIndexOfAnchoredSearchStrategy,
@@ -15,7 +20,7 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       const generator = strategy.processChunk(chunk, state);
       for (const output of generator) {
         outputs.push(
-          output.match ? replacement(output.content) : output.content
+          output.isMatch ? replacement(output.content) : output.content
         );
       }
     });
@@ -303,7 +308,7 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       const outputs: string[] = [];
 
       let generator = strategy.processChunk("Text with ", state);
-      outputs.push(generator.next().value!.content);
+      outputs.push(getValue(generator.next().value!));
       generator.return();
       outputs.push(strategy.flush(state));
       expect(outputs).toEqual(["Text with", " "]);
@@ -316,7 +321,7 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       const outputs: string[] = [];
 
       let generator = strategy.processChunk("Text with {", state);
-      outputs.push(generator.next().value!.content);
+      outputs.push(getValue(generator.next().value!));
       generator.return();
       outputs.push(strategy.flush(state));
       expect(outputs).toEqual(["Text with ", "{"]);
@@ -329,7 +334,7 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       const outputs: string[] = [];
 
       let generator = strategy.processChunk("Text with {{ something", state);
-      outputs.push(generator.next().value!.content);
+      outputs.push(getValue(generator.next().value!));
       expect(outputs).toEqual(["Text with "]);
       generator.return();
       expect(strategy.flush(state)).toBe("{{ something");
@@ -348,8 +353,8 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       outputs.push(generator.next().value!);
       outputs.push(generator.next().value!);
       expect(outputs).toEqual([
-        { content: "Text with ", match: false },
-        { content: "{{ something }}", match: true }
+        { isMatch: false, content: "Text with " },
+        { isMatch: true, content: "{{ something }}" }
       ]);
       generator.return();
       expect(strategy.flush(state)).toBe(" and {{ something more }}");
@@ -371,7 +376,7 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       // Exactly bufferSize (1) remaining - yieldUntil would equal position
       const generator = strategy.processChunk("AB", state);
       const result = generator.next();
-      expect(result.value?.content).toBe("A");
+      expect(getValue(result.value!)).toBe("A");
       expect(result.done).toBe(false);
       generator.return();
       expect(strategy.flush(state)).toBe("B");
@@ -402,8 +407,8 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       // Find first two needles but not the third - should buffer mid-sequence
       const generator = strategy.processChunk("text {{ }} more", state);
       const result1 = generator.next();
-      expect(result1.value?.content).toBe("text ");
-      expect(result1.value?.match).toBe(false);
+      expect(getValue(result1.value!)).toBe("text ");
+      expect(result1.value!.isMatch).toBe(false);
 
       generator.return(); // Cancel mid-sequence (found "{{" and "}}", looking for "!")
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
@@ -87,9 +87,9 @@ export class BufferedIndexOfAnchoredSearchStrategy
           if (state.currentNeedleIndex === 0) {
             const yieldUntil = length - (currentNeedle.length - 1);
             if (yieldUntil > position) {
-              const content = haystack.slice(position, yieldUntil);
+              const nonMatch = haystack.slice(position, yieldUntil);
               position = yieldUntil;
-              yield { content, match: false };
+              yield { isMatch: false, content: nonMatch };
             }
           }
           return;
@@ -97,9 +97,9 @@ export class BufferedIndexOfAnchoredSearchStrategy
 
         if (state.currentNeedleIndex === 0) {
           if (index > position) {
-            const content = haystack.slice(position, index);
+            const nonMatch = haystack.slice(position, index);
             position = index;
-            yield { content, match: false };
+            yield { isMatch: false, content: nonMatch };
           }
           matchStartPosition = index;
         }
@@ -109,8 +109,8 @@ export class BufferedIndexOfAnchoredSearchStrategy
           (state.currentNeedleIndex + 1) % this.needles.length;
         if (state.currentNeedleIndex === 0) {
           yield {
-            content: haystack.slice(matchStartPosition, position),
-            match: true
+            isMatch: true,
+            content: haystack.slice(matchStartPosition, position)
           };
         }
       }

--- a/src/search-strategies/benchmarking/buffered-indexOf-cancellable/README.md
+++ b/src/search-strategies/benchmarking/buffered-indexOf-cancellable/README.md
@@ -127,7 +127,7 @@ This variant implements `SearchStrategy<TState>` with `finally` block for cancel
   state: BufferedIndexOfCancellableState
 ): Generator<MatchResult, void, undefined> {
   try {
-    yield { content: "...", match: false };
+    yield { isMatch: false, content: "..." };
   } finally {
     // Executes when iteration stops (break, return, completion)
     state.buffer = /* preserve remaining content */;
@@ -160,7 +160,7 @@ const generator = strategy.processChunk(
 );
 
 for (const result of generator) {
-  if (result.match) {
+  if (result.isMatch) {
     // Stop after first match - triggers finally block
     break;
   }

--- a/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
@@ -27,22 +27,22 @@ export class BufferedIndexOfCancellableSearchStrategy
         if (index === -1) {
           const endPortion = 1 - this.needle.length;
           state.buffer = candidate.slice(endPortion);
-          const content = candidate.slice(0, endPortion);
+          const nonMatch = candidate.slice(0, endPortion);
           candidate = "";
-          if (content) {
-            yield { content, match: false };
+          if (nonMatch) {
+            yield { isMatch: false, content: nonMatch };
           }
           return;
         }
 
         if (index > 0) {
-          yield { content: candidate.slice(0, index), match: false };
+          yield { isMatch: false, content: candidate.slice(0, index) };
         }
 
-        const content = candidate.slice(index, index + this.needle.length);
+        const match = candidate.slice(index, index + this.needle.length);
         candidate = candidate.slice(index + this.needle.length);
         state.buffer = "";
-        yield { content, match: true };
+        yield { isMatch: true, content: match };
       }
     } finally {
       if (candidate) {

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/README.md
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/README.md
@@ -30,8 +30,8 @@ This variant implements the standard `SearchStrategy<TState>` interface:
   chunk: string,
   state: BufferedIndexOfCanonicalGeneratorState
 ): Generator<MatchResult, void, undefined> {
-  yield { content: "...", match: false };
-  yield { content: "...", match: true };
+  yield { isMatch: false, content: "..." };
+  yield { isMatch: true, content: "..." };
 }
 ```
 

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
@@ -9,15 +9,15 @@ describe("IndexOfKnuthMorrisPratt", () => {
         name: "finds pattern when haystack equals pattern",
         pattern: "OLD",
         chunks: ["OLD"],
-        expected: [{ content: "OLD", match: true }]
+        expected: [{ isMatch: true, content: "OLD" }]
       },
       {
         name: "finds pattern at start of chunk",
         pattern: "OLD",
         chunks: ["OLDtext"],
         expected: [
-          { content: "OLD", match: true },
-          { content: "text", match: false }
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: "text" }
         ]
       },
       {
@@ -25,8 +25,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["textOLD"],
         expected: [
-          { content: "text", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "text" },
+          { isMatch: true, content: "OLD" }
         ]
       },
       {
@@ -34,9 +34,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["Hello OLD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -44,11 +44,11 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["Replace OLD and OLD content"],
         expected: [
-          { content: "Replace ", match: false },
-          { content: "OLD", match: true },
-          { content: " and ", match: false },
-          { content: "OLD", match: true },
-          { content: " content", match: false }
+          { isMatch: false, content: "Replace " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " content" }
         ]
       },
       {
@@ -56,8 +56,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["OLDOLD"],
         expected: [
-          { content: "OLD", match: true },
-          { content: "OLD", match: true }
+          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD" }
         ]
       },
       {
@@ -65,9 +65,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "X",
         chunks: ["test X test"],
         expected: [
-          { content: "test ", match: false },
-          { content: "X", match: true },
-          { content: " test", match: false }
+          { isMatch: false, content: "test " },
+          { isMatch: true, content: "X" },
+          { isMatch: false, content: " test" }
         ]
       },
       {
@@ -75,9 +75,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "THE COMPLEX PATTERN",
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: "THE COMPLEX PATTERN" },
+          { isMatch: false, content: " here" }
         ]
       }
     ];
@@ -94,7 +94,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         }
 
         const flush = strategy.flush(state);
-        if (flush) results.push({ content: flush, match: false });
+        if (flush) results.push({ isMatch: false, content: flush });
 
         expect(results).toEqual(expected);
       });
@@ -107,7 +107,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         name: "returns content when pattern not found",
         pattern: "OLD",
         chunks: ["Hello beautiful world"],
-        expected: [{ content: "Hello beautiful world", match: false }]
+        expected: [{ isMatch: false, content: "Hello beautiful world" }]
       },
       {
         name: "returns empty for empty haystack",
@@ -119,13 +119,13 @@ describe("IndexOfKnuthMorrisPratt", () => {
         name: "case sensitive - lowercase pattern vs uppercase haystack",
         pattern: "old",
         chunks: ["OLD"],
-        expected: [{ content: "OLD", match: false }]
+        expected: [{ isMatch: false, content: "OLD" }]
       },
       {
         name: "case sensitive - uppercase pattern vs lowercase haystack",
         pattern: "OLD",
         chunks: ["old"],
-        expected: [{ content: "old", match: false }]
+        expected: [{ isMatch: false, content: "old" }]
       }
     ];
 
@@ -142,7 +142,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         }
 
         const flush = strategy.flush(state);
-        if (flush) results.push({ content: flush, match: false });
+        if (flush) results.push({ isMatch: false, content: flush });
 
         expect(results).toEqual(expected);
       });
@@ -156,9 +156,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["Hello O", "LD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -166,9 +166,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["Hello ", "OLD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -176,9 +176,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["Hello O", "LD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -186,9 +186,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["Hello OL", "D world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -196,9 +196,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "PATTERN",
         chunks: ["Find PAT", "TER", "N here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: "PATTERN" },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -206,9 +206,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["Hello ", "O", "L", "D", " world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -216,9 +216,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["text O", "LD more"],
         expected: [
-          { content: "text ", match: false },
-          { content: "OLD", match: true },
-          { content: " more", match: false }
+          { isMatch: false, content: "text " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " more" }
         ]
       },
       {
@@ -226,8 +226,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["OL OL", "D"],
         expected: [
-          { content: "OL ", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "OL " },
+          { isMatch: true, content: "OLD" }
         ]
       },
       {
@@ -235,8 +235,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["OLOL", "D"],
         expected: [
-          { content: "OL", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "OL" },
+          { isMatch: true, content: "OLD" }
         ]
       }
     ];
@@ -254,7 +254,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         }
 
         const flush = strategy.flush(state);
-        if (flush) results.push({ content: flush, match: false });
+        if (flush) results.push({ isMatch: false, content: flush });
 
         expect(results).toEqual(expected);
       });
@@ -267,21 +267,21 @@ describe("IndexOfKnuthMorrisPratt", () => {
         name: "partial match at end - one character",
         pattern: "OLD",
         chunks: ["text O"],
-        expectedYields: [{ content: "text ", match: false }],
+        expectedYields: [{ isMatch: false, content: "text " }],
         expectedFlush: "O"
       },
       {
         name: "partial match at end - two characters",
         pattern: "OLD",
         chunks: ["text OL"],
-        expectedYields: [{ content: "text ", match: false }],
+        expectedYields: [{ isMatch: false, content: "text " }],
         expectedFlush: "OL"
       },
       {
         name: "partial match at end - longest partial",
         pattern: "ABCDEF",
         chunks: ["text ABCD"],
-        expectedYields: [{ content: "text ", match: false }],
+        expectedYields: [{ isMatch: false, content: "text " }],
         expectedFlush: "ABCD"
       },
       {
@@ -295,7 +295,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         name: "overlapping pattern ends incomplete",
         pattern: "OLD",
         chunks: ["OLOL"],
-        expectedYields: [{ content: "OL", match: false }],
+        expectedYields: [{ isMatch: false, content: "OL" }],
         expectedFlush: "OL"
       }
     ];
@@ -327,10 +327,10 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["First OLD", " and second OLD"],
         expected: [
-          { content: "First ", match: false },
-          { content: "OLD", match: true },
-          { content: " and second ", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "First " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " and second " },
+          { isMatch: true, content: "OLD" }
         ]
       },
       {
@@ -338,10 +338,10 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["First OLD", "OLD second"],
         expected: [
-          { content: "First ", match: false },
-          { content: "OLD", match: true },
-          { content: "OLD", match: true },
-          { content: " second", match: false }
+          { isMatch: false, content: "First " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " second" }
         ]
       },
       {
@@ -349,10 +349,10 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["First O", "LD and OLD"],
         expected: [
-          { content: "First ", match: false },
-          { content: "OLD", match: true },
-          { content: " and ", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "First " },
+          { isMatch: true, content: "OLD" },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: "OLD" }
         ]
       }
     ];
@@ -383,15 +383,15 @@ describe("IndexOfKnuthMorrisPratt", () => {
       const iterator = strategy.processChunk("First OLD and second OLD", state);
       for (const match of iterator) {
         results.push(match);
-        if (match.match) {
+        if (match.isMatch) {
           break;
         }
       }
       const flushed = strategy.flush(state);
 
       expect(results).toEqual([
-        { content: "First ", match: false },
-        { content: "OLD", match: true }
+        { isMatch: false, content: "First " },
+        { isMatch: true, content: "OLD" }
       ]);
       expect(flushed).toBe(" and second OLD");
     });

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
@@ -41,9 +41,9 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
           state.needleIndex = (state.needleIndex + length) % this.needle.length;
 
           if (state.needleIndex === 0) {
-            const content = state.buffer;
+            const match = state.buffer;
             state.buffer = "";
-            yield { content, match: true };
+            yield { isMatch: true, content: match };
           }
         } else {
           haystack = state.buffer + haystack;
@@ -55,29 +55,29 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
         if (matchPos === -1) {
           const partialLength = this.KMP.getLengthOfSuffixMatch(haystack);
           if (partialLength) {
-            const content = haystack.slice(0, -partialLength);
-            if (content) {
-              yield { content, match: false };
+            const nonMatch = haystack.slice(0, -partialLength);
+            if (nonMatch) {
+              yield { isMatch: false, content: nonMatch };
             }
             state.buffer = haystack.slice(-partialLength);
             state.needleIndex = partialLength;
           } else {
-            yield { content: haystack, match: false };
+            yield { isMatch: false, content: haystack };
           }
           haystack = "";
           return;
         }
 
-        const content = haystack.slice(0, matchPos);
-        if (content) {
-          yield { content, match: false };
+        const nonMatch = haystack.slice(0, matchPos);
+        if (nonMatch) {
+          yield { isMatch: false, content: nonMatch };
         }
 
         haystack = haystack.slice(matchPos + this.needle.length);
         state.buffer = "";
         yield {
-          content: this.needle,
-          match: true
+          isMatch: true,
+          content: this.needle
         };
       }
     } finally {

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/README.md
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/README.md
@@ -302,7 +302,7 @@ This strategy implements `SearchStrategy<TState>` with `finally` block for cance
   state: LoopedIndexOfSearchState
 ): Generator<MatchResult, void, undefined> {
   try {
-    yield { content: "...", match: false };
+    yield { isMatch: false, content: "..." };
   } finally {
     // Executes when iteration stops (break, return, completion)
     state.buffer = /* preserve remaining content */;
@@ -342,7 +342,7 @@ const iterator = strategy.processChunk(
 );
 
 for (const result of iterator) {
-  if (result.match) {
+  if (result.isMatch) {
     // Stop after first match - triggers finally block
     break;
   }

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
@@ -37,9 +37,9 @@ export class LoopedIndexOfCancellableSearchStrategy
           state.needleIndex = (state.needleIndex + length) % this.needle.length;
 
           if (state.needleIndex === 0) {
-            const content = state.buffer;
+            const match = state.buffer;
             state.buffer = "";
-            yield { content, match: true };
+            yield { isMatch: true, content: match };
           }
         } else {
           haystack = state.buffer + haystack;
@@ -49,36 +49,36 @@ export class LoopedIndexOfCancellableSearchStrategy
       while (haystack) {
         const matchPos = haystack.indexOf(this.needle);
         if (matchPos === -1) {
-          const content = haystack;
+          const nonMatch = haystack;
           haystack = "";
           for (
             let partialLength = this.needle.length - 1;
             partialLength >= 1;
             partialLength--
           ) {
-            const haystackSuffix = content.slice(-partialLength);
+            const haystackSuffix = nonMatch.slice(-partialLength);
             const needlePrefix = this.needle.slice(0, partialLength);
             if (haystackSuffix === needlePrefix) {
               yield {
-                content: content.slice(0, -partialLength),
-                match: false
+                isMatch: false,
+                content: nonMatch.slice(0, -partialLength)
               };
-              state.buffer = content.slice(-partialLength);
+              state.buffer = nonMatch.slice(-partialLength);
               state.needleIndex = partialLength;
               return;
             }
           }
-          yield { content, match: false };
+          yield { isMatch: false, content: nonMatch };
 
           return;
         }
 
-        yield { content: haystack.slice(0, matchPos), match: false };
+        yield { isMatch: false, content: haystack.slice(0, matchPos) };
         haystack = haystack.slice(matchPos + this.needle.length);
         state.buffer = "";
         yield {
-          content: this.needle,
-          match: true
+          isMatch: true,
+          content: this.needle
         };
       }
     } finally {

--- a/src/search-strategies/index.ts
+++ b/src/search-strategies/index.ts
@@ -1,2 +1,5 @@
-export { LoopedIndexOfAnchoredSearchStrategy as StringAnchorSearchStrategy } from "./looped-indexOf-anchored/index.ts";
+export {
+  LoopedIndexOfAnchoredSearchStrategy as StringAnchorSearchStrategy,
+  type StringAnchorSearchState
+} from "./looped-indexOf-anchored/index.ts";
 export * from "./regex/index.ts";

--- a/src/search-strategies/looped-indexOf-anchored/README.md
+++ b/src/search-strategies/looped-indexOf-anchored/README.md
@@ -101,7 +101,7 @@ for (
   const needlePrefix = currentNeedle.slice(0, partialLength);
   if (haystackSuffix === needlePrefix) {
     // Found partial match - buffer it
-    yield { content: remainder.slice(0, -partialLength), match: false };
+    yield { isMatch: false, content: remainder.slice(0, -partialLength) };
     state.buffer = haystackSuffix;
     return;
   }

--- a/src/search-strategies/looped-indexOf-anchored/index.ts
+++ b/src/search-strategies/looped-indexOf-anchored/index.ts
@@ -1,1 +1,2 @@
 export { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
+export type { StringBufferState as StringAnchorSearchState } from "../string-buffer-strategy-base.ts";

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
@@ -10,9 +10,9 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     const flushed = strategy.flush(state);
 
     expect(results).toEqual([
-      { content: "before ", match: false },
-      { content: "{{", match: true },
-      { content: " after", match: false }
+      { isMatch: false, content: "before " },
+      { isMatch: true, content: "{{" },
+      { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
   });
@@ -25,9 +25,9 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     const flushed = strategy.flush(state);
 
     expect(results).toEqual([
-      { content: "before ", match: false },
-      { content: "{{name}}", match: true },
-      { content: " after", match: false }
+      { isMatch: false, content: "before " },
+      { isMatch: true, content: "{{name}}" },
+      { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
   });
@@ -39,13 +39,13 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     const results = [
       ...strategy.processChunk("before {", state),
       ...strategy.processChunk("{name}}", state),
-      { content: strategy.flush(state), match: false }
+      { isMatch: false, content: strategy.flush(state) }
     ];
 
     expect(results).toEqual([
-      { content: "before ", match: false },
-      { content: "{{name}}", match: true },
-      { content: "", match: false }
+      { isMatch: false, content: "before " },
+      { isMatch: true, content: "{{name}}" },
+      { isMatch: false, content: "" }
     ]);
   });
 
@@ -60,9 +60,9 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     const flushed = strategy.flush(state);
 
     expect(results).toEqual([
-      { content: "before ", match: false },
-      { content: "{{name}}", match: true },
-      { content: " after", match: false }
+      { isMatch: false, content: "before " },
+      { isMatch: true, content: "{{name}}" },
+      { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
   });
@@ -74,13 +74,13 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     const results = [
       ...strategy.processChunk("no matches here", state),
       ...strategy.processChunk("or here either", state),
-      { content: strategy.flush(state), match: false }
+      { isMatch: false, content: strategy.flush(state) }
     ];
 
     expect(results).toEqual([
-      { content: "no matches here", match: false },
-      { content: "or here either", match: false },
-      { content: "", match: false }
+      { isMatch: false, content: "no matches here" },
+      { isMatch: false, content: "or here either" },
+      { isMatch: false, content: "" }
     ]);
   });
 
@@ -91,11 +91,11 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     // Process first chunk - ends with 'a', not '{', so no buffering
     const results1 = [...strategy.processChunk("chunk ends with a", state)];
     expect(state.buffer).toBe("");
-    expect(results1).toEqual([{ content: "chunk ends with a", match: false }]);
+    expect(results1).toEqual([{ isMatch: false, content: "chunk ends with a" }]);
 
     // Process second chunk - no buffered content to prepend
     const results2 = [...strategy.processChunk("another chunk", state)];
-    expect(results2).toEqual([{ content: "another chunk", match: false }]);
+    expect(results2).toEqual([{ isMatch: false, content: "another chunk" }]);
   });
 
   it("should buffer when partial match detected", () => {
@@ -105,11 +105,11 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     // Process chunk ending with partial match
     const results1 = [...strategy.processChunk("text ends with {", state)];
     expect(state.buffer).toBe("{");
-    expect(results1).toEqual([{ content: "text ends with ", match: false }]);
+    expect(results1).toEqual([{ isMatch: false, content: "text ends with " }]);
 
     // Complete the match
     const results2 = [...strategy.processChunk("{name}}", state)];
-    expect(results2).toEqual([{ content: "{{name}}", match: true }]);
+    expect(results2).toEqual([{ isMatch: true, content: "{{name}}" }]);
   });
 
   it("should handle false starts", () => {
@@ -119,14 +119,14 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     const results = [
       ...strategy.processChunk("text {", state),
       ...strategy.processChunk("x {{match}}", state),
-      { content: strategy.flush(state), match: false }
+      { isMatch: false, content: strategy.flush(state) }
     ];
 
     expect(results).toEqual([
-      { content: "text ", match: false },
-      { content: "{x ", match: false },
-      { content: "{{match}}", match: true },
-      { content: "", match: false }
+      { isMatch: false, content: "text " },
+      { isMatch: false, content: "{x " },
+      { isMatch: true, content: "{{match}}" },
+      { isMatch: false, content: "" }
     ]);
   });
 
@@ -136,14 +136,14 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     const results = [
       ...strategy.processChunk("{{first}}{{second}}{{third}}", state),
-      { content: strategy.flush(state), match: false }
+      { isMatch: false, content: strategy.flush(state) }
     ];
 
     expect(results).toEqual([
-      { content: "{{first}}", match: true },
-      { content: "{{second}}", match: true },
-      { content: "{{third}}", match: true },
-      { content: "", match: false }
+      { isMatch: true, content: "{{first}}" },
+      { isMatch: true, content: "{{second}}" },
+      { isMatch: true, content: "{{third}}" },
+      { isMatch: false, content: "" }
     ]);
   });
 
@@ -162,9 +162,9 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     const flushed = strategy.flush(state);
 
     expect(results).toEqual([
-      { content: "before ", match: false },
-      { content: "<{{name}}>", match: true },
-      { content: " after", match: false }
+      { isMatch: false, content: "before " },
+      { isMatch: true, content: "<{{name}}>" },
+      { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
   });
@@ -175,13 +175,17 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     const results = [
       ...strategy.processChunk("{{incomplete", state),
-      { content: strategy.flush(state), match: false }
+      { isMatch: false, content: strategy.flush(state) }
     ];
 
-    expect(results).toEqual([{ content: "{{incomplete", match: false }]);
+    expect(results).toEqual([{ isMatch: false, content: "{{incomplete" }]);
   });
 
   describe("cancellation scenarios", () => {
+    // Helper to extract the string value from a MatchResult
+    const getValue = (result: { isMatch: false, content: string } | { isMatch: true, content: string }): string =>
+      result.content;
+
     it("flushes buffer when cancelling with no matches and no partial match", () => {
       const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
       const state = strategy.createState();
@@ -190,7 +194,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
       let generator = strategy.processChunk("Text with no match", state);
       const result = generator.next();
-      outputs.push(result.value!.content);
+      outputs.push(getValue(result.value!));
 
       // Generator returns after yielding because no partial match found
       expect(result.done).toBe(false);
@@ -209,7 +213,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
       let generator = strategy.processChunk("Text ends with {", state);
       const result = generator.next();
-      outputs.push(result.value!.content);
+      outputs.push(getValue(result.value!));
 
       // Generator returns after yielding and setting buffer to "{"
       expect(result.done).toBe(false);
@@ -226,7 +230,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
       let generator = strategy.processChunk("Text {{ something", state);
       const result = generator.next(); // Yields "Text "
-      expect(result.value?.content).toBe("Text ");
+      expect(getValue(result.value!)).toBe("Text ");
       expect(result.done).toBe(false);
 
       // Check if there's another yield before returning
@@ -314,7 +318,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
       // Let generator complete naturally
       const generator = strategy.processChunk("text", state);
       const result = generator.next();
-      expect(result.value?.content).toBe("text");
+      expect(getValue(result.value!)).toBe("text");
       expect(result.done).toBe(false);
 
       // No more yields, generator is done

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
@@ -70,24 +70,24 @@ export class LoopedIndexOfAnchoredSearchStrategy
                 const beforePartial = haystack.slice(position, -partialLength);
                 position = length - partialLength;
                 if (beforePartial) {
-                  yield { content: beforePartial, match: false };
+                  yield { isMatch: false, content: beforePartial };
                 }
                 return;
               }
             }
 
-            const content = haystack.slice(position);
+            const nonMatch = haystack.slice(position);
             position = length;
-            yield { content, match: false };
+            yield { isMatch: false, content: nonMatch };
           }
           return;
         }
 
         if (state.currentNeedleIndex === 0) {
           if (index > position) {
-            const content = haystack.slice(position, index);
+            const nonMatch = haystack.slice(position, index);
             position = index;
-            yield { content, match: false };
+            yield { isMatch: false, content: nonMatch };
           }
           matchStartPosition = index;
         }
@@ -97,8 +97,8 @@ export class LoopedIndexOfAnchoredSearchStrategy
           (state.currentNeedleIndex + 1) % this.needles.length;
         if (state.currentNeedleIndex === 0) {
           yield {
-            content: haystack.slice(matchStartPosition, position),
-            match: true
+            isMatch: true,
+            content: haystack.slice(matchStartPosition, position)
           };
         }
       }

--- a/src/search-strategies/regex/README.md
+++ b/src/search-strategies/regex/README.md
@@ -15,7 +15,7 @@ This has been chosen for simplicity and performance, with libraries such as [`in
 To enable optimistic/early yielding, certain regular expression features are unsupported. e.g. [lookbehinds](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion), negative [lookaheads](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) and [backreferences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference). See [Limitations](#limitations) for full explanation.
 
 > [!WARNING]
-> The strategy returns an object of type [`RegExpExecArray`](https://github.com/microsoft/TypeScript/blob/5026c6675cbbfd493011616639595084f899d513/src/lib/es5.d.ts#L960) (a result of calling `RegExp.prototype.exec`) extended to conform to the [`MatchResult` interface](../../../README.md#search-strategies), rather than a new object being created, for performance reasons. It hence includes all the properties of `RegExpExecArray`, including [`index`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#index) and [`input`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#input), which make little sense in a streaming scenario, and should be disregarded when used in a replacement function.
+> The strategy yields `{ isMatch: true, content: RegExpExecArray }` for matches (rather than `{ isMatch: true, content: string }`), where the `RegExpExecArray` is the result of calling `RegExp.prototype.exec`. This provides access to capture groups via `match.content[1]`, `match.content[2]`, etc., and named groups via `match.content.groups`. The array also includes [`index`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#index) and [`input`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#input) properties, which make little sense in a streaming scenario and should be disregarded.
 
 ## How It Works
 
@@ -24,13 +24,15 @@ To enable optimistic/early yielding, certain regular expression features are uns
 The strategy maintains two regex patterns:
 
 ```typescript
+import createPartialMatchRegex from "regex-partial-match";
+
 class RegexSearchStrategy {
   private readonly completeMatchRegex: RegExp; // Original pattern
   private readonly partialMatchRegex: RegExp; // Transformed for partial detection
 
   constructor(needle: RegExp) {
     this.completeMatchRegex = needle;
-    this.partialMatchRegex = toPartialMatch(needle); // Transform!
+    this.partialMatchRegex = createPartialMatchRegex(needle); // Transform!
   }
 }
 ```
@@ -217,7 +219,7 @@ Problem: A chunk ending `\ud83d` and another starting `\ude04` will produce two 
 In this example. the named group "foo" will be returned with these individual bytes / code points as matches, rather than the intended single match of `😄`.
 
 > [!TIP]
-> It's intended that the transform is used with a [`TextDecoderStream`](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream) to ensure multi-byte characters do not span chunks.
+> It's intended that the transform is used on [well-formed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/isWellFormed) strings, hence a [`TextDecoderStream`](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream) should be used to ensure multi-byte characters do not span chunks.
 
 ### ⚠️ Unbounded Quantifiers
 

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -5,6 +5,11 @@ import validateInput from "./input-validation.ts";
 
 vi.mock("./input-validation.ts");
 
+// Helper to extract string value from MatchResult
+function getValue(result: MatchResult<RegExpExecArray>): string {
+  return result.isMatch ? result.content[0] : result.content;
+}
+
 describe("RegexSearchStrategy", () => {
   it("should validate input regex", () => {
     const someRegex = /test-regex/;
@@ -24,21 +29,21 @@ describe("RegexSearchStrategy", () => {
         name: "handles no matches in non-matching haystack",
         pattern: /OLD/,
         chunks: ["something else"],
-        expected: [{ content: "something else", match: false }]
+        expected: [{ isMatch: false, content: "something else" }]
       },
       {
         name: "finds pattern when haystack equals pattern",
         pattern: /OLD/,
         chunks: ["OLD"],
-        expected: [{ content: "OLD", match: true }]
+        expected: [{ isMatch: true, content: expect.arrayContaining(["OLD"]) }]
       },
       {
         name: "finds pattern at start of chunk",
         pattern: /OLD/,
         chunks: ["OLDtext"],
         expected: [
-          { content: "OLD", match: true },
-          { content: "text", match: false }
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: "text" }
         ]
       },
       {
@@ -46,8 +51,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["textOLD"],
         expected: [
-          { content: "text", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "text" },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) }
         ]
       },
       {
@@ -55,9 +60,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["Hello OLD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -65,11 +70,11 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["Replace OLD and OLD content"],
         expected: [
-          { content: "Replace ", match: false },
-          { content: "OLD", match: true },
-          { content: " and ", match: false },
-          { content: "OLD", match: true },
-          { content: " content", match: false }
+          { isMatch: false, content: "Replace " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " content" }
         ]
       },
       {
@@ -77,8 +82,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["OLDOLD"],
         expected: [
-          { content: "OLD", match: true },
-          { content: "OLD", match: true }
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) }
         ]
       },
       {
@@ -86,9 +91,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /X/,
         chunks: ["test X test"],
         expected: [
-          { content: "test ", match: false },
-          { content: "X", match: true },
-          { content: " test", match: false }
+          { isMatch: false, content: "test " },
+          { isMatch: true, content: expect.arrayContaining(["X"]) },
+          { isMatch: false, content: " test" }
         ]
       },
       {
@@ -96,9 +101,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE COMPLEX PATTERN/,
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -106,9 +111,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE .* PATTERN/,
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -116,11 +121,11 @@ describe("RegexSearchStrategy", () => {
         pattern: /(FIRST|SECOND) PATTERN/,
         chunks: ["Find FIRST PATTERN and SECOND PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "FIRST PATTERN", match: true },
-          { content: " and ", match: false },
-          { content: "SECOND PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["FIRST PATTERN"]) },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: expect.arrayContaining(["SECOND PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -128,11 +133,11 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE .*? PATTERN/,
         chunks: ["Find THE FIRST PATTERN here and THE SECOND PATTERN there"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE FIRST PATTERN", match: true },
-          { content: " here and ", match: false },
-          { content: "THE SECOND PATTERN", match: true },
-          { content: " there", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          { isMatch: false, content: " here and " },
+          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          { isMatch: false, content: " there" }
         ]
       },
       {
@@ -140,9 +145,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /[A-Z]+/,
         chunks: ["find PATTERN here"],
         expected: [
-          { content: "find ", match: false },
-          { content: "PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "find " },
+          { isMatch: true, content: expect.arrayContaining(["PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -150,9 +155,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE [A-Z]{3}PLEX PATTERN/,
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -160,8 +165,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /.+?PLEX PATTERN/,
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { content: "Find THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: true, content: expect.arrayContaining(["Find THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -169,8 +174,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /COMPLEX PATTERN.+/,
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { content: "Find THE ", match: false },
-          { content: "COMPLEX PATTERN here", match: true }
+          { isMatch: false, content: "Find THE " },
+          { isMatch: true, content: expect.arrayContaining(["COMPLEX PATTERN here"]) }
         ]
       },
       {
@@ -178,9 +183,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE COMPLEX PATTERN/i,
         chunks: ["Find The cOmPlEx PATtern here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "The cOmPlEx PATtern", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["The cOmPlEx PATtern"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -188,9 +193,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE .+ PATTERN/s,
         chunks: ["Find THE COMP\nLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMP\nLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMP\nLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -200,11 +205,11 @@ describe("RegexSearchStrategy", () => {
           "Find \nTHE FIRST PATTERN\n here and \nTHE SECOND PATTERN\n there"
         ],
         expected: [
-          { content: "Find \n", match: false },
-          { content: "THE FIRST PATTERN", match: true },
-          { content: "\n here and \n", match: false },
-          { content: "THE SECOND PATTERN", match: true },
-          { content: "\n there", match: false }
+          { isMatch: false, content: "Find \n" },
+          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          { isMatch: false, content: "\n here and \n" },
+          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          { isMatch: false, content: "\n there" }
         ]
       },
       {
@@ -212,9 +217,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE COMPLEX PATTERN(?= here)/,
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -222,7 +227,7 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE COMPLEX PATTERN(?= here)/,
         chunks: ["Find THE COMPLEX PATTERN not here"],
         expected: [
-          { content: "Find THE COMPLEX PATTERN not here", match: false }
+          { isMatch: false, content: "Find THE COMPLEX PATTERN not here" }
         ]
       },
       {
@@ -230,30 +235,30 @@ describe("RegexSearchStrategy", () => {
         pattern: /\bPATTERN\b/,
         chunks: ["PATTERN! NotAPATTERN."],
         expected: [
-          { content: "PATTERN", match: true },
-          { content: "! NotAPATTERN.", match: false }
+          { isMatch: true, content: expect.arrayContaining(["PATTERN"]) },
+          { isMatch: false, content: "! NotAPATTERN." }
         ]
       },
       {
         name: "handles patterns with input boundary assertions",
         pattern: /^PATTERN$/,
         chunks: ["PATTERN"],
-        expected: [{ content: "PATTERN", match: true }]
+        expected: [{ isMatch: true, content: expect.arrayContaining(["PATTERN"]) }]
       },
       {
         name: "handles patterns with input boundary assertions (inverse scenario)",
         pattern: /^PATTERN$/,
         chunks: ["the PATTERN here"],
-        expected: [{ content: "the PATTERN here", match: false }]
+        expected: [{ isMatch: false, content: "the PATTERN here" }]
       },
       {
         name: "handles patterns with escaped characters",
         pattern: /THE \.COMPLEX \?PATTERN\*/,
         chunks: ["Find THE .COMPLEX ?PATTERN* here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE .COMPLEX ?PATTERN*", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE .COMPLEX ?PATTERN*"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -261,10 +266,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /(こんにちは|👋)/,
         chunks: ["Say こんにちは to everyone 👋"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんにちは", match: true },
-          { content: " to everyone ", match: false },
-          { content: "👋", match: true }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんにちは"]) },
+          { isMatch: false, content: " to everyone " },
+          { isMatch: true, content: expect.arrayContaining(["👋"]) }
         ]
       },
       {
@@ -272,9 +277,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /\p{Script=Hiragana}+/u,
         chunks: ["Say こんにちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんにちは", match: true },
-          { content: " to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんにちは"]) },
+          { isMatch: false, content: " to everyone" }
         ]
       },
       {
@@ -282,25 +287,25 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}]+/v,
         chunks: ["Say こんにちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんにちは", match: true },
-          { content: " to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんにちは"]) },
+          { isMatch: false, content: " to everyone" }
         ]
       },
       {
         name: "handles patterns with unicodeSet character classes (inverse scenario)",
         pattern: /[\p{Script=Hiragana}]+/v,
         chunks: ["Say konnichiwa to everyone"],
-        expected: [{ content: "Say konnichiwa to everyone", match: false }]
+        expected: [{ isMatch: false, content: "Say konnichiwa to everyone" }]
       },
       {
         name: "handles patterns with unicodeSet character classes with intersections",
         pattern: /[\p{Script=Hiragana}&&\p{Alphabetic}]+/v,
         chunks: ["Say こんにちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんにちは", match: true },
-          { content: " to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんにちは"]) },
+          { isMatch: false, content: " to everyone" }
         ]
       },
       {
@@ -308,13 +313,13 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\P{Script=Hiragana}&&\P{Alphabetic}]+/v,
         chunks: ["Say こんにちは123 to everyone"],
         expected: [
-          { content: "Say", match: false },
-          { content: " ", match: true },
-          { content: "こんにちは", match: false },
-          { content: "123 ", match: true },
-          { content: "to", match: false },
-          { content: " ", match: true },
-          { content: "everyone", match: false }
+          { isMatch: false, content: "Say" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "こんにちは" },
+          { isMatch: true, content: expect.arrayContaining(["123 "]) },
+          { isMatch: false, content: "to" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "everyone" }
         ]
       },
       {
@@ -322,13 +327,13 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}\p{Alphabetic}]+/v,
         chunks: ["Say こんにちは to everyone"],
         expected: [
-          { content: "Say", match: true },
-          { content: " ", match: false },
-          { content: "こんにちは", match: true },
-          { content: " ", match: false },
-          { content: "to", match: true },
-          { content: " ", match: false },
-          { content: "everyone", match: true }
+          { isMatch: true, content: expect.arrayContaining(["Say"]) },
+          { isMatch: false, content: " " },
+          { isMatch: true, content: expect.arrayContaining(["こんにちは"]) },
+          { isMatch: false, content: " " },
+          { isMatch: true, content: expect.arrayContaining(["to"]) },
+          { isMatch: false, content: " " },
+          { isMatch: true, content: expect.arrayContaining(["everyone"]) }
         ]
       },
       {
@@ -336,13 +341,13 @@ describe("RegexSearchStrategy", () => {
         pattern: /[^\p{Script=Hiragana}\p{Alphabetic}]+/v,
         chunks: ["Say こんにちは to everyone"],
         expected: [
-          { content: "Say", match: false },
-          { content: " ", match: true },
-          { content: "こんにちは", match: false },
-          { content: " ", match: true },
-          { content: "to", match: false },
-          { content: " ", match: true },
-          { content: "everyone", match: false }
+          { isMatch: false, content: "Say" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "こんにちは" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "to" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "everyone" }
         ]
       },
       {
@@ -350,9 +355,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}--[ちは]]+/v,
         chunks: ["Say こんにちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんに", match: true },
-          { content: "ちは to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんに"]) },
+          { isMatch: false, content: "ちは to everyone" }
         ]
       },
       {
@@ -360,15 +365,16 @@ describe("RegexSearchStrategy", () => {
         pattern: /(THE)( PATTERN)/,
         chunks: ["Find THE PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            [0]: "THE PATTERN",
-            [1]: "THE",
-            [2]: " PATTERN"
+            isMatch: true,
+            content: expect.objectContaining({
+              [0]: "THE PATTERN",
+              [1]: "THE",
+              [2]: " PATTERN"
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -376,14 +382,15 @@ describe("RegexSearchStrategy", () => {
         pattern: /(THE)(?: PATTERN)/,
         chunks: ["Find THE PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            [0]: "THE PATTERN",
-            [1]: "THE"
+            isMatch: true,
+            content: expect.objectContaining({
+              [0]: "THE PATTERN",
+              [1]: "THE"
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -391,13 +398,14 @@ describe("RegexSearchStrategy", () => {
         pattern: /(?<first>THE)(?<second> PATTERN)/,
         chunks: ["Find THE PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            groups: { first: "THE", second: " PATTERN" }
+            isMatch: true,
+            content: expect.objectContaining({
+              groups: { first: "THE", second: " PATTERN" }
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -405,22 +413,23 @@ describe("RegexSearchStrategy", () => {
         pattern: /(THE)(?<second> PATTERN)/,
         chunks: ["Find THE PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            [0]: "THE PATTERN",
-            [1]: "THE",
-            groups: { second: " PATTERN" }
+            isMatch: true,
+            content: expect.objectContaining({
+              [0]: "THE PATTERN",
+              [1]: "THE",
+              groups: { second: " PATTERN" }
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
         name: "handles patterns with astral characters matching as a single character, via the unicode flag",
         pattern: /./u,
         chunks: ["\ud83d\ude04"], // "😄"
-        expected: [{ content: "😄", match: true }]
+        expected: [{ isMatch: true, content: expect.arrayContaining(["😄"]) }]
       }
     ];
 
@@ -428,7 +437,7 @@ describe("RegexSearchStrategy", () => {
       test(name, () => {
         const strategy = new RegexSearchStrategy(pattern);
         const state = strategy.createState();
-        const results: MatchResult[] = [];
+        const results: MatchResult<RegExpExecArray>[] = [];
         for (const chunk of chunks) {
           for (const result of strategy.processChunk(chunk, state)) {
             results.push(result);
@@ -436,7 +445,7 @@ describe("RegexSearchStrategy", () => {
         }
 
         const flush = strategy.flush(state);
-        if (flush) results.push({ content: flush, match: false });
+        if (flush) results.push({ isMatch: false, content: flush });
 
         expect(results).toMatchObject(expected);
       });
@@ -449,7 +458,7 @@ describe("RegexSearchStrategy", () => {
         name: "returns content when pattern not found",
         pattern: /OLD/,
         chunks: ["Hello beautiful world"],
-        expected: [{ content: "Hello beautiful world", match: false }]
+        expected: [{ isMatch: false, content: "Hello beautiful world" }]
       },
       {
         name: "returns empty for empty haystack",
@@ -461,13 +470,13 @@ describe("RegexSearchStrategy", () => {
         name: "case sensitive - lowercase pattern vs uppercase haystack",
         pattern: /old/,
         chunks: ["OLD"],
-        expected: [{ content: "OLD", match: false }]
+        expected: [{ isMatch: false, content: "OLD" }]
       },
       {
         name: "case sensitive - uppercase pattern vs lowercase haystack",
         pattern: /OLD/,
         chunks: ["old"],
-        expected: [{ content: "old", match: false }]
+        expected: [{ isMatch: false, content: "old" }]
       }
     ];
 
@@ -475,7 +484,7 @@ describe("RegexSearchStrategy", () => {
       test(name, () => {
         const strategy = new RegexSearchStrategy(pattern);
         const state = strategy.createState();
-        const results: MatchResult[] = [];
+        const results: MatchResult<RegExpExecArray>[] = [];
         for (const chunk of chunks) {
           for (const result of strategy.processChunk(chunk, state)) {
             results.push(result);
@@ -483,7 +492,7 @@ describe("RegexSearchStrategy", () => {
         }
 
         const flush = strategy.flush(state);
-        if (flush) results.push({ content: flush, match: false });
+        if (flush) results.push({ isMatch: false, content: flush });
 
         expect(results).toMatchObject(expected);
       });
@@ -497,9 +506,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["Hello O", "LD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -507,9 +516,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["Hello ", "OLD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -517,9 +526,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["Hello O", "LD world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -527,9 +536,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["Hello OL", "D world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -537,9 +546,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /PATTERN/,
         chunks: ["Find PAT", "TER", "N here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -547,9 +556,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["Hello ", "O", "L", "D", " world"],
         expected: [
-          { content: "Hello ", match: false },
-          { content: "OLD", match: true },
-          { content: " world", match: false }
+          { isMatch: false, content: "Hello " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " world" }
         ]
       },
       {
@@ -557,9 +566,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["text O", "LD more"],
         expected: [
-          { content: "text ", match: false },
-          { content: "OLD", match: true },
-          { content: " more", match: false }
+          { isMatch: false, content: "text " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " more" }
         ]
       },
       {
@@ -567,8 +576,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["OL OL", "D"],
         expected: [
-          { content: "OL ", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "OL " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) }
         ]
       },
       {
@@ -576,8 +585,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["OLOL", "D"],
         expected: [
-          { content: "OL", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "OL" },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) }
         ]
       },
       {
@@ -585,9 +594,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE .+? PATTERN/,
         chunks: ["Find TH", "E COMPL", "EX ", "PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -595,9 +604,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE .* PATTERN/,
         chunks: ["Find THE COM", "PLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -605,11 +614,11 @@ describe("RegexSearchStrategy", () => {
         pattern: /(FIRST|SECOND) PATTERN/,
         chunks: ["Find FIR", "ST PATTERN and SE", "COND PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "FIRST PATTERN", match: true },
-          { content: " and ", match: false },
-          { content: "SECOND PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["FIRST PATTERN"]) },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: expect.arrayContaining(["SECOND PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -621,12 +630,12 @@ describe("RegexSearchStrategy", () => {
           "re and THE SECOND PATTERN there"
         ],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE FIRST PATTERN", match: true },
-          { content: " he", match: false },
-          { content: "re and ", match: false },
-          { content: "THE SECOND PATTERN", match: true },
-          { content: " there", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          { isMatch: false, content: " he" },
+          { isMatch: false, content: "re and " },
+          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          { isMatch: false, content: " there" }
         ]
       },
       {
@@ -634,9 +643,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE [A-Z]{3}PLEX PATTERN/,
         chunks: ["Find THE CO", "MPLEX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -644,8 +653,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /.+?PLEX PATTERN/,
         chunks: ["Find T", "HE CO", "MPLEX PATTERN here"],
         expected: [
-          { content: "Find THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: true, content: expect.arrayContaining(["Find THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -653,9 +662,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /COMPLEX PATTERN.+/,
         chunks: ["Find THE COMPLEX PATTE", "RN he", "re"],
         expected: [
-          { content: "Find THE ", match: false },
-          { content: "COMPLEX PATTERN he", match: true },
-          { content: "re", match: false }
+          { isMatch: false, content: "Find THE " },
+          { isMatch: true, content: expect.arrayContaining(["COMPLEX PATTERN he"]) },
+          { isMatch: false, content: "re" }
         ]
       },
       {
@@ -663,9 +672,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE .+? PATTERN/s,
         chunks: ["Find THE CO", "MP\nL", "EX PATTERN here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMP\nLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMP\nLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -677,11 +686,11 @@ describe("RegexSearchStrategy", () => {
           "TTERN\n there"
         ],
         expected: [
-          { content: "Find \n", match: false },
-          { content: "THE FIRST PATTERN", match: true },
-          { content: "\n here and \n", match: false },
-          { content: "THE SECOND PATTERN", match: true },
-          { content: "\n there", match: false }
+          { isMatch: false, content: "Find \n" },
+          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          { isMatch: false, content: "\n here and \n" },
+          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          { isMatch: false, content: "\n there" }
         ]
       },
       {
@@ -689,9 +698,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE COMPLEX PATTERN(?= here)/,
         chunks: ["Find THE COMPLEX PATTERN", " here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -699,8 +708,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE COMPLEX PATTERN(?= here)/,
         chunks: ["Find THE COMPLEX PATTERN", " not here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE COMPLEX PATTERN not here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: false, content: "THE COMPLEX PATTERN not here" }
         ]
       },
       {
@@ -708,24 +717,24 @@ describe("RegexSearchStrategy", () => {
         pattern: /\bPATTERN\b/,
         chunks: ["PATT", "ERN! NotAP", "ATTERN."],
         expected: [
-          { content: "PATTERN", match: true },
-          { content: "! NotAP", match: false },
-          { content: "ATTERN.", match: false }
+          { isMatch: true, content: expect.arrayContaining(["PATTERN"]) },
+          { isMatch: false, content: "! NotAP" },
+          { isMatch: false, content: "ATTERN." }
         ]
       },
       {
         name: "handles patterns with input boundary assertions, across chunks",
         pattern: /^PATTERN$/,
         chunks: ["PAT", "TERN"],
-        expected: [{ content: "PATTERN", match: true }]
+        expected: [{ isMatch: true, content: expect.arrayContaining(["PATTERN"]) }]
       },
       {
         name: "handles patterns with input boundary assertions (inverse scenario), across chunks",
         pattern: /^PATTERN$/,
         chunks: ["the PAT", "TERN here"],
         expected: [
-          { content: "the PAT", match: false },
-          { content: "TERN here", match: false }
+          { isMatch: false, content: "the PAT" },
+          { isMatch: false, content: "TERN here" }
         ]
       },
       {
@@ -733,9 +742,9 @@ describe("RegexSearchStrategy", () => {
         pattern: /THE \.COMPLEX \?PATTERN\*/,
         chunks: ["Find THE .COMP", "LEX ?PATTERN* here"],
         expected: [
-          { content: "Find ", match: false },
-          { content: "THE .COMPLEX ?PATTERN*", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "Find " },
+          { isMatch: true, content: expect.arrayContaining(["THE .COMPLEX ?PATTERN*"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -743,10 +752,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /[A-Z]+/,
         chunks: ["find PAT", "TERN here"],
         expected: [
-          { content: "find ", match: false },
-          { content: "PAT", match: true },
-          { content: "TERN", match: true },
-          { content: " here", match: false }
+          { isMatch: false, content: "find " },
+          { isMatch: true, content: expect.arrayContaining(["PAT"]) },
+          { isMatch: true, content: expect.arrayContaining(["TERN"]) },
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -754,10 +763,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /(こんにちは|👋)/,
         chunks: ["Say こん", "にちは to everyone ", "👋"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんにちは", match: true },
-          { content: " to everyone ", match: false },
-          { content: "👋", match: true }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんにちは"]) },
+          { isMatch: false, content: " to everyone " },
+          { isMatch: true, content: expect.arrayContaining(["👋"]) }
         ]
       },
       {
@@ -765,10 +774,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /\p{Script=Hiragana}+/u,
         chunks: ["Say こんに", "ちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんに", match: true },
-          { content: "ちは", match: true },
-          { content: " to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんに"]) },
+          { isMatch: true, content: expect.arrayContaining(["ちは"]) },
+          { isMatch: false, content: " to everyone" }
         ]
       },
       {
@@ -776,10 +785,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}]+/v,
         chunks: ["Say こん", "にちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こん", match: true },
-          { content: "にちは", match: true },
-          { content: " to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こん"]) },
+          { isMatch: true, content: expect.arrayContaining(["にちは"]) },
+          { isMatch: false, content: " to everyone" }
         ]
       },
       {
@@ -787,8 +796,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}]+/v,
         chunks: ["Say konn", "ichiwa to everyone"],
         expected: [
-          { content: "Say konn", match: false },
-          { content: "ichiwa to everyone", match: false }
+          { isMatch: false, content: "Say konn" },
+          { isMatch: false, content: "ichiwa to everyone" }
         ]
       },
       {
@@ -796,10 +805,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}&&\p{Alphabetic}]+/v,
         chunks: ["Say こんに", "ちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こんに", match: true },
-          { content: "ちは", match: true },
-          { content: " to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こんに"]) },
+          { isMatch: true, content: expect.arrayContaining(["ちは"]) },
+          { isMatch: false, content: " to everyone" }
         ]
       },
       {
@@ -807,15 +816,15 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\P{Script=Hiragana}&&\P{Alphabetic}]+/v,
         chunks: ["Say こんに", "ちは12", "3 to everyone"],
         expected: [
-          { content: "Say", match: false },
-          { content: " ", match: true },
-          { content: "こんに", match: false },
-          { content: "ちは", match: false },
-          { content: "12", match: true },
-          { content: "3 ", match: true },
-          { content: "to", match: false },
-          { content: " ", match: true },
-          { content: "everyone", match: false }
+          { isMatch: false, content: "Say" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "こんに" },
+          { isMatch: false, content: "ちは" },
+          { isMatch: true, content: expect.arrayContaining(["12"]) },
+          { isMatch: true, content: expect.arrayContaining(["3 "]) },
+          { isMatch: false, content: "to" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "everyone" }
         ]
       },
       {
@@ -823,14 +832,14 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}\p{Alphabetic}]+/v,
         chunks: ["Say こん", "にちは to everyone"],
         expected: [
-          { content: "Say", match: true },
-          { content: " ", match: false },
-          { content: "こん", match: true },
-          { content: "にちは", match: true },
-          { content: " ", match: false },
-          { content: "to", match: true },
-          { content: " ", match: false },
-          { content: "everyone", match: true }
+          { isMatch: true, content: expect.arrayContaining(["Say"]) },
+          { isMatch: false, content: " " },
+          { isMatch: true, content: expect.arrayContaining(["こん"]) },
+          { isMatch: true, content: expect.arrayContaining(["にちは"]) },
+          { isMatch: false, content: " " },
+          { isMatch: true, content: expect.arrayContaining(["to"]) },
+          { isMatch: false, content: " " },
+          { isMatch: true, content: expect.arrayContaining(["everyone"]) }
         ]
       },
       {
@@ -838,14 +847,14 @@ describe("RegexSearchStrategy", () => {
         pattern: /[^\p{Script=Hiragana}\p{Alphabetic}]+/v,
         chunks: ["Say こんに", "ちは to everyone"],
         expected: [
-          { content: "Say", match: false },
-          { content: " ", match: true },
-          { content: "こんに", match: false },
-          { content: "ちは", match: false },
-          { content: " ", match: true },
-          { content: "to", match: false },
-          { content: " ", match: true },
-          { content: "everyone", match: false }
+          { isMatch: false, content: "Say" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "こんに" },
+          { isMatch: false, content: "ちは" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "to" },
+          { isMatch: true, content: expect.arrayContaining([" "]) },
+          { isMatch: false, content: "everyone" }
         ]
       },
       {
@@ -853,10 +862,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /[\p{Script=Hiragana}--[ちは]]+/v,
         chunks: ["Say こん", "にちは to everyone"],
         expected: [
-          { content: "Say ", match: false },
-          { content: "こん", match: true },
-          { content: "に", match: true },
-          { content: "ちは to everyone", match: false }
+          { isMatch: false, content: "Say " },
+          { isMatch: true, content: expect.arrayContaining(["こん"]) },
+          { isMatch: true, content: expect.arrayContaining(["に"]) },
+          { isMatch: false, content: "ちは to everyone" }
         ]
       },
       {
@@ -864,15 +873,16 @@ describe("RegexSearchStrategy", () => {
         pattern: /(THE)( PATTERN)/,
         chunks: ["Find TH", "E PAT", "TERN here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            [0]: "THE PATTERN",
-            [1]: "THE",
-            [2]: " PATTERN"
+            isMatch: true,
+            content: expect.objectContaining({
+              [0]: "THE PATTERN",
+              [1]: "THE",
+              [2]: " PATTERN"
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -880,14 +890,15 @@ describe("RegexSearchStrategy", () => {
         pattern: /(THE)(?: PATTERN)/,
         chunks: ["Find THE P", "ATTERN here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            [0]: "THE PATTERN",
-            [1]: "THE"
+            isMatch: true,
+            content: expect.objectContaining({
+              [0]: "THE PATTERN",
+              [1]: "THE"
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -895,13 +906,14 @@ describe("RegexSearchStrategy", () => {
         pattern: /(?<first>THE)(?<second> PATTERN)/,
         chunks: ["Find TH", "E PA", "TTERN here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            groups: { first: "THE", second: " PATTERN" }
+            isMatch: true,
+            content: expect.objectContaining({
+              groups: { first: "THE", second: " PATTERN" }
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -909,15 +921,16 @@ describe("RegexSearchStrategy", () => {
         pattern: /(THE)(?<second> PATTERN)/,
         chunks: ["Find THE", " PATTER", "N here"],
         expected: [
-          { content: "Find ", match: false },
+          { isMatch: false, content: "Find " },
           {
-            content: "THE PATTERN",
-            match: true,
-            [0]: "THE PATTERN",
-            [1]: "THE",
-            groups: { second: " PATTERN" }
+            isMatch: true,
+            content: expect.objectContaining({
+              [0]: "THE PATTERN",
+              [1]: "THE",
+              groups: { second: " PATTERN" }
+            })
           },
-          { content: " here", match: false }
+          { isMatch: false, content: " here" }
         ]
       },
       {
@@ -925,8 +938,8 @@ describe("RegexSearchStrategy", () => {
         pattern: /(?<foo>.)/u,
         chunks: ["\ud83d", "\ude04"],
         expected: [
-          { content: "\ud83d", match: true, groups: { foo: "\ud83d" } },
-          { content: "\ude04", match: true, groups: { foo: "\ude04" } }
+          { isMatch: true, content: expect.objectContaining({ groups: { foo: "\ud83d" } }) },
+          { isMatch: true, content: expect.objectContaining({ groups: { foo: "\ude04" } }) }
         ]
       }
     ];
@@ -935,7 +948,7 @@ describe("RegexSearchStrategy", () => {
       test(name, () => {
         const strategy = new RegexSearchStrategy(pattern);
         const state = strategy.createState();
-        const results: MatchResult[] = [];
+        const results: MatchResult<RegExpExecArray>[] = [];
         for (const chunk of chunks) {
           for (const result of strategy.processChunk(chunk, state)) {
             results.push(result);
@@ -943,7 +956,7 @@ describe("RegexSearchStrategy", () => {
         }
 
         const flush = strategy.flush(state);
-        if (flush) results.push({ content: flush, match: false });
+        if (flush) results.push({ isMatch: false, content: flush });
 
         expect(results).toMatchObject(expected);
       });
@@ -956,21 +969,21 @@ describe("RegexSearchStrategy", () => {
         name: "partial match at end - one character",
         pattern: /OLD/,
         chunks: ["text O"],
-        expectedYields: [{ content: "text ", match: false }],
+        expectedYields: [{ isMatch: false, content: "text " }],
         expectedFlush: "O"
       },
       {
         name: "partial match at end - two characters",
         pattern: /OLD/,
         chunks: ["text OL"],
-        expectedYields: [{ content: "text ", match: false }],
+        expectedYields: [{ isMatch: false, content: "text " }],
         expectedFlush: "OL"
       },
       {
         name: "partial match at end - longest partial",
         pattern: /ABCDEF/,
         chunks: ["text ABCD"],
-        expectedYields: [{ content: "text ", match: false }],
+        expectedYields: [{ isMatch: false, content: "text " }],
         expectedFlush: "ABCD"
       },
       {
@@ -984,7 +997,7 @@ describe("RegexSearchStrategy", () => {
         name: "overlapping pattern ends incomplete",
         pattern: /OLD/,
         chunks: ["OLOL"],
-        expectedYields: [{ content: "OL", match: false }],
+        expectedYields: [{ isMatch: false, content: "OL" }],
         expectedFlush: "OL"
       }
     ];
@@ -994,7 +1007,7 @@ describe("RegexSearchStrategy", () => {
         test(name, () => {
           const strategy = new RegexSearchStrategy(pattern);
           const state = strategy.createState();
-          const results: MatchResult[] = [];
+          const results: MatchResult<RegExpExecArray>[] = [];
           for (const chunk of chunks) {
             for (const result of strategy.processChunk(chunk, state)) {
               results.push(result);
@@ -1016,10 +1029,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["First OLD", " and second OLD"],
         expected: [
-          { content: "First ", match: false },
-          { content: "OLD", match: true },
-          { content: " and second ", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "First " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " and second " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) }
         ]
       },
       {
@@ -1027,10 +1040,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["First OLD", "OLD second"],
         expected: [
-          { content: "First ", match: false },
-          { content: "OLD", match: true },
-          { content: "OLD", match: true },
-          { content: " second", match: false }
+          { isMatch: false, content: "First " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " second" }
         ]
       },
       {
@@ -1038,10 +1051,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /OLD/,
         chunks: ["First O", "LD and OLD"],
         expected: [
-          { content: "First ", match: false },
-          { content: "OLD", match: true },
-          { content: " and ", match: false },
-          { content: "OLD", match: true }
+          { isMatch: false, content: "First " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) },
+          { isMatch: false, content: " and " },
+          { isMatch: true, content: expect.arrayContaining(["OLD"]) }
         ]
       }
     ];
@@ -1050,7 +1063,7 @@ describe("RegexSearchStrategy", () => {
       test(name, () => {
         const strategy = new RegexSearchStrategy(pattern);
         const state = strategy.createState();
-        const results: MatchResult[] = [];
+        const results: MatchResult<RegExpExecArray>[] = [];
         for (const chunk of chunks) {
           for (const result of strategy.processChunk(chunk, state)) {
             results.push(result);
@@ -1070,7 +1083,7 @@ describe("RegexSearchStrategy", () => {
       const outputs: string[] = [];
 
       let generator = strategy.processChunk("Text with ", state);
-      outputs.push(generator.next().value!.content);
+      outputs.push(getValue(generator.next().value!));
       expect(generator.return().value).toBeUndefined();
       expect(strategy.flush(state)).toBe("");
       expect(outputs).toMatchObject(["Text with "]);
@@ -1083,7 +1096,7 @@ describe("RegexSearchStrategy", () => {
       const outputs: string[] = [];
 
       let generator = strategy.processChunk("Text with {", state);
-      outputs.push(generator.next().value!.content);
+      outputs.push(getValue(generator.next().value!));
       const remainder = generator.return().value;
       outputs.push(strategy.flush(state));
       expect(remainder).toBeUndefined();
@@ -1094,7 +1107,7 @@ describe("RegexSearchStrategy", () => {
       const strategy = new RegexSearchStrategy(/{{.+?}}/s);
       const state = strategy.createState();
 
-      const outputs: MatchResult[] = [];
+      const outputs: MatchResult<RegExpExecArray>[] = [];
 
       for (const value of strategy.processChunk(
         "Text with {{ something }} and {{ something more }}",
@@ -1104,8 +1117,8 @@ describe("RegexSearchStrategy", () => {
         if (outputs.length === 2) break;
       }
       expect(outputs).toMatchObject([
-        { content: "Text with ", match: false },
-        { content: "{{ something }}", match: true }
+        { isMatch: false, content: "Text with " },
+        { isMatch: true, content: expect.arrayContaining(["{{ something }}"]) }
       ]);
       expect(strategy.flush(state)).toBe(" and {{ something more }}");
     });

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -5,19 +5,6 @@ import StringBufferStrategyBase, {
   type StringBufferState
 } from "../string-buffer-strategy-base.ts";
 
-/**
- * Extended match result that includes all RegExp match information.
- * @internal
- */
-interface RegExpSuccessfulMatchResult extends MatchResult, RegExpExecArray {
-  match: true;
-}
-
-/**
- * Union type for regex match results.
- * @internal
- */
-type RegExpMatchResult = MatchResult | RegExpSuccessfulMatchResult;
 
 /**
  * A search strategy for finding patterns using regular expressions.
@@ -45,7 +32,7 @@ type RegExpMatchResult = MatchResult | RegExpSuccessfulMatchResult;
 
 export class RegexSearchStrategy
   extends StringBufferStrategyBase
-  implements SearchStrategy<StringBufferState>
+  implements SearchStrategy<StringBufferState, RegExpExecArray>
 {
   private readonly completeMatchRegex: RegExp;
   private readonly partialMatchRegex: RegExp;
@@ -60,7 +47,7 @@ export class RegexSearchStrategy
   *processChunk(
     haystack: string,
     state: StringBufferState
-  ): Generator<RegExpMatchResult, void, undefined> {
+  ): Generator<MatchResult<RegExpExecArray>, void, undefined> {
     haystack = state.buffer + haystack;
     const length = haystack.length;
     let position = 0;
@@ -75,13 +62,13 @@ export class RegexSearchStrategy
             state.buffer = remainingHaystack.slice(partialMatch.index);
             if (partialMatch.index > 0) {
               yield {
-                content: remainingHaystack.slice(0, partialMatch.index),
-                match: false
+                isMatch: false,
+                content: remainingHaystack.slice(0, partialMatch.index)
               };
             }
           } else {
             state.buffer = "";
-            yield { content: remainingHaystack, match: false };
+            yield { isMatch: false, content: remainingHaystack };
           }
           return;
         }
@@ -89,20 +76,13 @@ export class RegexSearchStrategy
         state.buffer = "";
         if (completeMatch.index) {
           const matchStart = position + completeMatch.index;
-          const content = haystack.slice(position, matchStart);
+          const nonMatch = haystack.slice(position, matchStart);
           position = matchStart;
-          yield {
-            content,
-            match: false
-          };
+          yield { isMatch: false, content: nonMatch };
         }
 
-        const result = completeMatch as RegExpSuccessfulMatchResult;
-        result.content = completeMatch[0];
-        result.match = true;
-
-        position += result.content.length;
-        yield result;
+        position += completeMatch[0].length;
+        yield { isMatch: true, content: completeMatch };
       }
     } finally {
       if (position < length) {

--- a/src/search-strategies/types.ts
+++ b/src/search-strategies/types.ts
@@ -1,19 +1,25 @@
 /**
- * Result of processing content - either a match or literal content
+ * Result of processing content - either a match or literal content.
+ *
+ * Uses boolean discrimination with typed content:
+ * - `{ isMatch: false, content: string }` - Literal content to yield as-is
+ * - `{ isMatch: true, content: T }` - Match value passed to replacement function
+ *
+ * @typeParam T - The type of value returned for matches (default: string)
  */
-export interface MatchResult {
-  content: string;
-  match: boolean;
-}
+export type MatchResult<T = string> =
+  | { isMatch: false; content: string }
+  | { isMatch: true; content: T };
 
 /**
  * Search strategy for finding patterns in streaming content.
  *
  * Strategies are stateless and reusable across multiple streams, hence state is owned by the consuming processor.
  *
- * @template TState - The type of state this strategy requires (use void for stateless strategies)
+ * @template T - The type of state this strategy requires (use void for stateless strategies)
+ * @template U - The type of match returned by the strategy (default: string)
  */
-export interface SearchStrategy<TState> {
+export interface SearchStrategy<TState, TMatch = string> {
   /**
    * Create initial state for this strategy.
    * Called once per stream processor instance.
@@ -25,12 +31,12 @@ export interface SearchStrategy<TState> {
    *
    * @param haystack - New content to process
    * @param state - Mutable state object to track search progress
-   * @yields MatchResult - Content chunks ready for output
+   * @yields MatchResult - Either `{ isMatch: false, content: string }` or `{ isMatch: true, content: TMatch }`
    */
   processChunk(
     haystack: string,
     state: TState
-  ): Generator<MatchResult, void, undefined>;
+  ): Generator<MatchResult<TMatch>, void, undefined>;
 
   /**
    * Flush any partial match content buffered in state.

--- a/src/search-strategies/types.ts
+++ b/src/search-strategies/types.ts
@@ -16,8 +16,8 @@ export type MatchResult<T = string> =
  *
  * Strategies are stateless and reusable across multiple streams, hence state is owned by the consuming processor.
  *
- * @template T - The type of state this strategy requires (use void for stateless strategies)
- * @template U - The type of match returned by the strategy (default: string)
+ * @template TState - The type of state this strategy requires (use void for stateless strategies)
+ * @template TMatch - The type of match returned by the strategy (default: string)
  */
 export interface SearchStrategy<TState, TMatch = string> {
   /**

--- a/test/benchmarks/runtime/benchmark-definitions.ts
+++ b/test/benchmarks/runtime/benchmark-definitions.ts
@@ -20,7 +20,7 @@ export interface BenchmarkDefinition {
   setup: () => {
     processor:
       | StaticReplacementProcessor<SearchState>
-      | FunctionReplacementProcessor
+      | FunctionReplacementProcessor<SearchState>
       | AsyncFunctionReplacementProcessor<SearchState>
       | AsyncIterableFunctionReplacementProcessor<SearchState>;
     input: string[];

--- a/test/harnesses/regex-anchor-sequence.ts
+++ b/test/harnesses/regex-anchor-sequence.ts
@@ -1,10 +1,8 @@
 import { FunctionReplacementProcessor } from "../../src/index.ts";
-import {
-  RegexSearchStrategy,
-  type RegexSearchState
-} from "../../src/search-strategies/regex/search-strategy.ts";
+import { RegexSearchStrategy } from "../../src/search-strategies/regex/search-strategy.ts";
 import { AnchorSequenceSearchStrategy } from "../../src/search-strategies/benchmarking/index.ts";
 import { ReplaceContentTransformer } from "../../src/adapters/web/index.ts";
+import type { StringBufferState } from "../../src/search-strategies/string-buffer-strategy-base.ts";
 
 export const RegexAnchorSequenceHarness = {
   name: "Regex + Anchor Sequence",
@@ -15,7 +13,7 @@ export const RegexAnchorSequenceHarness = {
     tokens: string[];
     replacement?: (match: string, index: number) => string;
   }) =>
-    new AnchorSequenceSearchStrategy<RegexSearchState>(
+    new AnchorSequenceSearchStrategy<StringBufferState, RegExpExecArray>(
       tokens.map(
         (token) => new RegexSearchStrategy(new RegExp(RegExp.escape(token)))
       )
@@ -24,7 +22,7 @@ export const RegexAnchorSequenceHarness = {
     strategy,
     replacement
   }: {
-    strategy: AnchorSequenceSearchStrategy<RegexSearchState>;
+    strategy: AnchorSequenceSearchStrategy<StringBufferState, RegExpExecArray>;
     replacement: (match: string, index: number) => string;
   }) =>
     new ReplaceContentTransformer(

--- a/test/harnesses/regex.ts
+++ b/test/harnesses/regex.ts
@@ -26,7 +26,7 @@ export const RegexHarness = {
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({
         searchStrategy: strategy,
-        replacement
+        replacement: (match, index) => replacement(match[0], index)
       })
     )
 };

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -1,8 +1,8 @@
-import type { MatchResult } from "../src/search-strategies/types.ts";
+import type { MatchResult, SearchStrategy } from "../src/search-strategies/types.ts";
 import { vi, type Mocked } from "vitest";
 export { server } from "./vitest.setup";
 
-function mockSearchStrategyFactory(...results: MatchResult[]) {
+function mockSearchStrategyFactory<TMatch = string>(...results: MatchResult<TMatch>[]): Mocked<SearchStrategy<object, TMatch>> {
   return {
     createState: vi.fn().mockReturnValue({}),
     processChunk: vi.fn().mockImplementation(function* () {


### PR DESCRIPTION
## Issue

resolves #21 

## Details

### Changed

- `RegexSearchStrategy` replacement functions now receive `RegExpExecArray` instead of `string`. This enables direct access to capture groups (`match[1]`, `match.groups`), but existing code using string methods like `match.toUpperCase()` must change to `match[0].toUpperCase()`
- `MatchResult` type refactored to a discriminated union with boolean discriminant: `{ isMatch: false; content: string } | { isMatch: true; content: T }`. This is a breaking change for custom `SearchStrategy` implementations or direct `processChunk()` consumers. Use `if (result.isMatch)` to check for matches and access the typed content via `result.content`
- `SearchStrategy` interface now accepts a second type parameter for match type: `SearchStrategy<TState, TMatch = string>`
- Replacement processors now use `<TState, TMatch>` type parameters directly for improved type inference
- Exported `StringAnchorSearchState` type alias for typed processor declarations

## Scout rule

- Added explicit `read` permission to the `ci.yml` GitHub actions workflow
- Various `README.md` typos
- rename `match` member `isMatch` for clarity

## Semantic Version Impact

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [x] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
