### PR TITLE
[23] Support Indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ import { FunctionReplacementProcessor } from "replace-content-transformer";
 const transformer = new ReplaceContentTransformer(
   new FunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["{{", "}}"]),
-    replacement: (match: string, index: number) =>
-      `${match.slice(2, -2)} was match ${index}`
+    replacement: (match: string, matchIndex: number) =>
+      `${match.slice(2, -2)} was match ${matchIndex}`
   })
 );
 ```
@@ -145,14 +145,14 @@ Access the character indices of the match, relative to the start of the stream:
 const transformer = new ReplaceContentTransformer(
   new FunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["{{", "}}"]),
-    replacement: (match: string, index: number, startIndex: number, endIndex: number) =>
-      `${match.slice(2, -2)}, found from ${startIndex} to ${endIndex}`
+    replacement: (match: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) =>
+      `${match.slice(2, -2)}, found from ${streamIndices[0]} to ${streamIndices[1]}`
   })
 );
 ```
 
 > [!NOTE]
-> `endIndex` is exclusive, following the same convention as [`String.prototype.slice(startIndex, endIndex)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice)[^2]
+> `streamIndices[1]` (endIndex) is exclusive, following the same convention as [`String.prototype.slice(startIndex, endIndex)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice)[^2]
 
 [^2]: See [half-open intervals](https://en.wikipedia.org/wiki/Interval_(mathematics)#Half-open_intervals)
 
@@ -332,7 +332,7 @@ const abortController = new AbortController();
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncIterableFunctionReplacementProcessor({
     searchStrategy: new StringAnchorSearchStrategy(["<esi:include", ">"]),
-    replacement: async (match, index) => {
+    replacement: async (match, matchIndex) => {
       const {
         groups: { url }
       } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -440,7 +440,7 @@ Pluggable strategies implement the `SearchStrategy` interface:
 ```typescript
 type MatchResult<T = string> =
   | { isMatch: false; content: string }
-  | { isMatch: true; content: T, startIndex: number, endIndex: number};
+  | { isMatch: true; content: T, streamIndices: [startIndex: number, endIndex: number]};
 
 interface SearchStrategy<TState, TMatch = string> {
   createState(): TState;
@@ -459,7 +459,7 @@ The `TMatch` type (defaulting to `string`) allows strategies like `RegexSearchSt
 The `flush` is called by the processor to extract anything buffered from the search strategy. This also re-sets the provided state parameter for re-use.
 
 > ![NOTE]
-> The `startIndex` and `endIndex` properties are absolute character offsets into the overall stream, thus not chunk-relative.
+> The `streamIndices` property contains absolute character offsets into the overall stream as `[startIndex, endIndex]`, thus not chunk-relative.
 
 Each strategy contains the pattern-matching logic for a specific use case:
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,24 @@ const transformer = new ReplaceContentTransformer(
 );
 ```
 
-#### Replacing a Regular Expression
+Access the character indices of the match, relative to the start of the stream:
+```typescript
+// "here's {{this}}" becomes "here's this, found from 7 to 15"
+const transformer = new ReplaceContentTransformer(
+  new FunctionReplacementProcessor({
+    searchStrategy: searchStrategyFactory(["{{", "}}"]),
+    replacement: (match: string, index: number, startIndex: number, endIndex: number) =>
+      `${match.slice(2, -2)}, found from ${startIndex} to ${endIndex}`
+  })
+);
+```
 
 > [!NOTE]
-> The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src//search-strategies/regex/README.md#limitations).
+> `endIndex` is exclusive, following the same convention as [`String.prototype.slice(startIndex, endIndex)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice)[^2]
+
+[^2]: See [half-open intervals](https://en.wikipedia.org/wiki/Interval_(mathematics)#Half-open_intervals)
+
+#### Replacing a Regular Expression
 
 ```typescript
 // `class="anything old-button"` becomes `class="anything new-button"`
@@ -160,6 +174,12 @@ const transformer = new ReplaceContentTransformer(
   })
 );
 ```
+
+> [!CAUTION]
+> The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src//search-strategies/regex/README.md#limitations).
+
+> [!IMPORTANT]
+> When requesting [`indices`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#indices), the output is adjusted to be based on a stream offset, since would be otherwise useless.
 
 #### Async Replacement
 
@@ -514,13 +534,13 @@ There are 5 stream processors to select from, rather than the system figuring ou
 
 There is no reliable way in javascript to detect the output type of a function without calling it, and trying to adapt just-in-time based on the first replacement made would be complex. The type of function can be thought to have a ["colour"](https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/#what-color-is-your-function) that requires up-front selection.
 
-Rather than a one-size-fits-all / common-denominator supporting asynchronicity (whether needed or not) or adapting to varying function output, the design accepts that a slight (but potentially significant) performance overhead exists with asynchronicity (in Node, at least) [^2]
+Rather than a one-size-fits-all / common-denominator supporting asynchronicity (whether needed or not) or adapting to varying function output, the design accepts that a slight (but potentially significant) performance overhead exists with asynchronicity (in Node, at least) [^3]
 
 Forcing all consumers to act asynchronously, or creating arbitrary iterator adapters above a simple static replacement, was deemed more unwieldy than the choice to be made.
 
 The project aimed for a lightweight code footprint, so providing many options (with unused variation tree-shaken out) is a means to optimise.
 
-[^2]: N.B. A similar performance overhead exists by virtue of the generator pattern used, but this is accepted for the just-in-time nature flexibility afforded.
+[^3]: N.B. A similar performance overhead exists by virtue of the generator pattern used, but this is accepted for the just-in-time nature flexibility afforded.
 
 **Why generators?**
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Pluggable strategies implement the `SearchStrategy` interface:
 ```typescript
 type MatchResult<T = string> =
   | { isMatch: false; content: string }
-  | { isMatch: true; content: T };
+  | { isMatch: true; content: T, startIndex: number, endIndex: number};
 
 interface SearchStrategy<TState, TMatch = string> {
   createState(): TState;
@@ -438,6 +438,9 @@ The `TState` type is specific to the strategy, managed by the consuming processo
 The `TMatch` type (defaulting to `string`) allows strategies like `RegexSearchStrategy` to return richer match data (e.g., `RegExpExecArray`) that includes capture groups.
 
 The `flush` is called by the processor to extract anything buffered from the search strategy. This also re-sets the provided state parameter for re-use.
+
+> ![NOTE]
+> The `startIndex` and `endIndex` properties are absolute character offsets into the overall stream, thus not chunk-relative.
 
 Each strategy contains the pattern-matching logic for a specific use case:
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ const transformer = new ReplaceContentTransformer(
 ```
 
 > [!CAUTION]
-> The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src//search-strategies/regex/README.md#limitations).
+> The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src/search-strategies/regex/README.md#limitations).
 
 #### Async Replacement
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ const transformer = new AsyncReplaceContentTransformer(
       if (response.ok) {
         return response.body.pipeThrough(new TextDecoderStream());
       }
-      if (index === 1) {
+      if (matchIndex === 1) {
         abortController.abort(); // after two replacements, stop replacing
       }
     }

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ const transformer = new ReplaceContentTransformer(
 > The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src//search-strategies/regex/README.md#limitations).
 
 > [!IMPORTANT]
-> When requesting [`indices`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#indices), the output is adjusted to be based on a stream offset, since would be otherwise useless.
+> When requesting [`indices`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#indices), the output is adjusted to be based on a whole stream offset, since would be otherwise useless.
 
 #### Async Replacement
 

--- a/README.md
+++ b/README.md
@@ -178,9 +178,6 @@ const transformer = new ReplaceContentTransformer(
 > [!CAUTION]
 > The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src//search-strategies/regex/README.md#limitations).
 
-> [!IMPORTANT]
-> When requesting [`indices`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#indices), the output is adjusted to be based on a whole stream offset, since would be otherwise useless.
-
 #### Async Replacement
 
 Replace with asynchronous content. Ensures each async replacement completes before the next starts.

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ The `TMatch` type (defaulting to `string`) allows strategies like `RegexSearchSt
 
 The `flush` is called by the processor to extract anything buffered from the search strategy. This also re-sets the provided state parameter for re-use.
 
-> ![NOTE]
+> [!NOTE]
 > The `streamIndices` property contains absolute character offsets into the overall stream as `[startIndex, endIndex]`, thus not chunk-relative.
 
 Each strategy contains the pattern-matching logic for a specific use case:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ import {
 The constructors expect a "stream processor" and optional `AbortSignal` as arguments:
 
 ```ts
-import type { SyncProcessor, AsyncProcessor } from "replace-content-transformer";
 const syncTransformer = new ReplaceContentTransformer(
   processor: SyncProcessor, stopReplacingSignal?: AbortSignal
 );
@@ -463,13 +462,13 @@ import { StringAnchorSearchStrategy } from "replace-content-transformer";
 const searchStrategy = new StringAnchorSearchStrategy(["<!--replace me -->"]); // single token
 ```
 
-..or
+...or:
 
 ```ts
 const searchStrategy = new StringAnchorSearchStrategy(["{{", "}}"]); // 2+ "anchor" delimiters/tokens
 ```
 
-or
+...or:
 
 ```ts
 import { RegexSearchStrategy } from "replace-content-transformer";

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `startIndex` and `endIndex` properties on `MatchResult` matches, providing absolute stream offsets for each match
+- `streamIndices` property on `MatchResult` matches, providing absolute stream offsets `[startIndex, endIndex]` for each match
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clarify in the benchmarking README that `--experimental-strip-types` is a Node thing
   - Update a `NOTE` in the main README to be a `CAUTION` and move under the example
 - No longer exporting internal use only types.  Not publicly documented, so not considering this a breaking change
-- Ensure the `BufferedIndexOfAnchoredSearchState` benchmark comparison strategy properly resets its state
+- Ensure the `BufferedIndexOfAnchoredSearchState`, `IndexOfKnuthMorrisPrattSearchStrategy` and `LoopedIndexOfCancellableSearchStrategy`  benchmark comparison strategies properly resets their state
 
 ## [1.0.0] - 2026-01-23
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `startIndex` and `endIndex` properties on `MatchResult` matches, providing absolute stream offsets for each match
+
 ## [1.0.0] - 2026-01-23
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Note in regex JSDoc that lookahead support is positive only
   - Clarify in the benchmarking README that `--experimental-strip-types` is a Node thing
   - Update a `NOTE` in the main README to be a `CAUTION` and move under the example
-
 - No longer exporting internal use only types.  Not publicly documented, so not considering this a breaking change
+- Ensure the `BufferedIndexOfAnchoredSearchState` benchmark comparison strategy properly resets its state
 
 ## [1.0.0] - 2026-01-23
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove reference to un-exported `BufferedIndexOfAnchoredSearchStrategy`, linking to benchmarking code within repo instead
   - Note in regex JSDoc that lookahead support is positive only
   - Clarify in the benchmarking README that `--experimental-strip-types` is a Node thing
+  - Update a `NOTE` in the main README to be a `CAUTION` and move under the example
 
 - No longer exporting internal use only types.  Not publicly documented, so not considering this a breaking change
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `startIndex` and `endIndex` properties on `MatchResult` matches, providing absolute stream offsets for each match
 
+### Fixed
+
+- Documentation:
+  - Consistent prefix for examples in main README
+  - Fix typo in release process
+  - Remove reference to un-exported `BufferedIndexOfAnchoredSearchStrategy`, linking to benchmarking code within repo instead
+  - Note in regex JSDoc that lookahead support is positive only
+
+- No longer exporting internal use only types.  Not publicly documented, so not considering this a breaking change
+
 ## [1.0.0] - 2026-01-23
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix typo in release process
   - Remove reference to un-exported `BufferedIndexOfAnchoredSearchStrategy`, linking to benchmarking code within repo instead
   - Note in regex JSDoc that lookahead support is positive only
+  - Clarify in the benchmarking README that `--experimental-strip-types` is a Node thing
 
 - No longer exporting internal use only types.  Not publicly documented, so not considering this a breaking change
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -2,7 +2,7 @@
 
 Releases are automated based on semver selections in merged PRs:
 
-1. Go to **Actions** → **Release** workflow
+1. Go to **Actions** → **Create Draft Release** workflow
 2. Click "**Run workflow**" → "**Run workflow**"
 3. The workflow will automatically:
    - Analyze all merged PRs since the last release

--- a/src/replacement-processors/README.md
+++ b/src/replacement-processors/README.md
@@ -13,9 +13,9 @@ Replaces all pattern matches with the same static string value. Simplest and fas
 
 ### ⚡ Function Replacement
 
-Replaces matches using a function that receives the matched content, match index and start and end character indices into the stream. Supports both sync and async replacement functions.
+Replaces matches using a function that receives the matched content, match index and stream indices. Supports both sync and async replacement functions.
 
-- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => string | Promise<string>`
+- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => string | Promise<string>`
 - **Execution**: Synchronous generator (can yield promises)
 - **Use Case**: Dynamic replacements, transformations, API calls
 - **Example**: `new FunctionReplacementProcessor({ searchStrategy, replacement: (match, i) => `[${i}]` })`
@@ -24,7 +24,7 @@ Replaces matches using a function that receives the matched content, match index
 
 Replacement function returns an iterable that yields multiple string chunks for a single match. Useful for streaming large replacements or expanding matches into multiple parts.
 
-- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => Iterable<string>`
+- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Iterable<string>`
 - **Execution**: Synchronous generator
 - **Use Case**: Expanding matches, streaming large replacements, multi-part substitutions
 - **Example**: `new IterableFunctionReplacementProcessor({ searchStrategy, replacement: (match) => ['<', match, '>'] })`
@@ -33,7 +33,7 @@ Replacement function returns an iterable that yields multiple string chunks for 
 
 Async version of FunctionReplacementProcessor. Replacement function must return a Promise. Processor awaits each replacement before yielding.
 
-- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => Promise<string>`
+- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<string>`
 - **Execution**: Async generator
 - **Use Case**: API calls, database lookups, async transformations
 - **Example**: `new AsyncFunctionReplacementProcessor({ searchStrategy, replacement: async (match) => await fetch(...) })`
@@ -42,7 +42,7 @@ Async version of FunctionReplacementProcessor. Replacement function must return 
 
 Async version of IterableFunctionReplacementProcessor. Replacement function returns an async iterable that yields chunks asynchronously.
 
-- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => AsyncIterable<string>`
+- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => AsyncIterable<string>`
 - **Execution**: Async generator
 - **Use Case**: Streaming API responses, async chunk generation
 - **Example**: `new AsyncIterableFunctionReplacementProcessor({ searchStrategy, replacement: async function* (match) { yield* streamData() } })`

--- a/src/replacement-processors/README.md
+++ b/src/replacement-processors/README.md
@@ -13,9 +13,9 @@ Replaces all pattern matches with the same static string value. Simplest and fas
 
 ### ⚡ Function Replacement
 
-Replaces matches using a function that receives the matched content and match index. Supports both sync and async replacement functions.
+Replaces matches using a function that receives the matched content, match index and start and end character indices into the stream. Supports both sync and async replacement functions.
 
-- **Replacement Type**: `(matchedContent: string, index: number) => string | Promise<string>`
+- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => string | Promise<string>`
 - **Execution**: Synchronous generator (can yield promises)
 - **Use Case**: Dynamic replacements, transformations, API calls
 - **Example**: `new FunctionReplacementProcessor({ searchStrategy, replacement: (match, i) => `[${i}]` })`
@@ -24,7 +24,7 @@ Replaces matches using a function that receives the matched content and match in
 
 Replacement function returns an iterable that yields multiple string chunks for a single match. Useful for streaming large replacements or expanding matches into multiple parts.
 
-- **Replacement Type**: `(matchedContent: string, index: number) => Iterable<string>`
+- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => Iterable<string>`
 - **Execution**: Synchronous generator
 - **Use Case**: Expanding matches, streaming large replacements, multi-part substitutions
 - **Example**: `new IterableFunctionReplacementProcessor({ searchStrategy, replacement: (match) => ['<', match, '>'] })`
@@ -33,7 +33,7 @@ Replacement function returns an iterable that yields multiple string chunks for 
 
 Async version of FunctionReplacementProcessor. Replacement function must return a Promise. Processor awaits each replacement before yielding.
 
-- **Replacement Type**: `(matchedContent: string, index: number) => Promise<string>`
+- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => Promise<string>`
 - **Execution**: Async generator
 - **Use Case**: API calls, database lookups, async transformations
 - **Example**: `new AsyncFunctionReplacementProcessor({ searchStrategy, replacement: async (match) => await fetch(...) })`
@@ -42,7 +42,7 @@ Async version of FunctionReplacementProcessor. Replacement function must return 
 
 Async version of IterableFunctionReplacementProcessor. Replacement function returns an async iterable that yields chunks asynchronously.
 
-- **Replacement Type**: `(matchedContent: string, index: number) => AsyncIterable<string>`
+- **Replacement Type**: `(matchedContent: string, index: number, startIndex: number, endIndex: number) => AsyncIterable<string>`
 - **Execution**: Async generator
 - **Use Case**: Streaming API responses, async chunk generation
 - **Example**: `new AsyncIterableFunctionReplacementProcessor({ searchStrategy, replacement: async function* (match) { yield* streamData() } })`

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -7,7 +7,7 @@ describe("AsyncFunctionReplacementProcessor", () => {
   it("calls async replacement function with matched content and index", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "MATCH" },
+      { isMatch: true, content: "MATCH", startIndex: 6, endIndex: 11 },
       { isMatch: false, content: " world" }
     );
 
@@ -23,15 +23,15 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", 0, undefined, undefined);
+    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", 0, 6, 11);
     expect(outputChunks).toEqual(["Hello ", "ASYNC_RESULT", " world"]);
   });
 
   it("increments match index for subsequent async matches", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "MATCH" },
+      { isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "MATCH" }
+      { isMatch: true, content: "MATCH", startIndex: 10, endIndex: 15 }
     );
 
     const asyncReplacementFn = vi.fn().mockResolvedValue("ASYNC");
@@ -47,14 +47,14 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, undefined, undefined);
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, undefined, undefined);
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, 0, 5);
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, 10, 15);
   });
 
   it("handles string replacement with async processor", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
       { isMatch: false, content: " world" }
     );
 
@@ -80,7 +80,7 @@ describe("AsyncFunctionReplacementProcessor", () => {
         if (callCount === 1) {
           yield { isMatch: false, content: "text " };
         } else {
-          yield { isMatch: true, content: "OLD" };
+          yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
           yield { isMatch: false, content: " end" };
         }
       }),
@@ -114,9 +114,9 @@ describe("AsyncFunctionReplacementProcessor", () => {
     });
 
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "OLD" }
+      { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
     );
 
     const processor = new AsyncFunctionReplacementProcessor({

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -23,7 +23,7 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", 0);
+    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", 0, undefined, undefined);
     expect(outputChunks).toEqual(["Hello ", "ASYNC_RESULT", " world"]);
   });
 
@@ -47,8 +47,8 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0);
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1);
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, undefined, undefined);
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, undefined, undefined);
   });
 
   it("handles string replacement with async processor", async () => {

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -7,7 +7,7 @@ describe("AsyncFunctionReplacementProcessor", () => {
   it("calls async replacement function with matched content and index", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "MATCH", startIndex: 6, endIndex: 11 },
+      { isMatch: true, content: "MATCH", streamIndices: [6, 11] },
       { isMatch: false, content: " world" }
     );
 
@@ -23,15 +23,15 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", 0, 6, 11);
+    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", 0, [6, 11]);
     expect(outputChunks).toEqual(["Hello ", "ASYNC_RESULT", " world"]);
   });
 
   it("increments match index for subsequent async matches", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 },
+      { isMatch: true, content: "MATCH", streamIndices: [0, 5] },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "MATCH", startIndex: 10, endIndex: 15 }
+      { isMatch: true, content: "MATCH", streamIndices: [10, 15] }
     );
 
     const asyncReplacementFn = vi.fn().mockResolvedValue("ASYNC");
@@ -47,14 +47,14 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, 0, 5);
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, 10, 15);
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, [0, 5]);
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, [10, 15]);
   });
 
   it("handles string replacement with async processor", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
       { isMatch: false, content: " world" }
     );
 
@@ -80,7 +80,7 @@ describe("AsyncFunctionReplacementProcessor", () => {
         if (callCount === 1) {
           yield { isMatch: false, content: "text " };
         } else {
-          yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
+          yield { isMatch: true, content: "OLD", streamIndices: [5, 8] };
           yield { isMatch: false, content: " end" };
         }
       }),
@@ -114,9 +114,9 @@ describe("AsyncFunctionReplacementProcessor", () => {
     });
 
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
+      { isMatch: true, content: "OLD", streamIndices: [0, 3] },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
+      { isMatch: true, content: "OLD", streamIndices: [8, 11] }
     );
 
     const processor = new AsyncFunctionReplacementProcessor({

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -19,9 +19,11 @@ export type AsyncFunctionReplacementProcessorOptions<
    * 
    * @param match - The matched content
    * @param index - Zero-based index of this match
+   * @param startIndex - start index of the match in the stream
+   * @param endIndex - end index (exclusive) of the match in the stream
    * @returns Promise resolving to the replacement string
    */
-  replacement: (match: TMatch, index: number) => Promise<string>;
+  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<string>;
 };
 
 /**
@@ -68,7 +70,7 @@ export class AsyncFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
-  private readonly replacementFn: (match: TMatch, index: number) => Promise<string>;
+  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<string>;
   private matchIndex: number = 0;
 
   constructor({
@@ -80,15 +82,20 @@ export class AsyncFunctionReplacementProcessor<
   }
 
   async *processChunk(chunk: string): AsyncGenerator<string, void, undefined> {
-    for (const { isMatch, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!isMatch) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield await this.replacementFn(content, this.matchIndex++);
+      yield await this.replacementFn(
+        result.content,
+        this.matchIndex++,
+        result.startIndex,
+        result.endIndex
+      );
     }
   }
 }

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -18,12 +18,11 @@ export type AsyncFunctionReplacementProcessorOptions<
    * Async function called for each match to generate the replacement content.
    * 
    * @param match - The matched content
-   * @param index - Zero-based index of this match
-   * @param startIndex - start index of the match in the stream
-   * @param endIndex - end index (exclusive) of the match in the stream
+   * @param matchIndex - Zero-based index of this match
+   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
    * @returns Promise resolving to the replacement string
    */
-  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<string>;
+  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<string>;
 };
 
 /**
@@ -56,8 +55,8 @@ export type AsyncFunctionReplacementProcessorOptions<
  * 
  * const processor = new AsyncFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{user}}'),
- *   replacement: async (match, index) => {
- *     const response = await fetch(`/api/users/${index}`);
+ *   replacement: async (match, matchIndex) => {
+ *     const response = await fetch(`/api/users/${matchIndex}`);
  *     return response.text();
  *   }
  * });
@@ -70,7 +69,7 @@ export class AsyncFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
-  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<string>;
+  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<string>;
   private matchIndex: number = 0;
 
   constructor({
@@ -93,8 +92,7 @@ export class AsyncFunctionReplacementProcessor<
       yield await this.replacementFn(
         result.content,
         this.matchIndex++,
-        result.startIndex,
-        result.endIndex
+        result.streamIndices
       );
     }
   }

--- a/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
@@ -6,7 +6,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("yields stream content chunk-by-chunk without buffering", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
       { isMatch: false, content: " world" }
     );
 
@@ -41,9 +41,9 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
 
   it("handles multiple matches with different stream replacements", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
+      { isMatch: true, content: "OLD", streamIndices: [0, 3] },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
+      { isMatch: true, content: "OLD", streamIndices: [8, 11] }
     );
 
     const stream1Chunks = ["A1", "A2"];
@@ -78,7 +78,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("handles empty stream replacement", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
       { isMatch: false, content: " world" }
     );
 
@@ -102,12 +102,12 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   });
 
   it("handles stream replacement with match context and index", async () => {
-    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 });
+    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", streamIndices: [0, 5] });
 
-    const streamFactory = async (matchedContent: string, index: number) => {
+    const streamFactory = async (matchedContent: string, matchIndex: number) => {
       return new ReadableStream({
         start(controller) {
-          controller.enqueue(`[${matchedContent}:${index}]`);
+          controller.enqueue(`[${matchedContent}:${matchIndex}]`);
           controller.close();
         }
       });
@@ -138,7 +138,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
         if (callCount === 1) {
           yield { isMatch: false, content: "text " };
         } else {
-          yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
+          yield { isMatch: true, content: "OLD", streamIndices: [5, 8] };
           yield { isMatch: false, content: " end" };
         }
       }),

--- a/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
@@ -6,7 +6,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("yields stream content chunk-by-chunk without buffering", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
       { isMatch: false, content: " world" }
     );
 
@@ -41,9 +41,9 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
 
   it("handles multiple matches with different stream replacements", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "OLD" }
+      { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
     );
 
     const stream1Chunks = ["A1", "A2"];
@@ -78,7 +78,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("handles empty stream replacement", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
       { isMatch: false, content: " world" }
     );
 
@@ -102,7 +102,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   });
 
   it("handles stream replacement with match context and index", async () => {
-    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH" });
+    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 });
 
     const streamFactory = async (matchedContent: string, index: number) => {
       return new ReadableStream({
@@ -138,7 +138,7 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
         if (callCount === 1) {
           yield { isMatch: false, content: "text " };
         } else {
-          yield { isMatch: true, content: "OLD" };
+          yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
           yield { isMatch: false, content: " end" };
         }
       }),

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -18,12 +18,11 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
    * Async function called for each match that returns an async iterable of replacement strings.
    * 
    * @param match - The matched content (type inferred from search strategy)
-   * @param index - Zero-based index of this match
-   * @param startIndex - start index of the match in the stream
-   * @param endIndex - end index (exclusive) of the match in the stream
+   * @param matchIndex - Zero-based index of this match
+   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
    * @returns Promise resolving to an async iterable of replacement strings
    */
-  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<AsyncIterable<string>>;
+  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<AsyncIterable<string>>;
 };
 
 /**
@@ -51,8 +50,8 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
  * 
  * const processor = new AsyncIterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{stream}}'),
- *   replacement: async function* (match, index) {
- *     const response = await fetch(`/api/stream/${index}`);
+ *   replacement: async function* (match, matchIndex) {
+ *     const response = await fetch(`/api/stream/${matchIndex}`);
  *     const reader = response.body.getReader();
  *     
  *     while (true) {
@@ -71,7 +70,7 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
  * ```typescript
  * const processor = new AsyncIterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{users}}'),
- *   replacement: async function* (match, index) {
+ *   replacement: async function* (match, matchIndex) {
  *     let page = 0;
  *     let hasMore = true;
  *     
@@ -93,7 +92,7 @@ export class AsyncIterableFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
-  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<AsyncIterable<string>>;
+  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<AsyncIterable<string>>;
   private matchIndex: number = 0;
 
   constructor({
@@ -116,8 +115,7 @@ export class AsyncIterableFunctionReplacementProcessor<
       yield* await this.replacementFn(
         result.content,
         this.matchIndex++,
-        result.startIndex,
-        result.endIndex
+        result.streamIndices
       );
     }
   }

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -19,9 +19,11 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
    * 
    * @param match - The matched content (type inferred from search strategy)
    * @param index - Zero-based index of this match
+   * @param startIndex - start index of the match in the stream
+   * @param endIndex - end index (exclusive) of the match in the stream
    * @returns Promise resolving to an async iterable of replacement strings
    */
-  replacement: (match: TMatch, index: number) => Promise<AsyncIterable<string>>;
+  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<AsyncIterable<string>>;
 };
 
 /**
@@ -103,15 +105,20 @@ export class AsyncIterableFunctionReplacementProcessor<
   }
 
   async *processChunk(chunk: string): AsyncGenerator<string, void, undefined> {
-    for (const { isMatch, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!isMatch) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield* await this.replacementFn(content, this.matchIndex++);
+      yield* await this.replacementFn(
+        result.content,
+        this.matchIndex++,
+        result.startIndex,
+        result.endIndex
+      );
     }
   }
 }

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -93,7 +93,7 @@ export class AsyncIterableFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
-  private readonly replacementFn: (match: TMatch, index: number) => Promise<AsyncIterable<string>>;
+  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => Promise<AsyncIterable<string>>;
   private matchIndex: number = 0;
 
   constructor({

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -129,7 +129,7 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenCalledWith("MATCH", 0);
+      expect(replacementFn).toHaveBeenCalledWith("MATCH", 0, undefined, undefined);
       expect(outputChunks).toEqual(["Hello ", "RESULT", " world"]);
     });
 
@@ -164,8 +164,8 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0);
-      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1);
+      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, undefined, undefined);
+      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, undefined, undefined);
     });
 
     it("continues processing after match to find subsequent matches", () => {

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -27,7 +27,7 @@ describe("FunctionReplacementProcessor", () => {
     it("yields content before match and replacement when complete match found", () => {
       const mockStrategy = mockSearchStrategyFactory(
         { isMatch: false, content: "Hello " },
-        { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+        { isMatch: true, content: "OLD", streamIndices: [6, 9] },
         { isMatch: false, content: " world" }
       );
 
@@ -85,7 +85,7 @@ describe("FunctionReplacementProcessor", () => {
             // "OL" is buffered (not yielded)
           } else if (callCount === 2) {
             // Second chunk completes the match
-            yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
+            yield { isMatch: true, content: "OLD", streamIndices: [5, 8] };
             yield { isMatch: false, content: " end" };
           }
         }),
@@ -110,10 +110,10 @@ describe("FunctionReplacementProcessor", () => {
       expect(outputChunks).toEqual(["text ", "NEW", " end"]);
     });
 
-    it("calls replacement function with matched content, index, startIndex and endIndex", () => {
+    it("calls replacement function with matched content, matchIndex and streamIndices", () => {
       const mockStrategy = mockSearchStrategyFactory(
         { isMatch: false, content: "Hello " },
-        { isMatch: true, content: "MATCH", startIndex: 6, endIndex: 11 },
+        { isMatch: true, content: "MATCH", streamIndices: [6, 11] },
         { isMatch: false, content: " world" }
       );
 
@@ -129,7 +129,7 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenCalledWith("MATCH", 0, 6, 11);
+      expect(replacementFn).toHaveBeenCalledWith("MATCH", 0, [6, 11]);
       expect(outputChunks).toEqual(["Hello ", "RESULT", " world"]);
     });
 
@@ -140,9 +140,9 @@ describe("FunctionReplacementProcessor", () => {
         processChunk: vi.fn().mockImplementation(function* () {
           callCount++;
           if (callCount === 1) {
-            yield { isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 };
+            yield { isMatch: true, content: "MATCH", streamIndices: [0, 5] };
           } else if (callCount === 2) {
-            yield { isMatch: true, content: "MATCH", startIndex: 5, endIndex: 10 };
+            yield { isMatch: true, content: "MATCH", streamIndices: [5, 10] };
           }
         }),
         flush: vi.fn().mockReturnValue("")
@@ -164,15 +164,15 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, 0, 5);
-      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, 5, 10);
+      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, [0, 5]);
+      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, [5, 10]);
     });
 
     it("continues processing after match to find subsequent matches", () => {
       const mockStrategy = mockSearchStrategyFactory(
-        { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
+        { isMatch: true, content: "OLD", streamIndices: [0, 3] },
         { isMatch: false, content: " and " },
-        { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
+        { isMatch: true, content: "OLD", streamIndices: [8, 11] }
       );
 
       const processor = new FunctionReplacementProcessor({
@@ -197,9 +197,9 @@ describe("FunctionReplacementProcessor", () => {
       });
 
       const mockStrategy = mockSearchStrategyFactory(
-        { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
+        { isMatch: true, content: "OLD", streamIndices: [0, 3] },
         { isMatch: false, content: " and " },
-        { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
+        { isMatch: true, content: "OLD", streamIndices: [8, 11] }
       );
 
       const processor = new FunctionReplacementProcessor({

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -85,7 +85,7 @@ describe("FunctionReplacementProcessor", () => {
             // "OL" is buffered (not yielded)
           } else if (callCount === 2) {
             // Second chunk completes the match
-            yield { isMatch: true, content: "OLD" };
+            yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
             yield { isMatch: false, content: " end" };
           }
         }),
@@ -142,7 +142,7 @@ describe("FunctionReplacementProcessor", () => {
           if (callCount === 1) {
             yield { isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 };
           } else if (callCount === 2) {
-            yield { isMatch: true, content: "MATCH", startIndex: 10, endIndex: 15 };
+            yield { isMatch: true, content: "MATCH", startIndex: 5, endIndex: 10 };
           }
         }),
         flush: vi.fn().mockReturnValue("")
@@ -165,7 +165,7 @@ describe("FunctionReplacementProcessor", () => {
       }
 
       expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, 0, 5);
-      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, 10, 15);
+      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, 5, 10);
     });
 
     it("continues processing after match to find subsequent matches", () => {

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -27,7 +27,7 @@ describe("FunctionReplacementProcessor", () => {
     it("yields content before match and replacement when complete match found", () => {
       const mockStrategy = mockSearchStrategyFactory(
         { isMatch: false, content: "Hello " },
-        { isMatch: true, content: "OLD" },
+        { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
         { isMatch: false, content: " world" }
       );
 
@@ -110,10 +110,10 @@ describe("FunctionReplacementProcessor", () => {
       expect(outputChunks).toEqual(["text ", "NEW", " end"]);
     });
 
-    it("calls replacement function with matched content and index", () => {
+    it("calls replacement function with matched content, index, startIndex and endIndex", () => {
       const mockStrategy = mockSearchStrategyFactory(
         { isMatch: false, content: "Hello " },
-        { isMatch: true, content: "MATCH" },
+        { isMatch: true, content: "MATCH", startIndex: 6, endIndex: 11 },
         { isMatch: false, content: " world" }
       );
 
@@ -129,7 +129,7 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenCalledWith("MATCH", 0, undefined, undefined);
+      expect(replacementFn).toHaveBeenCalledWith("MATCH", 0, 6, 11);
       expect(outputChunks).toEqual(["Hello ", "RESULT", " world"]);
     });
 
@@ -140,9 +140,9 @@ describe("FunctionReplacementProcessor", () => {
         processChunk: vi.fn().mockImplementation(function* () {
           callCount++;
           if (callCount === 1) {
-            yield { isMatch: true, content: "MATCH" };
+            yield { isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 };
           } else if (callCount === 2) {
-            yield { isMatch: true, content: "MATCH" };
+            yield { isMatch: true, content: "MATCH", startIndex: 10, endIndex: 15 };
           }
         }),
         flush: vi.fn().mockReturnValue("")
@@ -164,15 +164,15 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, undefined, undefined);
-      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, undefined, undefined);
+      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, 0, 5);
+      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, 10, 15);
     });
 
     it("continues processing after match to find subsequent matches", () => {
       const mockStrategy = mockSearchStrategyFactory(
-        { isMatch: true, content: "OLD" },
+        { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
         { isMatch: false, content: " and " },
-        { isMatch: true, content: "OLD" }
+        { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
       );
 
       const processor = new FunctionReplacementProcessor({
@@ -197,9 +197,9 @@ describe("FunctionReplacementProcessor", () => {
       });
 
       const mockStrategy = mockSearchStrategyFactory(
-        { isMatch: true, content: "OLD" },
+        { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
         { isMatch: false, content: " and " },
-        { isMatch: true, content: "OLD" }
+        { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
       );
 
       const processor = new FunctionReplacementProcessor({

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -20,9 +20,11 @@ export type FunctionReplacementProcessorOptions<
    * 
    * @param match - The matched content (type inferred from search strategy)
    * @param index - Zero-based index of this match (increments with each match)
+   * @param startIndex - start index of the match in the stream
+   * @param endIndex - end index (exclusive) of the match in the stream
    * @returns The replacement string, or a Promise<string> for async operations
    */
-  replacement: (match: TMatch, index: number) => R;
+  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => R;
 };
 
 /**
@@ -90,15 +92,20 @@ export class FunctionReplacementProcessor<
   }
 
   *processChunk(input: string): Generator<R | string, void, undefined> {
-    for (const { isMatch, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       input,
       this.searchState
     )) {
-      if (!isMatch) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield this.replacementFn(content, this.matchIndex++);
+      yield this.replacementFn(
+        result.content,
+        this.matchIndex++,
+        result.startIndex,
+        result.endIndex
+      );
     }
   }
 }

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -80,7 +80,7 @@ export class FunctionReplacementProcessor<
   TMatch = string,
   R extends string | Promise<string> = string
 > extends ReplacementProcessorBase<TState, TMatch> {
-  private readonly replacementFn: (match: TMatch, index: number) => R;
+  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => R;
   private matchIndex: number = 0;
 
   constructor({

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -19,12 +19,11 @@ export type FunctionReplacementProcessorOptions<
    * Function called for each match to generate the replacement content.
    * 
    * @param match - The matched content (type inferred from search strategy)
-   * @param index - Zero-based index of this match (increments with each match)
-   * @param startIndex - start index of the match in the stream
-   * @param endIndex - end index (exclusive) of the match in the stream
+   * @param matchIndex - Zero-based index of this match (increments with each match)
+   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
    * @returns The replacement string, or a Promise<string> for async operations
    */
-  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => R;
+  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => R;
 };
 
 /**
@@ -52,7 +51,7 @@ export type FunctionReplacementProcessorOptions<
  * 
  * const processor = new FunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory(/{{(\w+)}}/g),
- *   replacement: (match, index) => `Replacement #${index}: ${match[1]}`
+ *   replacement: (match, matchIndex) => `Replacement #${matchIndex}: ${match[1]}`
  * });
  * 
  * const transformer = new ReplaceContentTransformer(processor);
@@ -65,8 +64,8 @@ export type FunctionReplacementProcessorOptions<
  * 
  * const processor = new FunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{id}}'),
- *   replacement: async (match, index) => {
- *     const data = await fetch(`/api/data/${index}`);
+ *   replacement: async (match, matchIndex) => {
+ *     const data = await fetch(`/api/data/${matchIndex}`);
  *     return data.text();
  *   }
  * });
@@ -80,7 +79,7 @@ export class FunctionReplacementProcessor<
   TMatch = string,
   R extends string | Promise<string> = string
 > extends ReplacementProcessorBase<TState, TMatch> {
-  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => R;
+  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => R;
   private matchIndex: number = 0;
 
   constructor({
@@ -103,8 +102,7 @@ export class FunctionReplacementProcessor<
       yield this.replacementFn(
         result.content,
         this.matchIndex++,
-        result.startIndex,
-        result.endIndex
+        result.streamIndices
       );
     }
   }

--- a/src/replacement-processors/iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.test.ts
@@ -8,7 +8,7 @@ describe("IterableFunctionReplacementProcessor", () => {
   it("yields iterable content chunk-by-chunk without buffering", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
       { isMatch: false, content: " world" }
     );
     const iterableChunks = ["chunk1", "chunk2", "chunk3"];
@@ -35,9 +35,9 @@ describe("IterableFunctionReplacementProcessor", () => {
 
   it("handles multiple matches with different iterable replacements", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "OLD" }
+      { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
     );
 
     const iterable1Chunks = ["A1", "A2"];
@@ -65,7 +65,7 @@ describe("IterableFunctionReplacementProcessor", () => {
   it("handles empty iterable replacement", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
       { isMatch: false, content: " world" }
     );
 
@@ -85,7 +85,7 @@ describe("IterableFunctionReplacementProcessor", () => {
   });
 
   it("handles iterable replacement with match context and index", async () => {
-    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH" });
+    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 });
 
     const iterableFactory = (matchedContent: string, index: number) => {
       return [`[${matchedContent}:${index}]`];
@@ -119,7 +119,7 @@ describe("IterableFunctionReplacementProcessor", () => {
         if (callCount === 1) {
           yield { isMatch: false, content: "text " };
         } else {
-          yield { isMatch: true, content: "OLD" };
+          yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
           yield { isMatch: false, content: " end" };
         }
       }),

--- a/src/replacement-processors/iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.test.ts
@@ -8,7 +8,7 @@ describe("IterableFunctionReplacementProcessor", () => {
   it("yields iterable content chunk-by-chunk without buffering", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
       { isMatch: false, content: " world" }
     );
     const iterableChunks = ["chunk1", "chunk2", "chunk3"];
@@ -35,9 +35,9 @@ describe("IterableFunctionReplacementProcessor", () => {
 
   it("handles multiple matches with different iterable replacements", async () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
+      { isMatch: true, content: "OLD", streamIndices: [0, 3] },
       { isMatch: false, content: " and " },
-      { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 }
+      { isMatch: true, content: "OLD", streamIndices: [8, 11] }
     );
 
     const iterable1Chunks = ["A1", "A2"];
@@ -65,7 +65,7 @@ describe("IterableFunctionReplacementProcessor", () => {
   it("handles empty iterable replacement", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
       { isMatch: false, content: " world" }
     );
 
@@ -85,10 +85,10 @@ describe("IterableFunctionReplacementProcessor", () => {
   });
 
   it("handles iterable replacement with match context and index", async () => {
-    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", startIndex: 0, endIndex: 5 });
+    const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", streamIndices: [0, 5] });
 
-    const iterableFactory = (matchedContent: string, index: number) => {
-      return [`[${matchedContent}:${index}]`];
+    const iterableFactory = (matchedContent: string, matchIndex: number) => {
+      return [`[${matchedContent}:${matchIndex}]`];
     };
 
     const processor = new IterableFunctionReplacementProcessor({
@@ -119,7 +119,7 @@ describe("IterableFunctionReplacementProcessor", () => {
         if (callCount === 1) {
           yield { isMatch: false, content: "text " };
         } else {
-          yield { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 };
+          yield { isMatch: true, content: "OLD", streamIndices: [5, 8] };
           yield { isMatch: false, content: " end" };
         }
       }),

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -18,12 +18,11 @@ export type IterableFunctionReplacementProcessorOptions<
    * Function called for each match that returns an iterable of replacement strings.
    *
    * @param match - The matched content (type inferred from search strategy)
-   * @param index - Zero-based index of this match
-   * @param startIndex - start index of the match in the stream
-   * @param endIndex - end index (exclusive) of the match in the stream
+   * @param matchIndex - Zero-based index of this match
+   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
    * @returns An iterable of replacement strings
    */
-  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => Iterable<string>;
+  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Iterable<string>;
 };
 
 /**
@@ -49,7 +48,7 @@ export type IterableFunctionReplacementProcessorOptions<
  *
  * const processor = new IterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{list}}'),
- *   replacement: (match, index) => ['Item 1', 'Item 2', 'Item 3']
+ *   replacement: (match, matchIndex) => ['Item 1', 'Item 2', 'Item 3']
  * });
  *
  * const transformer = new ReplaceContentTransformer(processor);
@@ -59,7 +58,7 @@ export type IterableFunctionReplacementProcessorOptions<
  * ```typescript
  * const processor = new IterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{repeat}}'),
- *   replacement: function* (match, index) {
+ *   replacement: function* (match, matchIndex) {
  *     for (let i = 0; i < 5; i++) {
  *       yield `Iteration ${i}\n`;
  *     }
@@ -71,7 +70,7 @@ export class IterableFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements SyncProcessor {
-  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => Iterable<string>;
+  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Iterable<string>;
   private matchIndex: number = 0;
 
   constructor({
@@ -94,8 +93,7 @@ export class IterableFunctionReplacementProcessor<
       yield* this.replacementFn(
         result.content,
         this.matchIndex++,
-        result.startIndex,
-        result.endIndex
+        result.streamIndices
       );
     }
   }

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -71,7 +71,7 @@ export class IterableFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements SyncProcessor {
-  private readonly replacementFn: (match: TMatch, index: number) => Iterable<string>;
+  private readonly replacementFn: (match: TMatch, index: number, startIndex: number, endIndex: number) => Iterable<string>;
   private matchIndex: number = 0;
 
   constructor({

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -19,9 +19,11 @@ export type IterableFunctionReplacementProcessorOptions<
    *
    * @param match - The matched content (type inferred from search strategy)
    * @param index - Zero-based index of this match
+   * @param startIndex - start index of the match in the stream
+   * @param endIndex - end index (exclusive) of the match in the stream
    * @returns An iterable of replacement strings
    */
-  replacement: (match: TMatch, index: number) => Iterable<string>;
+  replacement: (match: TMatch, index: number, startIndex: number, endIndex: number) => Iterable<string>;
 };
 
 /**
@@ -81,15 +83,20 @@ export class IterableFunctionReplacementProcessor<
   }
 
   *processChunk(chunk: string): Generator<string, void, undefined> {
-    for (const { isMatch, content } of this.searchStrategy.processChunk(
+    for (const result of this.searchStrategy.processChunk(
       chunk,
       this.searchState
     )) {
-      if (!isMatch) {
-        yield content;
+      if (!result.isMatch) {
+        yield result.content;
         continue;
       }
-      yield* this.replacementFn(content, this.matchIndex++);
+      yield* this.replacementFn(
+        result.content,
+        this.matchIndex++,
+        result.startIndex,
+        result.endIndex
+      );
     }
   }
 }

--- a/src/replacement-processors/static-replacement-processor.test.ts
+++ b/src/replacement-processors/static-replacement-processor.test.ts
@@ -28,7 +28,7 @@ describe("StaticReplacementProcessor", () => {
   it("yields content before match and replacement when complete match found", () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
       { isMatch: false, content: " world" }
     );
 
@@ -49,9 +49,9 @@ describe("StaticReplacementProcessor", () => {
   it("handles multiple replacements in single chunk", () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
       { isMatch: false, content: " " },
-      { isMatch: true, content: "OLD", startIndex: 10, endIndex: 13 },
+      { isMatch: true, content: "OLD", streamIndices: [10, 13] },
       { isMatch: false, content: " world" }
     );
 
@@ -94,7 +94,7 @@ describe("StaticReplacementProcessor", () => {
 
   it("handles replacement at start of chunk", () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "Hello", startIndex: 0, endIndex: 5 },
+      { isMatch: true, content: "Hello", streamIndices: [0, 5] },
       { isMatch: false, content: " world" }
     );
 

--- a/src/replacement-processors/static-replacement-processor.test.ts
+++ b/src/replacement-processors/static-replacement-processor.test.ts
@@ -28,7 +28,7 @@ describe("StaticReplacementProcessor", () => {
   it("yields content before match and replacement when complete match found", () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
       { isMatch: false, content: " world" }
     );
 
@@ -49,9 +49,9 @@ describe("StaticReplacementProcessor", () => {
   it("handles multiple replacements in single chunk", () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
       { isMatch: false, content: " " },
-      { isMatch: true, content: "OLD" },
+      { isMatch: true, content: "OLD", startIndex: 10, endIndex: 13 },
       { isMatch: false, content: " world" }
     );
 
@@ -94,7 +94,7 @@ describe("StaticReplacementProcessor", () => {
 
   it("handles replacement at start of chunk", () => {
     const mockStrategy = mockSearchStrategyFactory(
-      { isMatch: true, content: "Hello" },
+      { isMatch: true, content: "Hello", startIndex: 0, endIndex: 5 },
       { isMatch: false, content: " world" }
     );
 

--- a/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
@@ -16,7 +16,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(results).toEqual([
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 },
+      { isMatch: true, content: "{{name}}", streamIndices: [6, 14] },
       { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
@@ -34,7 +34,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(results).toEqual([{ isMatch: false, content: "Hello " }]);
     expect(results2).toEqual([
-      { isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 },
+      { isMatch: true, content: "{{name}}", streamIndices: [6, 14] },
       { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
@@ -70,7 +70,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
       strategy.processChunk('<img src="/photo.jpg" alt="sunset"> text', state)
     );
     expect(results).toEqual([
-      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 }
+      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', streamIndices: [0, 35] }
     ]);
     expect(strategy.flush(state)).toEqual(" text");
   });
@@ -101,7 +101,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r2 = Array.from(strategy.processChunk("{name}}", state));
 
     expect(r1).toEqual([{ isMatch: false, content: "Hello " }]);
-    expect(r2).toEqual([{ isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{name}}", streamIndices: [6, 14] }]);
   });
 
   it("closing delimiter split across chunks", () => {
@@ -116,7 +116,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([]);
     expect(r2).toEqual([
-      { isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 },
+      { isMatch: true, content: "{{name}}", streamIndices: [0, 8] },
       { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
@@ -138,7 +138,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
     expect(r4).toEqual([
-      { isMatch: true, content: "{{hello}}", startIndex: 0, endIndex: 9 },
+      { isMatch: true, content: "{{hello}}", streamIndices: [0, 9] },
       { isMatch: false, content: " ther" }
     ]);
     expect(strategy.flush(state)).toEqual("e");
@@ -175,7 +175,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r1).toEqual([]);
     expect(r2).toEqual([
       { isMatch: false, content: "{x " },
-      { isMatch: true, content: "{{name}}", startIndex: 3, endIndex: 11 }
+      { isMatch: true, content: "{{name}}", streamIndices: [3, 11] }
     ]);
   });
 
@@ -193,9 +193,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
+      { isMatch: true, content: "{{first}}", streamIndices: [0, 9] },
       { isMatch: false, content: " " },
-      { isMatch: true, content: "{{second}}", startIndex: 10, endIndex: 20 }
+      { isMatch: true, content: "{{second}}", streamIndices: [10, 20] }
     ]);
   });
 
@@ -209,8 +209,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r1 = Array.from(strategy.processChunk("{{first}}", state));
     const r2 = Array.from(strategy.processChunk("{{second}}", state));
 
-    expect(r1).toEqual([{ isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 }]);
-    expect(r2).toEqual([{ isMatch: true, content: "{{second}}", startIndex: 9, endIndex: 19 }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{first}}", streamIndices: [0, 9] }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{second}}", streamIndices: [9, 19] }]);
   });
 
   it("sequence completes and next begins in same chunk", () => {
@@ -223,7 +223,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r1 = Array.from(strategy.processChunk("{{first}}", state));
     const r2 = Array.from(strategy.processChunk(" {{partial", state));
 
-    expect(r1).toEqual([{ isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{first}}", streamIndices: [0, 9] }]);
     expect(r2).toEqual([{ isMatch: false, content: " " }]);
 
     const r3 = strategy.flush(state);
@@ -241,9 +241,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r2 = Array.from(strategy.processChunk(" {", state));
     const r3 = Array.from(strategy.processChunk("{b}}", state));
 
-    expect(r1).toEqual([{ isMatch: true, content: "{{a}}", startIndex: 0, endIndex: 5 }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{a}}", streamIndices: [0, 5] }]);
     expect(r2).toEqual([{ isMatch: false, content: " " }]);
-    expect(r3).toEqual([{ isMatch: true, content: "{{b}}", startIndex: 6, endIndex: 11 }]);
+    expect(r3).toEqual([{ isMatch: true, content: "{{b}}", streamIndices: [6, 11] }]);
   });
 
   // ===== Edge Cases =====
@@ -257,7 +257,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     const results = Array.from(strategy.processChunk("{{}}", state));
 
-    expect(results).toEqual([{ isMatch: true, content: "{{}}", startIndex: 0, endIndex: 4 }]);
+    expect(results).toEqual([{ isMatch: true, content: "{{}}", streamIndices: [0, 4] }]);
   });
 
   it("consecutive sequences with no content between", () => {
@@ -270,8 +270,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const results = Array.from(strategy.processChunk("{{a}}{{b}}", state));
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{a}}", startIndex: 0, endIndex: 5 },
-      { isMatch: true, content: "{{b}}", startIndex: 5, endIndex: 10 }
+      { isMatch: true, content: "{{a}}", streamIndices: [0, 5] },
+      { isMatch: true, content: "{{b}}", streamIndices: [5, 10] }
     ]);
   });
 
@@ -287,7 +287,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([]);
     // The first "{{" matches, then accumulates "incomplete {{complete", then finds "}}" - valid match!
-    expect(r2).toEqual([{ isMatch: true, content: "{{incomplete {{complete}}", startIndex: 0, endIndex: 25 }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{incomplete {{complete}}", streamIndices: [0, 25] }]);
   });
 
   it("nested-looking but sequential delimiters", () => {
@@ -302,7 +302,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     // Should match "{{{{stuff}}" as first sequence, then "}}" is non-match
     expect(results).toEqual([
-      { isMatch: true, content: "{{{{stuff}}", startIndex: 0, endIndex: 11 },
+      { isMatch: true, content: "{{{{stuff}}", streamIndices: [0, 11] },
       { isMatch: false, content: "}" }
     ]);
     expect(strategy.flush(state)).toEqual("}");
@@ -325,7 +325,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
     expect(r4).toEqual([
-      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 }
+      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', streamIndices: [0, 35] }
     ]);
     expect(strategy.flush(state)).toEqual(" text");
   });
@@ -346,8 +346,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { isMatch: true, content: '<img src="a.jpg" alt="first">', startIndex: 0, endIndex: 29 },
-      { isMatch: true, content: '<img src="b.jpg" alt="second">', startIndex: 29, endIndex: 59 }
+      { isMatch: true, content: '<img src="a.jpg" alt="first">', streamIndices: [0, 29] },
+      { isMatch: true, content: '<img src="b.jpg" alt="second">', streamIndices: [29, 59] }
     ]);
   });
 
@@ -366,7 +366,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r1).toEqual([]);
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
-    expect(r4).toEqual([{ isMatch: true, content: "{{part1part2part3part4}}", startIndex: 0, endIndex: 24 }]);
+    expect(r4).toEqual([{ isMatch: true, content: "{{part1part2part3part4}}", streamIndices: [0, 24] }]);
   });
 
   it("delimiter appears in content between delimiters", () => {
@@ -382,7 +382,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{content with {{ inside}}", startIndex: 0, endIndex: 26 }
+      { isMatch: true, content: "{{content with {{ inside}}", streamIndices: [0, 26] }
     ]);
   });
 
@@ -399,7 +399,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([{ isMatch: false, content: "before " }]);
     expect(r2).toEqual([]);
-    expect(r3).toEqual([{ isMatch: true, content: "[middle]", startIndex: 7, endIndex: 15 }]);
+    expect(r3).toEqual([{ isMatch: true, content: "[middle]", streamIndices: [7, 15] }]);
     expect(strategy.flush(state)).toEqual(" after");
   });
 });

--- a/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
@@ -16,7 +16,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(results).toEqual([
       { isMatch: false, content: "Hello " },
-      { isMatch: true, content: "{{name}}" },
+      { isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 },
       { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
@@ -34,7 +34,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(results).toEqual([{ isMatch: false, content: "Hello " }]);
     expect(results2).toEqual([
-      { isMatch: true, content: "{{name}}" },
+      { isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 },
       { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
@@ -70,7 +70,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
       strategy.processChunk('<img src="/photo.jpg" alt="sunset"> text', state)
     );
     expect(results).toEqual([
-      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' }
+      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 }
     ]);
     expect(strategy.flush(state)).toEqual(" text");
   });
@@ -101,7 +101,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r2 = Array.from(strategy.processChunk("{name}}", state));
 
     expect(r1).toEqual([{ isMatch: false, content: "Hello " }]);
-    expect(r2).toEqual([{ isMatch: true, content: "{{name}}" }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 }]);
   });
 
   it("closing delimiter split across chunks", () => {
@@ -116,7 +116,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([]);
     expect(r2).toEqual([
-      { isMatch: true, content: "{{name}}" },
+      { isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 },
       { isMatch: false, content: " worl" }
     ]);
     expect(strategy.flush(state)).toEqual("d");
@@ -138,7 +138,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
     expect(r4).toEqual([
-      { isMatch: true, content: "{{hello}}" },
+      { isMatch: true, content: "{{hello}}", startIndex: 0, endIndex: 9 },
       { isMatch: false, content: " ther" }
     ]);
     expect(strategy.flush(state)).toEqual("e");
@@ -175,7 +175,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r1).toEqual([]);
     expect(r2).toEqual([
       { isMatch: false, content: "{x " },
-      { isMatch: true, content: "{{name}}" }
+      { isMatch: true, content: "{{name}}", startIndex: 3, endIndex: 11 }
     ]);
   });
 
@@ -193,9 +193,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{first}}" },
+      { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
       { isMatch: false, content: " " },
-      { isMatch: true, content: "{{second}}" }
+      { isMatch: true, content: "{{second}}", startIndex: 10, endIndex: 20 }
     ]);
   });
 
@@ -209,8 +209,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r1 = Array.from(strategy.processChunk("{{first}}", state));
     const r2 = Array.from(strategy.processChunk("{{second}}", state));
 
-    expect(r1).toEqual([{ isMatch: true, content: "{{first}}" }]);
-    expect(r2).toEqual([{ isMatch: true, content: "{{second}}" }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{second}}", startIndex: 9, endIndex: 19 }]);
   });
 
   it("sequence completes and next begins in same chunk", () => {
@@ -223,7 +223,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r1 = Array.from(strategy.processChunk("{{first}}", state));
     const r2 = Array.from(strategy.processChunk(" {{partial", state));
 
-    expect(r1).toEqual([{ isMatch: true, content: "{{first}}" }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 }]);
     expect(r2).toEqual([{ isMatch: false, content: " " }]);
 
     const r3 = strategy.flush(state);
@@ -241,9 +241,9 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const r2 = Array.from(strategy.processChunk(" {", state));
     const r3 = Array.from(strategy.processChunk("{b}}", state));
 
-    expect(r1).toEqual([{ isMatch: true, content: "{{a}}" }]);
+    expect(r1).toEqual([{ isMatch: true, content: "{{a}}", startIndex: 0, endIndex: 5 }]);
     expect(r2).toEqual([{ isMatch: false, content: " " }]);
-    expect(r3).toEqual([{ isMatch: true, content: "{{b}}" }]);
+    expect(r3).toEqual([{ isMatch: true, content: "{{b}}", startIndex: 6, endIndex: 11 }]);
   });
 
   // ===== Edge Cases =====
@@ -257,7 +257,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     const results = Array.from(strategy.processChunk("{{}}", state));
 
-    expect(results).toEqual([{ isMatch: true, content: "{{}}" }]);
+    expect(results).toEqual([{ isMatch: true, content: "{{}}", startIndex: 0, endIndex: 4 }]);
   });
 
   it("consecutive sequences with no content between", () => {
@@ -270,8 +270,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     const results = Array.from(strategy.processChunk("{{a}}{{b}}", state));
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{a}}" },
-      { isMatch: true, content: "{{b}}" }
+      { isMatch: true, content: "{{a}}", startIndex: 0, endIndex: 5 },
+      { isMatch: true, content: "{{b}}", startIndex: 5, endIndex: 10 }
     ]);
   });
 
@@ -287,7 +287,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([]);
     // The first "{{" matches, then accumulates "incomplete {{complete", then finds "}}" - valid match!
-    expect(r2).toEqual([{ isMatch: true, content: "{{incomplete {{complete}}" }]);
+    expect(r2).toEqual([{ isMatch: true, content: "{{incomplete {{complete}}", startIndex: 0, endIndex: 25 }]);
   });
 
   it("nested-looking but sequential delimiters", () => {
@@ -302,7 +302,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     // Should match "{{{{stuff}}" as first sequence, then "}}" is non-match
     expect(results).toEqual([
-      { isMatch: true, content: "{{{{stuff}}" },
+      { isMatch: true, content: "{{{{stuff}}", startIndex: 0, endIndex: 11 },
       { isMatch: false, content: "}" }
     ]);
     expect(strategy.flush(state)).toEqual("}");
@@ -325,7 +325,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
     expect(r4).toEqual([
-      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' }
+      { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 }
     ]);
     expect(strategy.flush(state)).toEqual(" text");
   });
@@ -346,8 +346,8 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { isMatch: true, content: '<img src="a.jpg" alt="first">' },
-      { isMatch: true, content: '<img src="b.jpg" alt="second">' }
+      { isMatch: true, content: '<img src="a.jpg" alt="first">', startIndex: 0, endIndex: 29 },
+      { isMatch: true, content: '<img src="b.jpg" alt="second">', startIndex: 29, endIndex: 59 }
     ]);
   });
 
@@ -366,7 +366,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     expect(r1).toEqual([]);
     expect(r2).toEqual([]);
     expect(r3).toEqual([]);
-    expect(r4).toEqual([{ isMatch: true, content: "{{part1part2part3part4}}" }]);
+    expect(r4).toEqual([{ isMatch: true, content: "{{part1part2part3part4}}", startIndex: 0, endIndex: 24 }]);
   });
 
   it("delimiter appears in content between delimiters", () => {
@@ -382,7 +382,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
     );
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{content with {{ inside}}" }
+      { isMatch: true, content: "{{content with {{ inside}}", startIndex: 0, endIndex: 26 }
     ]);
   });
 
@@ -399,7 +399,7 @@ describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrateg
 
     expect(r1).toEqual([{ isMatch: false, content: "before " }]);
     expect(r2).toEqual([]);
-    expect(r3).toEqual([{ isMatch: true, content: "[middle]" }]);
+    expect(r3).toEqual([{ isMatch: true, content: "[middle]", startIndex: 7, endIndex: 15 }]);
     expect(strategy.flush(state)).toEqual(" after");
   });
 });

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
@@ -114,7 +114,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "Hello {{name}} world" }],
         expectedResults: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "{{name}}" },
+          { isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 },
           { isMatch: false, content: " world" }
         ],
         expectedFlush: ""
@@ -124,7 +124,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{value}} text" }],
         expectedResults: [
-          { isMatch: true, content: "{{value}}" },
+          { isMatch: true, content: "{{value}}", startIndex: 0, endIndex: 9 },
           { isMatch: false, content: " text" }
         ],
         expectedFlush: ""
@@ -135,7 +135,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text {{value}}" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "{{value}}" }
+          { isMatch: true, content: "{{value}}", startIndex: 5, endIndex: 14 }
         ],
         expectedFlush: ""
       },
@@ -144,9 +144,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}} and {{second}}" }],
         expectedResults: [
-          { isMatch: true, content: "{{first}}" },
+          { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "{{second}}" }
+          { isMatch: true, content: "{{second}}", startIndex: 14, endIndex: 24 }
         ],
         expectedFlush: ""
       },
@@ -156,7 +156,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text {{}} more" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "{{}}" },
+          { isMatch: true, content: "{{}}", startIndex: 5, endIndex: 9 },
           { isMatch: false, content: " more" }
         ],
         expectedFlush: ""
@@ -166,7 +166,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ['<img src="', '" alt="', '">'],
         calls: [{ haystack: '<img src="/photo.jpg" alt="sunset"> text' }],
         expectedResults: [
-          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' },
+          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 },
           { isMatch: false, content: " text" }
         ],
         expectedFlush: ""
@@ -177,7 +177,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text [value] more" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "[value]" },
+          { isMatch: true, content: "[value]", startIndex: 5, endIndex: 12 },
           { isMatch: false, content: " more" }
         ],
         expectedFlush: ""
@@ -187,9 +187,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{this is a very long string with many words}}" }],
         expectedResults: [
-          {
-            isMatch: true, content: "{{this is a very long string with many words}}"
-          }
+          { isMatch: true, content: "{{this is a very long string with many words}}", startIndex: 0, endIndex: 46 }
         ],
         expectedFlush: ""
       },
@@ -198,9 +196,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}}" }, { haystack: " and {{second}}" }],
         expectedResults: [
-          { isMatch: true, content: "{{first}}" },
+          { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "{{second}}" }
+          { isMatch: true, content: "{{second}}", startIndex: 14, endIndex: 24 }
         ],
         expectedFlush: ""
       }
@@ -243,14 +241,14 @@ describe("AnchorSequenceSearchStrategy", () => {
         name: "start delimiter split across two chunks: '{' + '{name}}'",
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{" }, { haystack: "{name}}" }],
-        expectedResults: [{ isMatch: true, content: "{{name}}" }],
+        expectedResults: [{ isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 }],
         expectedFlush: ""
       },
       {
         name: "end delimiter split across two chunks: '{{name}' + '}'",
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{name}" }, { haystack: "}" }],
-        expectedResults: [{ isMatch: true, content: "{{name}}" }],
+        expectedResults: [{ isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 }],
         expectedFlush: ""
       },
       {
@@ -261,7 +259,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: '" alt="sunset">' }
         ],
         expectedResults: [
-          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">' }
+          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 }
         ],
         expectedFlush: ""
       },
@@ -276,7 +274,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: "}" },
           { haystack: "}" }
         ],
-        expectedResults: [{ isMatch: true, content: "{{name}}" }],
+        expectedResults: [{ isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 }],
         expectedFlush: ""
       },
       {
@@ -284,9 +282,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{name}}" }, { haystack: " {{value}}" }],
         expectedResults: [
-          { isMatch: true, content: "{{name}}" },
+          { isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 },
           { isMatch: false, content: " " },
-          { isMatch: true, content: "{{value}}" }
+          { isMatch: true, content: "{{value}}", startIndex: 9, endIndex: 18 }
         ],
         expectedFlush: ""
       },
@@ -296,7 +294,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text " }, { haystack: "{{name}}" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "{{name}}" }
+          { isMatch: true, content: "{{name}}", startIndex: 5, endIndex: 13 }
         ],
         expectedFlush: ""
       },
@@ -308,7 +306,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: "IN content E" },
           { haystack: "ND" }
         ],
-        expectedResults: [{ isMatch: true, content: "BEGIN content END" }],
+        expectedResults: [{ isMatch: true, content: "BEGIN content END", startIndex: 0, endIndex: 17 }],
         expectedFlush: ""
       },
       {
@@ -316,9 +314,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}} and {{se" }, { haystack: "cond}} end" }],
         expectedResults: [
-          { isMatch: true, content: "{{first}}" },
+          { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "{{second}}" },
+          { isMatch: true, content: "{{second}}", startIndex: 14, endIndex: 24 },
           { isMatch: false, content: " end" }
         ],
         expectedFlush: ""
@@ -373,7 +371,7 @@ describe("AnchorSequenceSearchStrategy", () => {
 
       expect(results).toEqual([
         { isMatch: false, content: "First " },
-        { isMatch: true, content: "{{OLD}}" }
+        { isMatch: true, content: "{{OLD}}", startIndex: 6, endIndex: 13 }
       ]);
       expect(flushed).toEqual(" and second {{OLD}}");
     });

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
@@ -114,7 +114,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "Hello {{name}} world" }],
         expectedResults: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "{{name}}", startIndex: 6, endIndex: 14 },
+          { isMatch: true, content: "{{name}}", streamIndices: [6, 14] },
           { isMatch: false, content: " world" }
         ],
         expectedFlush: ""
@@ -124,7 +124,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{value}} text" }],
         expectedResults: [
-          { isMatch: true, content: "{{value}}", startIndex: 0, endIndex: 9 },
+          { isMatch: true, content: "{{value}}", streamIndices: [0, 9] },
           { isMatch: false, content: " text" }
         ],
         expectedFlush: ""
@@ -135,7 +135,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text {{value}}" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "{{value}}", startIndex: 5, endIndex: 14 }
+          { isMatch: true, content: "{{value}}", streamIndices: [5, 14] }
         ],
         expectedFlush: ""
       },
@@ -144,9 +144,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}} and {{second}}" }],
         expectedResults: [
-          { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
+          { isMatch: true, content: "{{first}}", streamIndices: [0, 9] },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "{{second}}", startIndex: 14, endIndex: 24 }
+          { isMatch: true, content: "{{second}}", streamIndices: [14, 24] }
         ],
         expectedFlush: ""
       },
@@ -156,7 +156,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text {{}} more" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "{{}}", startIndex: 5, endIndex: 9 },
+          { isMatch: true, content: "{{}}", streamIndices: [5, 9] },
           { isMatch: false, content: " more" }
         ],
         expectedFlush: ""
@@ -166,7 +166,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ['<img src="', '" alt="', '">'],
         calls: [{ haystack: '<img src="/photo.jpg" alt="sunset"> text' }],
         expectedResults: [
-          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 },
+          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', streamIndices: [0, 35] },
           { isMatch: false, content: " text" }
         ],
         expectedFlush: ""
@@ -177,7 +177,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text [value] more" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "[value]", startIndex: 5, endIndex: 12 },
+          { isMatch: true, content: "[value]", streamIndices: [5, 12] },
           { isMatch: false, content: " more" }
         ],
         expectedFlush: ""
@@ -187,7 +187,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{this is a very long string with many words}}" }],
         expectedResults: [
-          { isMatch: true, content: "{{this is a very long string with many words}}", startIndex: 0, endIndex: 46 }
+          { isMatch: true, content: "{{this is a very long string with many words}}", streamIndices: [0, 46] }
         ],
         expectedFlush: ""
       },
@@ -196,9 +196,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}}" }, { haystack: " and {{second}}" }],
         expectedResults: [
-          { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
+          { isMatch: true, content: "{{first}}", streamIndices: [0, 9] },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "{{second}}", startIndex: 14, endIndex: 24 }
+          { isMatch: true, content: "{{second}}", streamIndices: [14, 24] }
         ],
         expectedFlush: ""
       }
@@ -241,14 +241,14 @@ describe("AnchorSequenceSearchStrategy", () => {
         name: "start delimiter split across two chunks: '{' + '{name}}'",
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{" }, { haystack: "{name}}" }],
-        expectedResults: [{ isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 }],
+        expectedResults: [{ isMatch: true, content: "{{name}}", streamIndices: [0, 8] }],
         expectedFlush: ""
       },
       {
         name: "end delimiter split across two chunks: '{{name}' + '}'",
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{name}" }, { haystack: "}" }],
-        expectedResults: [{ isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 }],
+        expectedResults: [{ isMatch: true, content: "{{name}}", streamIndices: [0, 8] }],
         expectedFlush: ""
       },
       {
@@ -259,7 +259,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: '" alt="sunset">' }
         ],
         expectedResults: [
-          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', startIndex: 0, endIndex: 35 }
+          { isMatch: true, content: '<img src="/photo.jpg" alt="sunset">', streamIndices: [0, 35] }
         ],
         expectedFlush: ""
       },
@@ -274,7 +274,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: "}" },
           { haystack: "}" }
         ],
-        expectedResults: [{ isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 }],
+        expectedResults: [{ isMatch: true, content: "{{name}}", streamIndices: [0, 8] }],
         expectedFlush: ""
       },
       {
@@ -282,9 +282,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{name}}" }, { haystack: " {{value}}" }],
         expectedResults: [
-          { isMatch: true, content: "{{name}}", startIndex: 0, endIndex: 8 },
+          { isMatch: true, content: "{{name}}", streamIndices: [0, 8] },
           { isMatch: false, content: " " },
-          { isMatch: true, content: "{{value}}", startIndex: 9, endIndex: 18 }
+          { isMatch: true, content: "{{value}}", streamIndices: [9, 18] }
         ],
         expectedFlush: ""
       },
@@ -294,7 +294,7 @@ describe("AnchorSequenceSearchStrategy", () => {
         calls: [{ haystack: "text " }, { haystack: "{{name}}" }],
         expectedResults: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "{{name}}", startIndex: 5, endIndex: 13 }
+          { isMatch: true, content: "{{name}}", streamIndices: [5, 13] }
         ],
         expectedFlush: ""
       },
@@ -306,7 +306,7 @@ describe("AnchorSequenceSearchStrategy", () => {
           { haystack: "IN content E" },
           { haystack: "ND" }
         ],
-        expectedResults: [{ isMatch: true, content: "BEGIN content END", startIndex: 0, endIndex: 17 }],
+        expectedResults: [{ isMatch: true, content: "BEGIN content END", streamIndices: [0, 17] }],
         expectedFlush: ""
       },
       {
@@ -314,9 +314,9 @@ describe("AnchorSequenceSearchStrategy", () => {
         delimiters: ["{{", "}}"],
         calls: [{ haystack: "{{first}} and {{se" }, { haystack: "cond}} end" }],
         expectedResults: [
-          { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
+          { isMatch: true, content: "{{first}}", streamIndices: [0, 9] },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "{{second}}", startIndex: 14, endIndex: 24 },
+          { isMatch: true, content: "{{second}}", streamIndices: [14, 24] },
           { isMatch: false, content: " end" }
         ],
         expectedFlush: ""
@@ -371,7 +371,7 @@ describe("AnchorSequenceSearchStrategy", () => {
 
       expect(results).toEqual([
         { isMatch: false, content: "First " },
-        { isMatch: true, content: "{{OLD}}", startIndex: 6, endIndex: 13 }
+        { isMatch: true, content: "{{OLD}}", streamIndices: [6, 13] }
       ]);
       expect(flushed).toEqual(" and second {{OLD}}");
     });

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
@@ -84,7 +84,7 @@ export class AnchorSequenceSearchStrategy<TState, TMatch = string>
           const endIndex = state.streamOffset + inputLength - haystack.length;
           const startIndex = endIndex - match.length;
           state.buffer = "";
-          yield { isMatch: true, content: match, startIndex, endIndex };
+          yield { isMatch: true, content: match, streamIndices: [startIndex, endIndex] };
         }
       }
     } finally {

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
@@ -46,6 +46,7 @@ export class AnchorSequenceSearchStrategy<TState, TMatch = string>
     haystack: string,
     state: AnchorSequenceSearchState<TState>
   ): Generator<MatchResult, void, undefined> {
+    const inputLength = haystack.length;
     let isMidMatch = state.currentNeedleIndex !== 0;
     try {
       while (haystack) {
@@ -80,14 +81,17 @@ export class AnchorSequenceSearchStrategy<TState, TMatch = string>
         isMidMatch = state.currentNeedleIndex !== 0;
         if (!isMidMatch) {
           const match = state.buffer;
+          const endIndex = state.streamOffset + inputLength - haystack.length;
+          const startIndex = endIndex - match.length;
           state.buffer = "";
-          yield { isMatch: true, content: match };
+          yield { isMatch: true, content: match, startIndex, endIndex };
         }
       }
     } finally {
       if (haystack) {
         state.buffer += haystack;
       }
+      state.streamOffset += inputLength;
     }
   }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
@@ -354,7 +354,7 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       outputs.push(generator.next().value!);
       expect(outputs).toEqual([
         { isMatch: false, content: "Text with " },
-        { isMatch: true, content: "{{ something }}", startIndex: 10, endIndex: 25 }
+        { isMatch: true, content: "{{ something }}", streamIndices: [10, 25] }
       ]);
       generator.return();
       expect(strategy.flush(state)).toBe(" and {{ something more }}");

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
@@ -354,7 +354,7 @@ describe("BufferedIndexOfAnchoredSearchStrategy", () => {
       outputs.push(generator.next().value!);
       expect(outputs).toEqual([
         { isMatch: false, content: "Text with " },
-        { isMatch: true, content: "{{ something }}" }
+        { isMatch: true, content: "{{ something }}", startIndex: 10, endIndex: 25 }
       ]);
       generator.return();
       expect(strategy.flush(state)).toBe(" and {{ something more }}");

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
@@ -112,8 +112,7 @@ export class BufferedIndexOfAnchoredSearchStrategy
           yield {
             isMatch: true,
             content: haystack.slice(matchStartPosition, position),
-            startIndex: baseOffset + matchStartPosition,
-            endIndex: baseOffset + position
+            streamIndices: [baseOffset + matchStartPosition, baseOffset + position]
           };
         }
       }

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
@@ -1,9 +1,6 @@
 import type { MatchResult, SearchStrategy } from "../../types.ts";
 import StringBufferStrategyBase from "../../string-buffer-strategy-base.ts";
 
-/**
- * State object for {@link BufferedIndexOfAnchoredSearchStrategy}.
- */
 export type BufferedIndexOfAnchoredSearchState = {
   /** Buffer holding partial content that may contain incomplete matches spanning chunks */
   buffer: string;

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
@@ -4,6 +4,8 @@ import StringBufferStrategyBase from "../../string-buffer-strategy-base.ts";
 export type BufferedIndexOfAnchoredSearchState = {
   /** Buffer holding partial content that may contain incomplete matches spanning chunks */
   buffer: string;
+  /** Tracks absolute stream offset for position reporting */
+  streamOffset: number;
   /** Index of the current needle being matched in a multi-needle sequence */
   currentNeedleIndex: number;
 };
@@ -72,10 +74,12 @@ export class BufferedIndexOfAnchoredSearchStrategy
     haystack: string,
     state: BufferedIndexOfAnchoredSearchState
   ): Generator<MatchResult, void, undefined> {
+    const bufferLength = state.buffer.length;
+    const baseOffset = state.streamOffset - bufferLength;
     haystack = state.buffer + haystack;
     const length = haystack.length;
     let position = 0;
-    let matchStartPosition;
+    let matchStartPosition = 0;
     try {
       while (position < length) {
         const currentNeedle = this.needles[state.currentNeedleIndex];
@@ -107,13 +111,16 @@ export class BufferedIndexOfAnchoredSearchStrategy
         if (state.currentNeedleIndex === 0) {
           yield {
             isMatch: true,
-            content: haystack.slice(matchStartPosition, position)
+            content: haystack.slice(matchStartPosition, position),
+            startIndex: baseOffset + matchStartPosition,
+            endIndex: baseOffset + position
           };
         }
       }
     } finally {
       const isMidMatch = state.currentNeedleIndex > 0;
       state.buffer = haystack.slice(isMidMatch ? matchStartPosition : position);
+      state.streamOffset += haystack.length - bufferLength;
     }
   }
 }

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
@@ -112,7 +112,10 @@ export class BufferedIndexOfAnchoredSearchStrategy
           yield {
             isMatch: true,
             content: haystack.slice(matchStartPosition, position),
-            streamIndices: [baseOffset + matchStartPosition, baseOffset + position]
+            streamIndices: [
+              baseOffset + matchStartPosition,
+              baseOffset + position
+            ]
           };
         }
       }
@@ -121,5 +124,10 @@ export class BufferedIndexOfAnchoredSearchStrategy
       state.buffer = haystack.slice(isMidMatch ? matchStartPosition : position);
       state.streamOffset += haystack.length - bufferLength;
     }
+  }
+
+  flush(state: BufferedIndexOfAnchoredSearchState): string {
+    state.currentNeedleIndex = 0;
+    return super.flush(state);
   }
 }

--- a/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
@@ -50,7 +50,7 @@ export class BufferedIndexOfCancellableSearchStrategy
         const match = candidate.slice(index, index + this.needle.length);
         candidate = candidate.slice(index + this.needle.length);
         state.buffer = "";
-        yield { isMatch: true, content: match, startIndex, endIndex };
+        yield { isMatch: true, content: match, streamIndices: [startIndex, endIndex] };
       }
     } finally {
       if (candidate) {

--- a/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
@@ -3,6 +3,7 @@ import StringBufferStrategyBase from "../../string-buffer-strategy-base.ts";
 
 export type BufferedIndexOfCancellableSearchState = {
   buffer: string;
+  streamOffset: number;
 };
 
 export class BufferedIndexOfCancellableSearchStrategy
@@ -20,7 +21,11 @@ export class BufferedIndexOfCancellableSearchStrategy
     haystack: string,
     state: BufferedIndexOfCancellableSearchState
   ): Generator<MatchResult, void, undefined> {
+    const inputLength = haystack.length;
+    const bufferLength = state.buffer.length;
+    const baseOffset = state.streamOffset - bufferLength;
     let candidate = state.buffer + haystack;
+    let candidateOffset = 0;
     try {
       while (candidate) {
         const index = candidate.indexOf(this.needle);
@@ -39,15 +44,19 @@ export class BufferedIndexOfCancellableSearchStrategy
           yield { isMatch: false, content: candidate.slice(0, index) };
         }
 
+        const startIndex = baseOffset + candidateOffset + index;
+        const endIndex = startIndex + this.needle.length;
+        candidateOffset += index + this.needle.length;
         const match = candidate.slice(index, index + this.needle.length);
         candidate = candidate.slice(index + this.needle.length);
         state.buffer = "";
-        yield { isMatch: true, content: match };
+        yield { isMatch: true, content: match, startIndex, endIndex };
       }
     } finally {
       if (candidate) {
         state.buffer = candidate;
       }
+      state.streamOffset += inputLength;
     }
   }
 }

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/README.md
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/README.md
@@ -31,7 +31,7 @@ This variant implements the standard `SearchStrategy<TState>` interface:
   state: BufferedIndexOfCanonicalGeneratorState
 ): Generator<MatchResult, void, undefined> {
   yield { isMatch: false, content: "..." };
-  yield { isMatch: true, content: "...", startIndex: #, endIndex: # };
+  yield { isMatch: true, content: "...", streamIndices: [#, #] };
 }
 ```
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/README.md
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/README.md
@@ -31,7 +31,7 @@ This variant implements the standard `SearchStrategy<TState>` interface:
   state: BufferedIndexOfCanonicalGeneratorState
 ): Generator<MatchResult, void, undefined> {
   yield { isMatch: false, content: "..." };
-  yield { isMatch: true, content: "..." };
+  yield { isMatch: true, content: "...", startIndex: #, endIndex: # };
 }
 ```
 

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
@@ -9,14 +9,14 @@ describe("IndexOfKnuthMorrisPratt", () => {
         name: "finds pattern when haystack equals pattern",
         pattern: "OLD",
         chunks: ["OLD"],
-        expected: [{ isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 }]
+        expected: [{ isMatch: true, content: "OLD", streamIndices: [0, 3] }]
       },
       {
         name: "finds pattern at start of chunk",
         pattern: "OLD",
         chunks: ["OLDtext"],
         expected: [
-          { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
+          { isMatch: true, content: "OLD", streamIndices: [0, 3] },
           { isMatch: false, content: "text" }
         ]
       },
@@ -26,7 +26,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["textOLD"],
         expected: [
           { isMatch: false, content: "text" },
-          { isMatch: true, content: "OLD", startIndex: 4, endIndex: 7 }
+          { isMatch: true, content: "OLD", streamIndices: [4, 7] }
         ]
       },
       {
@@ -35,7 +35,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello OLD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " world" }
         ]
       },
@@ -45,9 +45,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Replace OLD and OLD content"],
         expected: [
           { isMatch: false, content: "Replace " },
-          { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 },
+          { isMatch: true, content: "OLD", streamIndices: [8, 11] },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "OLD", startIndex: 16, endIndex: 19 },
+          { isMatch: true, content: "OLD", streamIndices: [16, 19] },
           { isMatch: false, content: " content" }
         ]
       },
@@ -56,8 +56,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["OLDOLD"],
         expected: [
-          { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
-          { isMatch: true, content: "OLD", startIndex: 3, endIndex: 6 }
+          { isMatch: true, content: "OLD", streamIndices: [0, 3] },
+          { isMatch: true, content: "OLD", streamIndices: [3, 6] }
         ]
       },
       {
@@ -66,7 +66,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["test X test"],
         expected: [
           { isMatch: false, content: "test " },
-          { isMatch: true, content: "X", startIndex: 5, endIndex: 6 },
+          { isMatch: true, content: "X", streamIndices: [5, 6] },
           { isMatch: false, content: " test" }
         ]
       },
@@ -76,7 +76,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: "THE COMPLEX PATTERN", startIndex: 5, endIndex: 24 },
+          { isMatch: true, content: "THE COMPLEX PATTERN", streamIndices: [5, 24] },
           { isMatch: false, content: " here" }
         ]
       }
@@ -157,7 +157,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello O", "LD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " world" }
         ]
       },
@@ -167,7 +167,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello ", "OLD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " world" }
         ]
       },
@@ -177,7 +177,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello O", "LD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " world" }
         ]
       },
@@ -187,7 +187,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello OL", "D world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " world" }
         ]
       },
@@ -197,7 +197,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Find PAT", "TER", "N here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: "PATTERN", startIndex: 5, endIndex: 12 },
+          { isMatch: true, content: "PATTERN", streamIndices: [5, 12] },
           { isMatch: false, content: " here" }
         ]
       },
@@ -207,7 +207,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello ", "O", "L", "D", " world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " world" }
         ]
       },
@@ -217,7 +217,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["text O", "LD more"],
         expected: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 },
+          { isMatch: true, content: "OLD", streamIndices: [5, 8] },
           { isMatch: false, content: " more" }
         ]
       },
@@ -227,7 +227,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["OL OL", "D"],
         expected: [
           { isMatch: false, content: "OL " },
-          { isMatch: true, content: "OLD", startIndex: 3, endIndex: 6 }
+          { isMatch: true, content: "OLD", streamIndices: [3, 6] }
         ]
       },
       {
@@ -236,7 +236,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["OLOL", "D"],
         expected: [
           { isMatch: false, content: "OL" },
-          { isMatch: true, content: "OLD", startIndex: 2, endIndex: 5 }
+          { isMatch: true, content: "OLD", streamIndices: [2, 5] }
         ]
       }
     ];
@@ -328,9 +328,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["First OLD", " and second OLD"],
         expected: [
           { isMatch: false, content: "First " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " and second " },
-          { isMatch: true, content: "OLD", startIndex: 21, endIndex: 24 }
+          { isMatch: true, content: "OLD", streamIndices: [21, 24] }
         ]
       },
       {
@@ -339,8 +339,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["First OLD", "OLD second"],
         expected: [
           { isMatch: false, content: "First " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
-          { isMatch: true, content: "OLD", startIndex: 9, endIndex: 12 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
+          { isMatch: true, content: "OLD", streamIndices: [9, 12] },
           { isMatch: false, content: " second" }
         ]
       },
@@ -350,9 +350,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["First O", "LD and OLD"],
         expected: [
           { isMatch: false, content: "First " },
-          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", streamIndices: [6, 9] },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "OLD", startIndex: 14, endIndex: 17 }
+          { isMatch: true, content: "OLD", streamIndices: [14, 17] }
         ]
       }
     ];
@@ -391,7 +391,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
 
       expect(results).toEqual([
         { isMatch: false, content: "First " },
-        { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 }
+        { isMatch: true, content: "OLD", streamIndices: [6, 9] }
       ]);
       expect(flushed).toBe(" and second OLD");
     });

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
@@ -9,14 +9,14 @@ describe("IndexOfKnuthMorrisPratt", () => {
         name: "finds pattern when haystack equals pattern",
         pattern: "OLD",
         chunks: ["OLD"],
-        expected: [{ isMatch: true, content: "OLD" }]
+        expected: [{ isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 }]
       },
       {
         name: "finds pattern at start of chunk",
         pattern: "OLD",
         chunks: ["OLDtext"],
         expected: [
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
           { isMatch: false, content: "text" }
         ]
       },
@@ -26,7 +26,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["textOLD"],
         expected: [
           { isMatch: false, content: "text" },
-          { isMatch: true, content: "OLD" }
+          { isMatch: true, content: "OLD", startIndex: 4, endIndex: 7 }
         ]
       },
       {
@@ -35,7 +35,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello OLD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " world" }
         ]
       },
@@ -45,9 +45,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Replace OLD and OLD content"],
         expected: [
           { isMatch: false, content: "Replace " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 8, endIndex: 11 },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 16, endIndex: 19 },
           { isMatch: false, content: " content" }
         ]
       },
@@ -56,8 +56,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         pattern: "OLD",
         chunks: ["OLDOLD"],
         expected: [
-          { isMatch: true, content: "OLD" },
-          { isMatch: true, content: "OLD" }
+          { isMatch: true, content: "OLD", startIndex: 0, endIndex: 3 },
+          { isMatch: true, content: "OLD", startIndex: 3, endIndex: 6 }
         ]
       },
       {
@@ -66,7 +66,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["test X test"],
         expected: [
           { isMatch: false, content: "test " },
-          { isMatch: true, content: "X" },
+          { isMatch: true, content: "X", startIndex: 5, endIndex: 6 },
           { isMatch: false, content: " test" }
         ]
       },
@@ -76,7 +76,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: "THE COMPLEX PATTERN" },
+          { isMatch: true, content: "THE COMPLEX PATTERN", startIndex: 5, endIndex: 24 },
           { isMatch: false, content: " here" }
         ]
       }
@@ -157,7 +157,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello O", "LD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " world" }
         ]
       },
@@ -167,7 +167,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello ", "OLD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " world" }
         ]
       },
@@ -177,7 +177,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello O", "LD world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " world" }
         ]
       },
@@ -187,7 +187,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello OL", "D world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " world" }
         ]
       },
@@ -197,7 +197,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Find PAT", "TER", "N here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: "PATTERN" },
+          { isMatch: true, content: "PATTERN", startIndex: 5, endIndex: 12 },
           { isMatch: false, content: " here" }
         ]
       },
@@ -207,7 +207,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["Hello ", "O", "L", "D", " world"],
         expected: [
           { isMatch: false, content: "Hello " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " world" }
         ]
       },
@@ -217,7 +217,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["text O", "LD more"],
         expected: [
           { isMatch: false, content: "text " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 5, endIndex: 8 },
           { isMatch: false, content: " more" }
         ]
       },
@@ -227,7 +227,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["OL OL", "D"],
         expected: [
           { isMatch: false, content: "OL " },
-          { isMatch: true, content: "OLD" }
+          { isMatch: true, content: "OLD", startIndex: 3, endIndex: 6 }
         ]
       },
       {
@@ -236,7 +236,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["OLOL", "D"],
         expected: [
           { isMatch: false, content: "OL" },
-          { isMatch: true, content: "OLD" }
+          { isMatch: true, content: "OLD", startIndex: 2, endIndex: 5 }
         ]
       }
     ];
@@ -328,9 +328,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["First OLD", " and second OLD"],
         expected: [
           { isMatch: false, content: "First " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " and second " },
-          { isMatch: true, content: "OLD" }
+          { isMatch: true, content: "OLD", startIndex: 21, endIndex: 24 }
         ]
       },
       {
@@ -339,8 +339,8 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["First OLD", "OLD second"],
         expected: [
           { isMatch: false, content: "First " },
-          { isMatch: true, content: "OLD" },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
+          { isMatch: true, content: "OLD", startIndex: 9, endIndex: 12 },
           { isMatch: false, content: " second" }
         ]
       },
@@ -350,9 +350,9 @@ describe("IndexOfKnuthMorrisPratt", () => {
         chunks: ["First O", "LD and OLD"],
         expected: [
           { isMatch: false, content: "First " },
-          { isMatch: true, content: "OLD" },
+          { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: "OLD" }
+          { isMatch: true, content: "OLD", startIndex: 14, endIndex: 17 }
         ]
       }
     ];
@@ -391,7 +391,7 @@ describe("IndexOfKnuthMorrisPratt", () => {
 
       expect(results).toEqual([
         { isMatch: false, content: "First " },
-        { isMatch: true, content: "OLD" }
+        { isMatch: true, content: "OLD", startIndex: 6, endIndex: 9 }
       ]);
       expect(flushed).toBe(" and second OLD");
     });

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
@@ -102,4 +102,9 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
       state.streamOffset += inputLength;
     }
   }
+
+  flush(state: IndexOfKnuthMorrisPrattSearchState): string {
+    state.needleIndex = 0;
+    return super.flush(state);
+  }
 }

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
@@ -1,10 +1,11 @@
 import type { SearchStrategy, MatchResult } from "../../types.ts";
 import KMP from "./knuth-morris-pratt.ts";
-import StringBufferStrategyBase from "../../string-buffer-strategy-base.ts";
+import StringBufferStrategyBase, {
+  type StringBufferState
+} from "../../string-buffer-strategy-base.ts";
 
-export interface IndexOfKnuthMorrisPrattSearchState {
+export interface IndexOfKnuthMorrisPrattSearchState extends StringBufferState {
   needleIndex: number;
-  buffer: string;
 }
 
 export class IndexOfKnuthMorrisPrattSearchStrategy
@@ -28,8 +29,12 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
     haystack: string,
     state: IndexOfKnuthMorrisPrattSearchState
   ): Generator<MatchResult, void, undefined> {
+    const inputLength = haystack.length;
+    let absoluteCursor = state.streamOffset;
     try {
       if (state.needleIndex) {
+        const bufferLength = state.buffer.length;
+        const matchStart = absoluteCursor - bufferLength;
         const needlePossibleWithinHaystack = this.needle.slice(
           state.needleIndex,
           state.needleIndex + haystack.length
@@ -38,15 +43,22 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
         if (needlePossibleWithinHaystack === haystack.slice(0, length)) {
           state.buffer += haystack.slice(0, length);
           haystack = haystack.slice(length);
+          absoluteCursor += length;
           state.needleIndex = (state.needleIndex + length) % this.needle.length;
 
           if (state.needleIndex === 0) {
             const match = state.buffer;
             state.buffer = "";
-            yield { isMatch: true, content: match };
+            yield {
+              isMatch: true,
+              content: match,
+              startIndex: matchStart,
+              endIndex: matchStart + this.needle.length
+            };
           }
         } else {
           haystack = state.buffer + haystack;
+          absoluteCursor -= bufferLength;
         }
       }
 
@@ -73,17 +85,23 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
           yield { isMatch: false, content: nonMatch };
         }
 
+        const startIndex = absoluteCursor + matchPos;
+        const endIndex = startIndex + this.needle.length;
+        absoluteCursor += matchPos + this.needle.length;
         haystack = haystack.slice(matchPos + this.needle.length);
         state.buffer = "";
         yield {
           isMatch: true,
-          content: this.needle
+          content: this.needle,
+          startIndex,
+          endIndex
         };
       }
     } finally {
       if (haystack) {
         state.buffer += haystack;
       }
+      state.streamOffset += inputLength;
     }
   }
 }

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
@@ -52,8 +52,7 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
             yield {
               isMatch: true,
               content: match,
-              startIndex: matchStart,
-              endIndex: matchStart + this.needle.length
+              streamIndices: [matchStart, matchStart + this.needle.length]
             };
           }
         } else {
@@ -93,8 +92,7 @@ export class IndexOfKnuthMorrisPrattSearchStrategy
         yield {
           isMatch: true,
           content: this.needle,
-          startIndex,
-          endIndex
+          streamIndices: [startIndex, endIndex]
         };
       }
     } finally {

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
@@ -103,4 +103,9 @@ export class LoopedIndexOfCancellableSearchStrategy
       state.streamOffset += inputLength;
     }
   }
+
+  flush(state: LoopedIndexOfCancellableSearchState): string {
+    state.needleIndex = 0;
+    return super.flush(state);
+  }
 }

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
@@ -1,8 +1,9 @@
 import type { SearchStrategy, MatchResult } from "../../types.ts";
-import StringBufferStrategyBase from "../../string-buffer-strategy-base.ts";
-export interface LoopedIndexOfCancellableSearchState {
+import StringBufferStrategyBase, {
+  type StringBufferState
+} from "../../string-buffer-strategy-base.ts";
+export interface LoopedIndexOfCancellableSearchState extends StringBufferState {
   needleIndex: number;
-  buffer: string;
 }
 
 export class LoopedIndexOfCancellableSearchStrategy
@@ -24,8 +25,12 @@ export class LoopedIndexOfCancellableSearchStrategy
     haystack: string,
     state: LoopedIndexOfCancellableSearchState
   ): Generator<MatchResult, void, undefined> {
+    const inputLength = haystack.length;
+    let absoluteCursor = state.streamOffset;
     try {
       if (state.needleIndex) {
+        const bufferLength = state.buffer.length;
+        const matchStart = absoluteCursor - bufferLength;
         const needlePossibleWithinHaystack = this.needle.slice(
           state.needleIndex,
           state.needleIndex + haystack.length
@@ -34,15 +39,22 @@ export class LoopedIndexOfCancellableSearchStrategy
         if (needlePossibleWithinHaystack === haystack.slice(0, length)) {
           state.buffer += haystack.slice(0, length);
           haystack = haystack.slice(length);
+          absoluteCursor += length;
           state.needleIndex = (state.needleIndex + length) % this.needle.length;
 
           if (state.needleIndex === 0) {
             const match = state.buffer;
             state.buffer = "";
-            yield { isMatch: true, content: match };
+            yield {
+              isMatch: true,
+              content: match,
+              startIndex: matchStart,
+              endIndex: matchStart + this.needle.length
+            };
           }
         } else {
           haystack = state.buffer + haystack;
+          absoluteCursor -= bufferLength;
         }
       }
 
@@ -74,17 +86,23 @@ export class LoopedIndexOfCancellableSearchStrategy
         }
 
         yield { isMatch: false, content: haystack.slice(0, matchPos) };
+        const startIndex = absoluteCursor + matchPos;
+        const endIndex = startIndex + this.needle.length;
+        absoluteCursor += matchPos + this.needle.length;
         haystack = haystack.slice(matchPos + this.needle.length);
         state.buffer = "";
         yield {
           isMatch: true,
-          content: this.needle
+          content: this.needle,
+          startIndex,
+          endIndex
         };
       }
     } finally {
       if (haystack) {
         state.buffer = haystack;
       }
+      state.streamOffset += inputLength;
     }
   }
 }

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
@@ -48,8 +48,7 @@ export class LoopedIndexOfCancellableSearchStrategy
             yield {
               isMatch: true,
               content: match,
-              startIndex: matchStart,
-              endIndex: matchStart + this.needle.length
+              streamIndices: [matchStart, matchStart + this.needle.length]
             };
           }
         } else {
@@ -94,8 +93,7 @@ export class LoopedIndexOfCancellableSearchStrategy
         yield {
           isMatch: true,
           content: this.needle,
-          startIndex,
-          endIndex
+          streamIndices: [startIndex, endIndex]
         };
       }
     } finally {

--- a/src/search-strategies/index.ts
+++ b/src/search-strategies/index.ts
@@ -1,5 +1,4 @@
 export {
-  LoopedIndexOfAnchoredSearchStrategy as StringAnchorSearchStrategy,
-  type StringAnchorSearchState
+  LoopedIndexOfAnchoredSearchStrategy as StringAnchorSearchStrategy
 } from "./looped-indexOf-anchored/index.ts";
 export * from "./regex/index.ts";

--- a/src/search-strategies/looped-indexOf-anchored/README.md
+++ b/src/search-strategies/looped-indexOf-anchored/README.md
@@ -201,7 +201,7 @@ type LoopedIndexOfAnchoredSearchState = {
 ### Two-Token Pattern (Opening/Closing Delimiters)
 
 ```typescript
-import { LoopedIndexOfAnchoredSearchStrategy } from "replace-content-transformer";
+import { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
 
 const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
 ```

--- a/src/search-strategies/looped-indexOf-anchored/README.md
+++ b/src/search-strategies/looped-indexOf-anchored/README.md
@@ -201,8 +201,6 @@ type LoopedIndexOfAnchoredSearchState = {
 ### Two-Token Pattern (Opening/Closing Delimiters)
 
 ```typescript
-import { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
-
 const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
 ```
 

--- a/src/search-strategies/looped-indexOf-anchored/index.ts
+++ b/src/search-strategies/looped-indexOf-anchored/index.ts
@@ -1,2 +1,1 @@
 export { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
-export type { StringBufferState as StringAnchorSearchState } from "../string-buffer-strategy-base.ts";

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
@@ -11,7 +11,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{" },
+      { isMatch: true, content: "{{", startIndex: 7, endIndex: 9 },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -26,7 +26,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{name}}" },
+      { isMatch: true, content: "{{name}}", startIndex: 7, endIndex: 15 },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -44,7 +44,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{name}}" },
+      { isMatch: true, content: "{{name}}", startIndex: 7, endIndex: 15 },
       { isMatch: false, content: "" }
     ]);
   });
@@ -61,7 +61,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{name}}" },
+      { isMatch: true, content: "{{name}}", startIndex: 7, endIndex: 15 },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -109,7 +109,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     // Complete the match
     const results2 = [...strategy.processChunk("{name}}", state)];
-    expect(results2).toEqual([{ isMatch: true, content: "{{name}}" }]);
+    expect(results2).toEqual([{ isMatch: true, content: "{{name}}", startIndex: 15, endIndex: 23 }]);
   });
 
   it("should handle false starts", () => {
@@ -125,7 +125,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     expect(results).toEqual([
       { isMatch: false, content: "text " },
       { isMatch: false, content: "{x " },
-      { isMatch: true, content: "{{match}}" },
+      { isMatch: true, content: "{{match}}", startIndex: 8, endIndex: 17 },
       { isMatch: false, content: "" }
     ]);
   });
@@ -140,9 +140,9 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     ];
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{first}}" },
-      { isMatch: true, content: "{{second}}" },
-      { isMatch: true, content: "{{third}}" },
+      { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
+      { isMatch: true, content: "{{second}}", startIndex: 9, endIndex: 19 },
+      { isMatch: true, content: "{{third}}", startIndex: 19, endIndex: 28 },
       { isMatch: false, content: "" }
     ]);
   });
@@ -163,7 +163,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "<{{name}}>" },
+      { isMatch: true, content: "<{{name}}>", startIndex: 7, endIndex: 17 },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -388,6 +388,67 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
       // Should buffer "{{{"
       expect(strategy.flush(state)).toBe("{{{");
+    });
+  });
+
+  describe("stream offset tracking", () => {
+    it("should track correct indices across chunk boundaries", () => {
+      const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
+      const state = strategy.createState();
+
+      const results1 = [...strategy.processChunk("prefix {", state)];
+      const results2 = [...strategy.processChunk("{content}}", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 7,
+        endIndex: 18
+      });
+    });
+
+    it("should track indices across multiple chunks with no matches initially", () => {
+      const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
+      const state = strategy.createState();
+
+      const results1 = [...strategy.processChunk("chunk1 no matches ", state)];
+      const results2 = [...strategy.processChunk("chunk2 {{match}} end", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 25,
+        endIndex: 34
+      });
+    });
+
+    it("should reset offset on createState", () => {
+      const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
+ 
+      const state1 = strategy.createState();
+      const [match1] = [...strategy.processChunk("{{m1}}", state1)];
+      expect(match1).toMatchObject({ startIndex: 0, endIndex: 6 });
+
+      const state2 = strategy.createState();
+      const [match2] = [...strategy.processChunk("{{m2}}", state2)];
+      expect(match2).toMatchObject({ startIndex: 0, endIndex: 6 });
+    });
+
+    it("should handle indices correctly with buffered partial matches", () => {
+      const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
+      const state = strategy.createState();
+
+      // First chunk ends with partial match
+      const results1 = [...strategy.processChunk("text {", state)];
+      // Second chunk completes and continues
+      const results2 = [...strategy.processChunk("{done}} after", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 5,
+        endIndex: 13
+      });
     });
   });
 });

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
@@ -11,7 +11,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{", startIndex: 7, endIndex: 9 },
+      { isMatch: true, content: "{{", streamIndices: [7, 9] },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -26,7 +26,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{name}}", startIndex: 7, endIndex: 15 },
+      { isMatch: true, content: "{{name}}", streamIndices: [7, 15] },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -44,7 +44,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{name}}", startIndex: 7, endIndex: 15 },
+      { isMatch: true, content: "{{name}}", streamIndices: [7, 15] },
       { isMatch: false, content: "" }
     ]);
   });
@@ -61,7 +61,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "{{name}}", startIndex: 7, endIndex: 15 },
+      { isMatch: true, content: "{{name}}", streamIndices: [7, 15] },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -109,7 +109,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     // Complete the match
     const results2 = [...strategy.processChunk("{name}}", state)];
-    expect(results2).toEqual([{ isMatch: true, content: "{{name}}", startIndex: 15, endIndex: 23 }]);
+    expect(results2).toEqual([{ isMatch: true, content: "{{name}}", streamIndices: [15, 23] }]);
   });
 
   it("should handle false starts", () => {
@@ -125,7 +125,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     expect(results).toEqual([
       { isMatch: false, content: "text " },
       { isMatch: false, content: "{x " },
-      { isMatch: true, content: "{{match}}", startIndex: 8, endIndex: 17 },
+      { isMatch: true, content: "{{match}}", streamIndices: [8, 17] },
       { isMatch: false, content: "" }
     ]);
   });
@@ -140,9 +140,9 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
     ];
 
     expect(results).toEqual([
-      { isMatch: true, content: "{{first}}", startIndex: 0, endIndex: 9 },
-      { isMatch: true, content: "{{second}}", startIndex: 9, endIndex: 19 },
-      { isMatch: true, content: "{{third}}", startIndex: 19, endIndex: 28 },
+      { isMatch: true, content: "{{first}}", streamIndices: [0, 9] },
+      { isMatch: true, content: "{{second}}", streamIndices: [9, 19] },
+      { isMatch: true, content: "{{third}}", streamIndices: [19, 28] },
       { isMatch: false, content: "" }
     ]);
   });
@@ -163,7 +163,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
     expect(results).toEqual([
       { isMatch: false, content: "before " },
-      { isMatch: true, content: "<{{name}}>", startIndex: 7, endIndex: 17 },
+      { isMatch: true, content: "<{{name}}>", streamIndices: [7, 17] },
       { isMatch: false, content: " after" }
     ]);
     expect(flushed).toBe("");
@@ -402,8 +402,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 7,
-        endIndex: 18
+        streamIndices: [7, 18]
       });
     });
 
@@ -417,8 +416,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 25,
-        endIndex: 34
+        streamIndices: [25, 34]
       });
     });
 
@@ -427,11 +425,11 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
  
       const state1 = strategy.createState();
       const [match1] = [...strategy.processChunk("{{m1}}", state1)];
-      expect(match1).toMatchObject({ startIndex: 0, endIndex: 6 });
+      expect(match1).toMatchObject({ streamIndices: [0, 6] });
 
       const state2 = strategy.createState();
       const [match2] = [...strategy.processChunk("{{m2}}", state2)];
-      expect(match2).toMatchObject({ startIndex: 0, endIndex: 6 });
+      expect(match2).toMatchObject({ streamIndices: [0, 6] });
     });
 
     it("should handle indices correctly with buffered partial matches", () => {
@@ -446,8 +444,7 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 5,
-        endIndex: 13
+        streamIndices: [5, 13]
       });
     });
   });

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
@@ -432,6 +432,23 @@ describe("LoopedIndexOfAnchoredSearchStrategy", () => {
       expect(match2).toMatchObject({ streamIndices: [0, 6] });
     });
 
+    it("should reset streamOffset on flush for state reuse", () => {
+      const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
+      const state = strategy.createState();
+
+      // Stream 1
+      const results1 = [...strategy.processChunk("text {{m1}}", state)];
+      strategy.flush(state);
+      const match1 = results1.find((r) => r.isMatch);
+      expect(match1).toMatchObject({ streamIndices: [5, 11] });
+
+      // Stream 2: reuse state after flush — indices should start from 0 again
+      const results2 = [...strategy.processChunk("text {{m2}}", state)];
+      strategy.flush(state);
+      const match2 = results2.find((r) => r.isMatch);
+      expect(match2).toMatchObject({ streamIndices: [5, 11] });
+    });
+
     it("should handle indices correctly with buffered partial matches", () => {
       const strategy = new LoopedIndexOfAnchoredSearchStrategy(["{{", "}}"]);
       const state = strategy.createState();

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
@@ -49,6 +49,7 @@ export class LoopedIndexOfAnchoredSearchStrategy
     haystack: string,
     state: LoopedIndexOfAnchoredSearchState
   ): Generator<MatchResult, void, undefined> {
+    const bufferLength = state.buffer.length;
     haystack = state.buffer + haystack;
     const length = haystack.length;
     let position = 0;
@@ -70,7 +71,10 @@ export class LoopedIndexOfAnchoredSearchStrategy
                 const beforePartial = haystack.slice(position, -partialLength);
                 position = length - partialLength;
                 if (beforePartial) {
-                  yield { isMatch: false, content: beforePartial };
+                  yield {
+                    isMatch: false,
+                    content: beforePartial
+                  };
                 }
                 return;
               }
@@ -96,15 +100,21 @@ export class LoopedIndexOfAnchoredSearchStrategy
         state.currentNeedleIndex =
           (state.currentNeedleIndex + 1) % this.needles.length;
         if (state.currentNeedleIndex === 0) {
+          const content = haystack.slice(matchStartPosition, position);
+          const startIndex = state.streamOffset + ((matchStartPosition ?? 0) - bufferLength);
+          const endIndex = startIndex + content.length;
           yield {
             isMatch: true,
-            content: haystack.slice(matchStartPosition, position)
+            content,
+            startIndex,
+            endIndex
           };
         }
       }
     } finally {
       const isMidMatch = state.currentNeedleIndex > 0;
       state.buffer = haystack.slice(isMidMatch ? matchStartPosition : position);
+      state.streamOffset += haystack.length - bufferLength;
     }
   }
 

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
@@ -106,8 +106,7 @@ export class LoopedIndexOfAnchoredSearchStrategy
           yield {
             isMatch: true,
             content,
-            startIndex,
-            endIndex
+            streamIndices: [startIndex, endIndex]
           };
         }
       }

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
@@ -3,10 +3,7 @@ import StringBufferStrategyBase, {
   type StringBufferState
 } from "../string-buffer-strategy-base.ts";
 
-/**
- * State object for {@link LoopedIndexOfAnchoredSearchStrategy}.
- */
-type LoopedIndexOfAnchoredSearchState = StringBufferState & {
+export type LoopedIndexOfAnchoredSearchState = StringBufferState & {
   /** Index of the current needle being matched in a multi-needle sequence */
   currentNeedleIndex: number;
 };
@@ -15,9 +12,11 @@ type LoopedIndexOfAnchoredSearchState = StringBufferState & {
  * A high-performance search strategy for finding sequential string patterns (anchor sequences)
  * using smart partial matching to avoid unnecessary buffering.
  *
- * Similar to {@link BufferedIndexOfAnchoredSearchStrategy} but uses intelligent partial matching
- * at chunk boundaries - only buffering when there's actually a potential partial match, rather
- * than blindly buffering the maximum possible partial match length.
+ * Similar to the buffered indexOf anchored strategy
+ * (https://github.com/TomStrepsil/replace-content-transformer/blob/64c8d74ea8651401375bf01c00372fcdf2dbfcbb/src/search-strategies/benchmarking/buffered-indexOf-anchored/README.md)
+ * but uses intelligent partial matching at chunk boundaries - only buffering when there's 
+ * actually a potential partial match, rather than blindly buffering the maximum possible 
+ * partial match length.
  *
  * This strategy efficiently searches for sequences of strings that must appear in order,
  * separated by any content. For example, `['{{', 'name', '}}']` matches `{{name}}` or

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
@@ -49,10 +49,11 @@ export class LoopedIndexOfAnchoredSearchStrategy
     state: LoopedIndexOfAnchoredSearchState
   ): Generator<MatchResult, void, undefined> {
     const bufferLength = state.buffer.length;
+    const baseOffset = state.streamOffset - bufferLength;
     haystack = state.buffer + haystack;
     const length = haystack.length;
     let position = 0;
-    let matchStartPosition;
+    let matchStartPosition = 0;
     try {
       while (position < length) {
         const currentNeedle = this.needles[state.currentNeedleIndex];
@@ -100,8 +101,8 @@ export class LoopedIndexOfAnchoredSearchStrategy
           (state.currentNeedleIndex + 1) % this.needles.length;
         if (state.currentNeedleIndex === 0) {
           const content = haystack.slice(matchStartPosition, position);
-          const startIndex = state.streamOffset + ((matchStartPosition ?? 0) - bufferLength);
-          const endIndex = startIndex + content.length;
+          const startIndex = baseOffset + matchStartPosition;
+          const endIndex = baseOffset + position;
           yield {
             isMatch: true,
             content,

--- a/src/search-strategies/regex/README.md
+++ b/src/search-strategies/regex/README.md
@@ -166,7 +166,7 @@ type RegexSearchState = {
 
 ## Limitations
 
-Due to the streaming nature of the algorithm, or due to the implementation of `regex-partial-match`, certain regex features are problematic:
+Due to the streaming nature of the algorithm, or due to the implementation of [`regex-partial-match`](https://github.com/TomStrepsil/regex-partial-match), certain regex features are problematic:
 
 ### ❌ Backreferences
 

--- a/src/search-strategies/regex/README.md
+++ b/src/search-strategies/regex/README.md
@@ -18,7 +18,7 @@ To enable optimistic/early yielding, certain regular expression features are uns
 > The strategy yields an object containing `{ content: RegExpExecArray }` for matches (rather than `{ content: string }`), where the `RegExpExecArray` is the result of calling `RegExp.prototype.exec`. This provides access to capture groups via `match.content[1]`, `match.content[2]`, etc., and named groups via `match.content.groups`. The array also includes [`index`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#index) and [`input`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#input) properties, which make little sense in a streaming scenario and should be disregarded.
 
 > [!NOTE]
-> Where the `d` flag is provided, indices are mapped to be offsets into the stream as a whole.  The indices on the match will duplicate the `startIndex` and `endIndex` arguments passed to the replacement function.  However, the `groups` property on indices is also updated, which may prove more useful.
+> Where the `d` flag is provided, indices are mapped to be offsets into the stream as a whole.  The indices on the match will duplicate the `streamIndices` passed to the replacement function.  However, the `groups` property on indices is also updated, which may prove more useful.
 
 ## How It Works
 

--- a/src/search-strategies/regex/README.md
+++ b/src/search-strategies/regex/README.md
@@ -15,7 +15,10 @@ This has been chosen for simplicity and performance, with libraries such as [`in
 To enable optimistic/early yielding, certain regular expression features are unsupported. e.g. [lookbehinds](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion), negative [lookaheads](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) and [backreferences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Backreference). See [Limitations](#limitations) for full explanation.
 
 > [!WARNING]
-> The strategy yields `{ isMatch: true, content: RegExpExecArray }` for matches (rather than `{ isMatch: true, content: string }`), where the `RegExpExecArray` is the result of calling `RegExp.prototype.exec`. This provides access to capture groups via `match.content[1]`, `match.content[2]`, etc., and named groups via `match.content.groups`. The array also includes [`index`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#index) and [`input`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#input) properties, which make little sense in a streaming scenario and should be disregarded.
+> The strategy yields an object containing `{ content: RegExpExecArray }` for matches (rather than `{ content: string }`), where the `RegExpExecArray` is the result of calling `RegExp.prototype.exec`. This provides access to capture groups via `match.content[1]`, `match.content[2]`, etc., and named groups via `match.content.groups`. The array also includes [`index`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#index) and [`input`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#input) properties, which make little sense in a streaming scenario and should be disregarded.
+
+> [!NOTE]
+> Where the `d` flag is provided, indices are mapped to be offsets into the stream as a whole.  These align with the `startIndex` and `endIndex` properties of the returned match.
 
 ## How It Works
 
@@ -200,14 +203,6 @@ Problem: A chunk ending "foo" would naively match.
 
 Knowing when to buffer requires understanding if the part of the regular expression next to match is a lookahead. To implement would require a non-native regular expression state machine, or otherwise.
 
-### ❌ Indices
-
-```js
-/foo/d;
-```
-
-Stream-based indices would require recording total characters received in the stream, and code to handle conversion from the within-chunk indices, not currently supported.
-
 ### ⚠️ Surrogate pairs separated by chunks
 
 ```js
@@ -262,18 +257,21 @@ Quantifier will be satisfied eagerly, thus multiple matches will occur. e.g. chu
 - 👀 [Lookahead assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) (positive only): `/foo(?=bar)/`
 - 🔢 [Quantifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet#quantifiers): `/a{2,4}/`, `/b*?/`, `/c+/` (with caveats above for potential split matching, etc.)
 - 📋 [Character classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class): `/[a-z]/`
-- 🔣 [Character escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape) (`\n`, `\t`, `\x61`, `\u0061`, `\u{1F600}`)
+- 🔣 [Character escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape): (`\n`, `\t`, `\x61`, `\u0061`, `\u{1F600}`)
 - 🧩 [Character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape): `/\w+/`, `/\d{3}/`
 - 🌐 [Unicode character class escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape): `/\p{Script_Extensions=Latin}+/gu`
-- 🧮 [Unicode sets (`v` flag)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets) (`/[\p{Lowercase}&&\p{Script=Greek}]/v`)
+- 🧮 [Unicode sets (`v` flag)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets): (`/[\p{Lowercase}&&\p{Script=Greek}]/v`)
 - 🔀 [Disjunctions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction): `/cat|dog/`
 - 👥 [Non-capturing groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group): `/(?:hello)+/`
 - 👪 Capturing groups (🫥 [unnamed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group) and 📛 [named](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group)): `/(hello|hi) there (?<name>.+?)/`
 - 三 [Multiline](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline): `/^.+?$/ms`
 - 🚧 Boundary assertions (⚓ [input](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion), 🆒 [word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion)): `/\b.+?\b/`, `/^t/m`
+- 🗂️ [Indices](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Groups_and_backreferences#using_groups_and_match_indices)[^2]: `/foo/d`
 
 ## Credits
 
 See [credits](https://github.com/TomStrepsil/regex-partial-match/blob/main/README.md#credits) for `regex-partial-match`.
 
 [^1]: After significant performance degradation was observed when attempting [knuth-morris-pratt](https://en.wikipedia.org/wiki/Knuth%E2%80%93Morris%E2%80%93Pratt_algorithm) for static string partial matching, the project has prioritised innate matching capabilities of the language.
+
+[^2]: See note within [algorithm overview](#algorithm-overview) regarding indices mapping.

--- a/src/search-strategies/regex/README.md
+++ b/src/search-strategies/regex/README.md
@@ -18,7 +18,7 @@ To enable optimistic/early yielding, certain regular expression features are uns
 > The strategy yields an object containing `{ content: RegExpExecArray }` for matches (rather than `{ content: string }`), where the `RegExpExecArray` is the result of calling `RegExp.prototype.exec`. This provides access to capture groups via `match.content[1]`, `match.content[2]`, etc., and named groups via `match.content.groups`. The array also includes [`index`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#index) and [`input`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#input) properties, which make little sense in a streaming scenario and should be disregarded.
 
 > [!NOTE]
-> Where the `d` flag is provided, indices are mapped to be offsets into the stream as a whole.  These align with the `startIndex` and `endIndex` properties of the returned match.
+> Where the `d` flag is provided, indices are mapped to be offsets into the stream as a whole.  The indices on the match will duplicate the `startIndex` and `endIndex` arguments passed to the replacement function.  However, the `groups` property on indices is also updated, which may prove more useful.
 
 ## How It Works
 

--- a/src/search-strategies/regex/input-validation.test.ts
+++ b/src/search-strategies/regex/input-validation.test.ts
@@ -19,12 +19,6 @@ describe("input validation", () => {
     );
   });
 
-  it("should not allow indices flag to be set", () => {
-    expect(() => inputValidation(/test/d)).toThrow(
-      "expressions with 'd' (indices) flag are not supported"
-    );
-  });
-
   it("should not allow backreferences to be used", () => {
     expect(() => inputValidation(/(.)\1/)).toThrow(
       "backreferences are not supported"

--- a/src/search-strategies/regex/input-validation.ts
+++ b/src/search-strategies/regex/input-validation.ts
@@ -8,9 +8,6 @@ const inputValidation = (needle: RegExp) => {
   if (needle.source.match(/\\[\dk]/)) {
     throw new Error("backreferences are not supported");
   }
-  if (needle.flags.includes("d")) {
-    throw new Error("expressions with 'd' (indices) flag are not supported");
-  }
 };
 
 export default inputValidation;

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -102,7 +102,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -112,7 +115,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -124,7 +130,10 @@ describe("RegexSearchStrategy", () => {
           { isMatch: false, content: "Find " },
           { isMatch: true, content: expect.arrayContaining(["FIRST PATTERN"]) },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: expect.arrayContaining(["SECOND PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["SECOND PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -134,9 +143,15 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE FIRST PATTERN here and THE SECOND PATTERN there"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE FIRST PATTERN"])
+          },
           { isMatch: false, content: " here and " },
-          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE SECOND PATTERN"])
+          },
           { isMatch: false, content: " there" }
         ]
       },
@@ -156,7 +171,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -165,7 +183,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /.+?PLEX PATTERN/,
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
-          { isMatch: true, content: expect.arrayContaining(["Find THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["Find THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -175,7 +196,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find THE " },
-          { isMatch: true, content: expect.arrayContaining(["COMPLEX PATTERN here"]) }
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["COMPLEX PATTERN here"])
+          }
         ]
       },
       {
@@ -184,7 +208,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find The cOmPlEx PATtern here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["The cOmPlEx PATtern"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["The cOmPlEx PATtern"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -194,7 +221,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMP\nLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMP\nLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMP\nLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -206,9 +236,15 @@ describe("RegexSearchStrategy", () => {
         ],
         expected: [
           { isMatch: false, content: "Find \n" },
-          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE FIRST PATTERN"])
+          },
           { isMatch: false, content: "\n here and \n" },
-          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE SECOND PATTERN"])
+          },
           { isMatch: false, content: "\n there" }
         ]
       },
@@ -218,7 +254,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -243,7 +282,9 @@ describe("RegexSearchStrategy", () => {
         name: "handles patterns with input boundary assertions",
         pattern: /^PATTERN$/,
         chunks: ["PATTERN"],
-        expected: [{ isMatch: true, content: expect.arrayContaining(["PATTERN"]) }]
+        expected: [
+          { isMatch: true, content: expect.arrayContaining(["PATTERN"]) }
+        ]
       },
       {
         name: "handles patterns with input boundary assertions (inverse scenario)",
@@ -257,7 +298,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE .COMPLEX ?PATTERN* here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE .COMPLEX ?PATTERN*"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE .COMPLEX ?PATTERN*"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -595,7 +639,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find TH", "E COMPL", "EX ", "PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -605,7 +652,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COM", "PLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -617,7 +667,10 @@ describe("RegexSearchStrategy", () => {
           { isMatch: false, content: "Find " },
           { isMatch: true, content: expect.arrayContaining(["FIRST PATTERN"]) },
           { isMatch: false, content: " and " },
-          { isMatch: true, content: expect.arrayContaining(["SECOND PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["SECOND PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -631,10 +684,16 @@ describe("RegexSearchStrategy", () => {
         ],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE FIRST PATTERN"])
+          },
           { isMatch: false, content: " he" },
           { isMatch: false, content: "re and " },
-          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE SECOND PATTERN"])
+          },
           { isMatch: false, content: " there" }
         ]
       },
@@ -644,7 +703,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE CO", "MPLEX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -653,7 +715,10 @@ describe("RegexSearchStrategy", () => {
         pattern: /.+?PLEX PATTERN/,
         chunks: ["Find T", "HE CO", "MPLEX PATTERN here"],
         expected: [
-          { isMatch: true, content: expect.arrayContaining(["Find THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["Find THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -663,7 +728,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMPLEX PATTE", "RN he", "re"],
         expected: [
           { isMatch: false, content: "Find THE " },
-          { isMatch: true, content: expect.arrayContaining(["COMPLEX PATTERN he"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["COMPLEX PATTERN he"])
+          },
           { isMatch: false, content: "re" }
         ]
       },
@@ -673,7 +741,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE CO", "MP\nL", "EX PATTERN here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMP\nLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMP\nLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -687,9 +758,15 @@ describe("RegexSearchStrategy", () => {
         ],
         expected: [
           { isMatch: false, content: "Find \n" },
-          { isMatch: true, content: expect.arrayContaining(["THE FIRST PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE FIRST PATTERN"])
+          },
           { isMatch: false, content: "\n here and \n" },
-          { isMatch: true, content: expect.arrayContaining(["THE SECOND PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE SECOND PATTERN"])
+          },
           { isMatch: false, content: "\n there" }
         ]
       },
@@ -699,7 +776,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE COMPLEX PATTERN", " here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE COMPLEX PATTERN"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE COMPLEX PATTERN"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -726,7 +806,9 @@ describe("RegexSearchStrategy", () => {
         name: "handles patterns with input boundary assertions, across chunks",
         pattern: /^PATTERN$/,
         chunks: ["PAT", "TERN"],
-        expected: [{ isMatch: true, content: expect.arrayContaining(["PATTERN"]) }]
+        expected: [
+          { isMatch: true, content: expect.arrayContaining(["PATTERN"]) }
+        ]
       },
       {
         name: "handles patterns with input boundary assertions (inverse scenario), across chunks",
@@ -743,7 +825,10 @@ describe("RegexSearchStrategy", () => {
         chunks: ["Find THE .COMP", "LEX ?PATTERN* here"],
         expected: [
           { isMatch: false, content: "Find " },
-          { isMatch: true, content: expect.arrayContaining(["THE .COMPLEX ?PATTERN*"]) },
+          {
+            isMatch: true,
+            content: expect.arrayContaining(["THE .COMPLEX ?PATTERN*"])
+          },
           { isMatch: false, content: " here" }
         ]
       },
@@ -938,8 +1023,14 @@ describe("RegexSearchStrategy", () => {
         pattern: /(?<foo>.)/u,
         chunks: ["\ud83d", "\ude04"],
         expected: [
-          { isMatch: true, content: expect.objectContaining({ groups: { foo: "\ud83d" } }) },
-          { isMatch: true, content: expect.objectContaining({ groups: { foo: "\ude04" } }) }
+          {
+            isMatch: true,
+            content: expect.objectContaining({ groups: { foo: "\ud83d" } })
+          },
+          {
+            isMatch: true,
+            content: expect.objectContaining({ groups: { foo: "\ude04" } })
+          }
         ]
       }
     ];
@@ -1199,7 +1290,9 @@ describe("RegexSearchStrategy", () => {
       const strategy = new RegexSearchStrategy(/{{(\w+)}}/);
       const state = strategy.createState();
 
-      const results = [...strategy.processChunk("prefix {{name}} suffix", state)];
+      const results = [
+        ...strategy.processChunk("prefix {{name}} suffix", state)
+      ];
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
@@ -1252,7 +1345,9 @@ describe("RegexSearchStrategy", () => {
       const strategy = new RegexSearchStrategy(/{{(\w+)}}/d);
       const state = strategy.createState();
 
-      const results = [...strategy.processChunk("prefix {{name}} suffix", state)];
+      const results = [
+        ...strategy.processChunk("prefix {{name}} suffix", state)
+      ];
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
         streamIndices: [7, 15]
@@ -1266,7 +1361,9 @@ describe("RegexSearchStrategy", () => {
       const strategy = new RegexSearchStrategy(/{{(?<name>\w+)}}/d);
       const state = strategy.createState();
 
-      const results = [...strategy.processChunk("prefix {{foo}} suffix", state)];
+      const results = [
+        ...strategy.processChunk("prefix {{foo}} suffix", state)
+      ];
       const match = results.find((r) => r.isMatch);
       const indices = match!.content.indices!;
       expect(indices[0]).toEqual([7, 14]);
@@ -1412,6 +1509,44 @@ describe("RegexSearchStrategy", () => {
       // "word" group matched, "num" group undefined
       expect(indices.groups!.word).toEqual(indices[1]);
       expect(indices.groups!.num).toBeUndefined();
+    });
+
+    it("should produce correct streamIndices when state is reused after flush", () => {
+      const strategy = new RegexSearchStrategy(/hello/d);
+      const state = strategy.createState();
+
+      // Stream 1: match at position 7
+      const results1 = [...strategy.processChunk("prefix hello suffix", state)];
+      strategy.flush(state);
+      const match1 = results1.find((r) => r.isMatch);
+      expect(match1).toMatchObject({ streamIndices: [7, 12] });
+
+      // Stream 2: reuse state after flush — indices should start from 0 again
+      const results2 = [...strategy.processChunk("prefix hello suffix", state)];
+      strategy.flush(state);
+      const match2 = results2.find((r) => r.isMatch);
+      expect(match2).toMatchObject({ streamIndices: [7, 12] });
+    });
+
+    it("should produce correct streamIndices after flush with multi-chunk streams", () => {
+      const strategy = new RegexSearchStrategy(/world/);
+      const state = strategy.createState();
+
+      // Stream 1: two chunks
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      [...strategy.processChunk("hello ", state)];
+      const results1 = [...strategy.processChunk("world!", state)];
+      strategy.flush(state);
+      const match1 = results1.find((r) => r.isMatch);
+      expect(match1).toMatchObject({ streamIndices: [6, 11] });
+
+      // Stream 2: same content, reused state — should get same indices
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      [...strategy.processChunk("hello ", state)];
+      const results2 = [...strategy.processChunk("world!", state)];
+      strategy.flush(state);
+      const match2 = results2.find((r) => r.isMatch);
+      expect(match2).toMatchObject({ streamIndices: [6, 11] });
     });
   });
 });

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -1133,8 +1133,7 @@ describe("RegexSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 7,
-        endIndex: 10
+        streamIndices: [7, 10]
       });
     });
 
@@ -1148,8 +1147,7 @@ describe("RegexSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 7,
-        endIndex: 10
+        streamIndices: [7, 10]
       });
     });
 
@@ -1162,12 +1160,10 @@ describe("RegexSearchStrategy", () => {
       const matches = results.filter((r) => r.isMatch);
       expect(matches).toHaveLength(2);
       expect(matches[0]).toMatchObject({
-        startIndex: 2,
-        endIndex: 5
+        streamIndices: [2, 5]
       });
       expect(matches[1]).toMatchObject({
-        startIndex: 8,
-        endIndex: 11
+        streamIndices: [8, 11]
       });
     });
 
@@ -1181,8 +1177,7 @@ describe("RegexSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 25,
-        endIndex: 28
+        streamIndices: [25, 28]
       });
     });
 
@@ -1192,12 +1187,12 @@ describe("RegexSearchStrategy", () => {
       const state1 = strategy.createState();
       const results1 = [...strategy.processChunk("OLD", state1)];
       const match1 = results1.find((r) => r.isMatch);
-      expect(match1?.startIndex).toBe(0);
+      expect(match1?.streamIndices[0]).toBe(0);
 
       const state2 = strategy.createState();
       const results2 = [...strategy.processChunk("OLD", state2)];
       const match2 = results2.find((r) => r.isMatch);
-      expect(match2?.startIndex).toBe(0);
+      expect(match2?.streamIndices[0]).toBe(0);
     });
 
     it("should track indices with capture groups", () => {
@@ -1208,8 +1203,7 @@ describe("RegexSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 7,
-        endIndex: 15
+        streamIndices: [7, 15]
       });
     });
 
@@ -1223,8 +1217,7 @@ describe("RegexSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 5,
-        endIndex: 13
+        streamIndices: [5, 13]
       });
     });
 
@@ -1236,8 +1229,7 @@ describe("RegexSearchStrategy", () => {
 
       expect(results[0]).toMatchObject({
         isMatch: true,
-        startIndex: 0,
-        endIndex: 3
+        streamIndices: [0, 3]
       });
     });
   });
@@ -1251,8 +1243,7 @@ describe("RegexSearchStrategy", () => {
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
         isMatch: true,
-        startIndex: 7,
-        endIndex: 10
+        streamIndices: [7, 10]
       });
       expect(match!.content.indices![0]).toEqual([7, 10]);
     });
@@ -1264,8 +1255,7 @@ describe("RegexSearchStrategy", () => {
       const results = [...strategy.processChunk("prefix {{name}} suffix", state)];
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 7,
-        endIndex: 15
+        streamIndices: [7, 15]
       });
       const indices = match!.content.indices!;
       expect(indices[0]).toEqual([7, 15]);
@@ -1293,8 +1283,7 @@ describe("RegexSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 23,
-        endIndex: 26
+        streamIndices: [23, 26]
       });
       expect(match!.content.indices![0]).toEqual([23, 26]);
     });
@@ -1321,8 +1310,7 @@ describe("RegexSearchStrategy", () => {
 
       const match = results.find((r) => r.isMatch);
       expect(match).toMatchObject({
-        startIndex: 5,
-        endIndex: 8
+        streamIndices: [5, 8]
       });
       expect(match!.content.indices![0]).toEqual([5, 8]);
     });

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -1123,4 +1123,208 @@ describe("RegexSearchStrategy", () => {
       expect(strategy.flush(state)).toBe(" and {{ something more }}");
     });
   });
+
+  describe("stream offset tracking", () => {
+    it("should track correct indices for single chunk match", () => {
+      const strategy = new RegexSearchStrategy(/OLD/);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("before OLD after", state)];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 7,
+        endIndex: 10
+      });
+    });
+
+    it("should track correct indices across chunk boundaries", () => {
+      const strategy = new RegexSearchStrategy(/OLD/);
+      const state = strategy.createState();
+
+      const results1 = [...strategy.processChunk("prefix OL", state)];
+      const results2 = [...strategy.processChunk("D suffix", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 7,
+        endIndex: 10
+      });
+    });
+
+    it("should track multiple matches with correct indices", () => {
+      const strategy = new RegexSearchStrategy(/OLD/);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("a OLD b OLD c", state)];
+
+      const matches = results.filter((r) => r.isMatch);
+      expect(matches).toHaveLength(2);
+      expect(matches[0]).toMatchObject({
+        startIndex: 2,
+        endIndex: 5
+      });
+      expect(matches[1]).toMatchObject({
+        startIndex: 8,
+        endIndex: 11
+      });
+    });
+
+    it("should track indices across multiple chunks with no matches initially", () => {
+      const strategy = new RegexSearchStrategy(/OLD/);
+      const state = strategy.createState();
+
+      const results1 = [...strategy.processChunk("chunk1 no matches ", state)];
+      const results2 = [...strategy.processChunk("chunk2 OLD end", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 25,
+        endIndex: 28
+      });
+    });
+
+    it("should reset offset on createState", () => {
+      const strategy = new RegexSearchStrategy(/OLD/);
+
+      const state1 = strategy.createState();
+      const results1 = [...strategy.processChunk("OLD", state1)];
+      const match1 = results1.find((r) => r.isMatch);
+      expect(match1?.startIndex).toBe(0);
+
+      const state2 = strategy.createState();
+      const results2 = [...strategy.processChunk("OLD", state2)];
+      const match2 = results2.find((r) => r.isMatch);
+      expect(match2?.startIndex).toBe(0);
+    });
+
+    it("should track indices with capture groups", () => {
+      const strategy = new RegexSearchStrategy(/{{(\w+)}}/);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix {{name}} suffix", state)];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 7,
+        endIndex: 15
+      });
+    });
+
+    it("should handle indices correctly with buffered partial matches", () => {
+      const strategy = new RegexSearchStrategy(/{{.+?}}/);
+      const state = strategy.createState();
+
+      const results1 = [...strategy.processChunk("text {", state)];
+      const results2 = [...strategy.processChunk("{done}} after", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 5,
+        endIndex: 13
+      });
+    });
+
+    it("should track indices for match at stream start", () => {
+      const strategy = new RegexSearchStrategy(/OLD/);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("OLD after", state)];
+
+      expect(results[0]).toMatchObject({
+        isMatch: true,
+        startIndex: 0,
+        endIndex: 3
+      });
+    });
+  });
+
+  describe("RegExpExecArray.indices with d flag", () => {
+    it("should produce indices on matches", () => {
+      const strategy = new RegexSearchStrategy(/OLD/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix OLD suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        isMatch: true,
+        startIndex: 7,
+        endIndex: 10
+      });
+      expect(match!.content.indices![0]).toEqual([7, 10]);
+    });
+
+    it("should produce indices for capture groups", () => {
+      const strategy = new RegexSearchStrategy(/{{(\w+)}}/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix {{name}} suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 7,
+        endIndex: 15
+      });
+      const indices = match!.content.indices!;
+      expect(indices[0]).toEqual([7, 15]);
+      expect(indices[1]).toEqual([9, 13]);
+    });
+
+    it("should produce named group indices", () => {
+      const strategy = new RegexSearchStrategy(/{{(?<name>\w+)}}/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix {{foo}} suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      const indices = match!.content.indices!;
+      expect(indices[0]).toEqual([7, 14]);
+      expect(indices.groups!.name).toEqual([9, 12]);
+    });
+
+    it("should adjust indices across chunk boundaries", () => {
+      const strategy = new RegexSearchStrategy(/OLD/d);
+      const state = strategy.createState();
+
+      const results1 = [...strategy.processChunk("chunk1 no match ", state)];
+      const results2 = [...strategy.processChunk("chunk2 OLD end", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 23,
+        endIndex: 26
+      });
+      expect(match!.content.indices![0]).toEqual([23, 26]);
+    });
+
+    it("should adjust indices for multiple matches", () => {
+      const strategy = new RegexSearchStrategy(/OLD/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("a OLD b OLD c", state)];
+
+      const matches = results.filter((r) => r.isMatch);
+      expect(matches).toHaveLength(2);
+      expect(matches[0]!.content.indices![0]).toEqual([2, 5]);
+      expect(matches[1]!.content.indices![0]).toEqual([8, 11]);
+    });
+
+    it("should adjust indices across buffered partial matches", () => {
+      const strategy = new RegexSearchStrategy(/OLD/d);
+      const state = strategy.createState();
+
+      const results1 = [...strategy.processChunk("text OL", state)];
+      const results2 = [...strategy.processChunk("D end", state)];
+      const results = [...results1, ...results2];
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        startIndex: 5,
+        endIndex: 8
+      });
+      expect(match!.content.indices![0]).toEqual([5, 8]);
+    });
+  });
 });

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -1314,5 +1314,104 @@ describe("RegexSearchStrategy", () => {
       });
       expect(match!.content.indices![0]).toEqual([5, 8]);
     });
+
+    it("should handle optional unmatched capture group (undefined index entry)", () => {
+      const strategy = new RegexSearchStrategy(/a(b)?c/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix ac suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        streamIndices: [7, 9]
+      });
+      const indices = match!.content.indices!;
+      expect(indices[0]).toEqual([7, 9]);
+      expect(indices[1]).toBeUndefined();
+    });
+
+    it("should handle optional matched capture group", () => {
+      const strategy = new RegexSearchStrategy(/a(b)?c/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix abc suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        streamIndices: [7, 10]
+      });
+      const indices = match!.content.indices!;
+      expect(indices[0]).toEqual([7, 10]);
+      expect(indices[1]).toEqual([8, 9]);
+    });
+
+    it("should handle named optional unmatched group (undefined in indices.groups)", () => {
+      const strategy = new RegexSearchStrategy(/a(?<mid>b)?c/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix ac suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        streamIndices: [7, 9]
+      });
+      const indices = match!.content.indices!;
+      expect(indices[0]).toEqual([7, 9]);
+      expect(indices[1]).toBeUndefined();
+      expect(indices.groups!.mid).toBeUndefined();
+    });
+
+    it("should handle named optional matched group", () => {
+      const strategy = new RegexSearchStrategy(/a(?<mid>b)?c/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix abc suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      const indices = match!.content.indices!;
+      expect(indices[0]).toEqual([7, 10]);
+      expect(indices[1]).toEqual([8, 9]);
+      expect(indices.groups!.mid).toEqual([8, 9]);
+    });
+
+    it("should handle mixed matched and unmatched optional groups", () => {
+      const strategy = new RegexSearchStrategy(/(?<a>x)?y(?<b>z)?/d);
+      const state = strategy.createState();
+
+      // Only "y" matches — both optional groups unmatched
+      const results1 = [...strategy.processChunk("prefix y suffix", state)];
+      const match1 = results1.find((r) => r.isMatch);
+      const indices1 = match1!.content.indices!;
+      expect(indices1[0]).toEqual([7, 8]);
+      expect(indices1[1]).toBeUndefined();
+      expect(indices1[2]).toBeUndefined();
+      expect(indices1.groups!.a).toBeUndefined();
+      expect(indices1.groups!.b).toBeUndefined();
+    });
+
+    it("should handle optional groups with offset from prior chunks", () => {
+      const strategy = new RegexSearchStrategy(/a(?<opt>b)?c/d);
+      const state = strategy.createState();
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- just need to dummy process a chunk to advance the stream index
+      [...strategy.processChunk("first chunk no match ", state)];
+      const results2 = [...strategy.processChunk("ac end", state)];
+      const match = results2.find((r) => r.isMatch);
+      expect(match).toMatchObject({
+        streamIndices: [21, 23]
+      });
+      const indices = match!.content.indices!;
+      expect(indices[0]).toEqual([21, 23]);
+      expect(indices[1]).toBeUndefined();
+      expect(indices.groups!.opt).toBeUndefined();
+    });
+
+    it("should handle alternation where one branch has more groups", () => {
+      const strategy = new RegexSearchStrategy(/(?<word>\w+)|(?<num>\d+)/d);
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix hello suffix", state)];
+      const match = results.find((r) => r.isMatch);
+      const indices = match!.content.indices!;
+      // "word" group matched, "num" group undefined
+      expect(indices.groups!.word).toEqual(indices[1]);
+      expect(indices.groups!.num).toBeUndefined();
+    });
   });
 });

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -17,7 +17,8 @@ import StringBufferStrategyBase, {
  * @see {@link https://github.com/microsoft/TypeScript/issues/61078}
  * @see {@link https://github.com/microsoft/TypeScript/pull/61079}
  * 
- * However, this still incorrectly types groups as `Record<string, [number, number]>` without `undefined` values,
+ * However, this still incorrectly types groups as `Record<string, [number, number]>` without `undefined` values
+ * @see {@link https://github.com/microsoft/TypeScript/issues/63281}
  */
 interface CorrectedRegExpIndicesArray
   extends Array<[number, number] | undefined> {

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -54,6 +54,7 @@ export class RegexSearchStrategy
     state: StringBufferState
   ): Generator<MatchResult<RegExpExecArray>, void, undefined> {
     const bufferLength = state.buffer.length;
+    const baseOffset = state.streamOffset - bufferLength;
     haystack = state.buffer + haystack;
     const length = haystack.length;
     let position = 0;
@@ -88,7 +89,7 @@ export class RegexSearchStrategy
         }
 
         const matchLength = completeMatch[0].length;
-        const startIndex = state.streamOffset + (position - bufferLength);
+        const startIndex = baseOffset + position;
         const endIndex = startIndex + matchLength;
         position += matchLength;
 

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -5,8 +5,33 @@ import StringBufferStrategyBase, {
   type StringBufferState
 } from "../string-buffer-strategy-base.ts";
 
-function updateIndices(indices: [number,number][], offset: number) {
+/**
+ * Corrected version of {@link RegExpIndicesArray} that models `undefined`
+ * entries for unmatched optional/alternation capture groups.
+ *
+ * TypeScript's built-in type incorrectly declares `Array<[number, number]>`,
+ * but the ES2022 spec (and all engines) place `undefined` at positions
+ * corresponding to non-participating capture groups.
+ *
+ * Fixed upstream but not yet released:
+ * @see {@link https://github.com/microsoft/TypeScript/issues/61078}
+ * @see {@link https://github.com/microsoft/TypeScript/pull/61079}
+ * 
+ * However, this still incorrectly types groups as `Record<string, [number, number]>` without `undefined` values,
+ */
+interface CorrectedRegExpIndicesArray
+  extends Array<[number, number] | undefined> {
+  groups?: {
+    [key: string]: [number, number] | undefined;
+  };
+}
+
+function updateIndices(
+  indices: CorrectedRegExpIndicesArray,
+  offset: number
+) {
   for (const entry of indices) {
+    if (entry === undefined) continue;
     entry[0] += offset;
     entry[1] += offset;
   }
@@ -94,10 +119,15 @@ export class RegexSearchStrategy
         position += matchLength;
 
         if (completeMatch.indices) {
+          const indices =
+            completeMatch.indices as CorrectedRegExpIndicesArray;
           const offset = startIndex - completeMatch.index;
-          updateIndices(completeMatch.indices, offset);
-          if (completeMatch.indices.groups) {
-            updateIndices(Object.values(completeMatch.indices.groups), offset);
+          updateIndices(indices, offset);
+          if (indices.groups) {
+            updateIndices(
+              Object.values(indices.groups) as CorrectedRegExpIndicesArray,
+              offset
+            );
           }
         }
 

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -101,7 +101,7 @@ export class RegexSearchStrategy
           }
         }
 
-        yield { isMatch: true, content: completeMatch, startIndex, endIndex };
+        yield { isMatch: true, content: completeMatch, streamIndices: [startIndex, endIndex] };
       }
     } finally {
       if (position < length) {

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -5,12 +5,18 @@ import StringBufferStrategyBase, {
   type StringBufferState
 } from "../string-buffer-strategy-base.ts";
 
+function updateIndices(indices: [number,number][], offset: number) {
+  for (const entry of indices) {
+    entry[0] += offset;
+    entry[1] += offset;
+  }
+}
 
 /**
  * A search strategy for finding patterns using regular expressions.
  *
  * This strategy enables powerful pattern matching using JavaScript RegExp, supporting
- * most standard regex features (capture groups, lookaheads, character classes, etc.).
+ * most standard regex features (capture groups, positive lookaheads, character classes, etc.).
  * It correctly handles matches that span chunk boundaries by maintaining a buffer and
  * using partial match detection to avoid splitting incomplete patterns.
  *
@@ -29,7 +35,6 @@ import StringBufferStrategyBase, {
  * });
  * ```
  */
-
 export class RegexSearchStrategy
   extends StringBufferStrategyBase
   implements SearchStrategy<StringBufferState, RegExpExecArray>
@@ -48,6 +53,7 @@ export class RegexSearchStrategy
     haystack: string,
     state: StringBufferState
   ): Generator<MatchResult<RegExpExecArray>, void, undefined> {
+    const bufferLength = state.buffer.length;
     haystack = state.buffer + haystack;
     const length = haystack.length;
     let position = 0;
@@ -81,13 +87,26 @@ export class RegexSearchStrategy
           yield { isMatch: false, content: nonMatch };
         }
 
-        position += completeMatch[0].length;
-        yield { isMatch: true, content: completeMatch };
+        const matchLength = completeMatch[0].length;
+        const startIndex = state.streamOffset + (position - bufferLength);
+        const endIndex = startIndex + matchLength;
+        position += matchLength;
+
+        if (completeMatch.indices) {
+          const offset = startIndex - completeMatch.index;
+          updateIndices(completeMatch.indices, offset);
+          if (completeMatch.indices.groups) {
+            updateIndices(Object.values(completeMatch.indices.groups), offset);
+          }
+        }
+
+        yield { isMatch: true, content: completeMatch, startIndex, endIndex };
       }
     } finally {
       if (position < length) {
         state.buffer += haystack.slice(position);
       }
+      state.streamOffset += haystack.length - bufferLength;
     }
   }
 }

--- a/src/search-strategies/string-buffer-strategy-base.ts
+++ b/src/search-strategies/string-buffer-strategy-base.ts
@@ -10,6 +10,7 @@ abstract class StringBufferStrategyBase {
   flush(state: StringBufferState): string {
     const flushed = state.buffer;
     state.buffer = "";
+    state.streamOffset = 0;
     return flushed;
   }
 }

--- a/src/search-strategies/string-buffer-strategy-base.ts
+++ b/src/search-strategies/string-buffer-strategy-base.ts
@@ -1,10 +1,11 @@
 export type StringBufferState = {
   buffer: string;
+  streamOffset: number;
 };
 
 abstract class StringBufferStrategyBase {
   createState(): StringBufferState {
-    return { buffer: "" };
+    return { buffer: "", streamOffset: 0 };
   }
   flush(state: StringBufferState): string {
     const flushed = state.buffer;

--- a/src/search-strategies/types.ts
+++ b/src/search-strategies/types.ts
@@ -3,13 +3,13 @@
  *
  * Uses boolean discrimination with typed content:
  * - `{ isMatch: false, content: string }` - Literal content to yield as-is
- * - `{ isMatch: true, content: T, startIndex: number, endIndex: number }` - Match value passed to replacement function
+ * - `{ isMatch: true, content: T, streamIndices: [startIndex, endIndex] }` - Match value passed to replacement function
  *
  * @typeParam T - The type of value returned for matches (default: string)
  */
 export type MatchResult<T = string> =
   | { isMatch: false; content: string }
-  | { isMatch: true; content: T; startIndex: number; endIndex: number };
+  | { isMatch: true; content: T; streamIndices: [startIndex: number, endIndex: number] };
 
 /**
  * Search strategy for finding patterns in streaming content.

--- a/src/search-strategies/types.ts
+++ b/src/search-strategies/types.ts
@@ -3,7 +3,7 @@
  *
  * Uses boolean discrimination with typed content:
  * - `{ isMatch: false, content: string }` - Literal content to yield as-is
- * - `{ isMatch: true, content: T, streamIndices: [startIndex, endIndex] }` - Match value passed to replacement function
+ * - `{ isMatch: true, content: T, streamIndices: [startIndex, endIndex] }` - Match value passed to replacement function (endIndex is exclusive / half-open interval)
  *
  * @typeParam T - The type of value returned for matches (default: string)
  */
@@ -31,7 +31,7 @@ export interface SearchStrategy<TState, TMatch = string> {
    *
    * @param haystack - New content to process
    * @param state - Mutable state object to track search progress
-   * @yields MatchResult - Either `{ isMatch: false, content: string }` or `{ isMatch: true, content: TMatch }`
+   * @yields MatchResult - Either `{ isMatch: false, content: string }` or `{ isMatch: true, content: TMatch, streamIndices: [startIndex, endIndex] }`
    */
   processChunk(
     haystack: string,

--- a/src/search-strategies/types.ts
+++ b/src/search-strategies/types.ts
@@ -3,7 +3,7 @@
  *
  * Uses boolean discrimination with typed content:
  * - `{ isMatch: false, content: string }` - Literal content to yield as-is
- * - `{ isMatch: true, content: T, startIndex?: number, endIndex?: number }` - Match value passed to replacement function
+ * - `{ isMatch: true, content: T, startIndex: number, endIndex: number }` - Match value passed to replacement function
  *
  * @typeParam T - The type of value returned for matches (default: string)
  */

--- a/src/search-strategies/types.ts
+++ b/src/search-strategies/types.ts
@@ -3,13 +3,13 @@
  *
  * Uses boolean discrimination with typed content:
  * - `{ isMatch: false, content: string }` - Literal content to yield as-is
- * - `{ isMatch: true, content: T }` - Match value passed to replacement function
+ * - `{ isMatch: true, content: T, startIndex?: number, endIndex?: number }` - Match value passed to replacement function
  *
  * @typeParam T - The type of value returned for matches (default: string)
  */
 export type MatchResult<T = string> =
   | { isMatch: false; content: string }
-  | { isMatch: true; content: T };
+  | { isMatch: true; content: T; startIndex: number; endIndex: number };
 
 /**
  * Search strategy for finding patterns in streaming content.

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -126,4 +126,4 @@ Stream processing performance with the same code across different JavaScript eng
 - Algorithm benchmarks focus on **algorithmic differences** (same runtime, different approaches)
 - Runtime benchmarks focus on **engine differences** (same code, different engines)
 - All benchmarks run in the workspace context with access to `../../src/` for imports
-- Scripts use `--experimental-strip-types` for TypeScript execution without compilation
+- Scripts use `--experimental-strip-types` on Node, for TypeScript execution without compilation

--- a/test/benchmarks/runtime/benchmark-definitions.ts
+++ b/test/benchmarks/runtime/benchmark-definitions.ts
@@ -5,9 +5,9 @@ import {
   AsyncIterableFunctionReplacementProcessor
 } from "../../../src/replacement-processors/index.ts";
 import {
-  StringAnchorSearchStrategy,
-  type StringAnchorSearchState as SearchState
+  StringAnchorSearchStrategy
 } from "../../../src/search-strategies/index.ts";
+import type { LoopedIndexOfAnchoredSearchState as SearchState } from "../../../src/search-strategies/looped-indexOf-anchored/search-strategy.ts";
 
 /**
  * Core benchmark definitions - categorized object


### PR DESCRIPTION
## Issue

resolves #23

## Details

- Add details of the start and end index of each successful match, relative to the start of the input stream
  - Updates the search strategy state to hold a running character offset
  - Update the regex strategy to allow [the `d` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices)
    - Mutate returned indices to be stream aware
  - Rename positional argument `index` to `matchIndex` in replacement functions, for clarity / to differentiate from stream indices
  - Update all search strategies for consistent benchmarking

N.B. benchmarking before/after the change confirms no performance impact to existing functionality for exported search strategies:

<details>
<summary>Comparison</summary>

### Looped IndexOf Anchored

Scenario | before | after | Δ
-- | -- | -- | --
Setup Cost | 18.06 ns | 18.12 ns | +0.3%
Single chunk, multiple patterns | 421.16 ns | 419.14 ns | -0.5%
Cross-chunk boundary | 454.01 ns | 442.00 ns | -2.6%
Multiple cross-chunk | 838.46 ns | 830.89 ns | -0.9%
No matches (10 chunks) | 1.43 µs | 1.45 µs | +1.4%
High match density | 1.13 µs | 1.14 µs | +0.9%
Consecutive patterns | 440.12 ns | 436.05 ns | -0.9%
Long content between anchors | 347.89 ns | 346.86 ns | -0.3%
Large chunks | 1.17 µs | 1.14 µs | -2.6%
Pathological: Repeated prefix | 728.90 ns | 717.89 ns | -1.5%
Pathological: All-same-char | 846.81 ns | 865.26 ns | +2.2%
Pathological: Repetitive prefix | 846.23 ns | 849.96 ns | +0.4%
HTML template | 1.02 µs | 1.02 µs | 0.0%
Markdown with code blocks | 449.77 ns | 448.63 ns | -0.3%
Bash script | 444.50 ns | 440.26 ns | -1.0%
EJS template | 984.76 ns | 1.01 µs | +2.6%
MediaWiki template | 844.81 ns | 844.14 ns | -0.1%
XSLT attribute value | 1.20 µs | 1.19 µs | -0.8%
Medium tokens | 419.82 ns | 422.48 ns | +0.6%

**Average (excl. Setup): -0.2%** — effectively neutral. 12 of 18 scenarios improved or flat, 6 regressed slightly. All deltas within ±2.6% noise range.

### Regex

Scenario | before | after | Δ
-- | -- | -- | --
Setup Cost | 485.68 ns | 457.01 ns | -5.9%
Single chunk | 461.71 ns | 449.77 ns | -2.6%
Cross-chunk boundary | 517.29 ns | 501.36 ns | -3.1%
Multiple cross-chunk | 977.63 ns | 980.72 ns | +0.3%
No matches | 1.82 µs | 1.79 µs | -1.6%
High match density | 1.25 µs | 1.24 µs | -0.8%
Consecutive patterns | 446.16 ns | 457.72 ns | +2.6%
Long content | 378.75 ns | 377.47 ns | -0.3%
Large chunks | 1.46 µs | 1.45 µs | -0.7%
Pathological: Repeated prefix | 714.39 ns | 718.27 ns | +0.5%
Pathological: All-same-char | 868.97 ns | 876.80 ns | +0.9%
Pathological: Repetitive prefix | 934.73 ns | 946.21 ns | +1.2%
HTML template | 1.14 µs | 1.17 µs | +2.6%
Markdown | 479.00 ns | 487.62 ns | +1.8%
Bash script | 473.23 ns | 476.05 ns | +0.6%
EJS template | 1.04 µs | 1.06 µs | +1.9%
MediaWiki | 974.39 ns | 983.05 ns | +0.9%
XSLT | 1.39 µs | 1.43 µs | +2.9%
Medium tokens | 420.22 ns | 427.58 ns | +1.8%

**Average (excl. Setup): +0.5%** — within noise. Mixed results, no systematic regression.


<details>
<summary>Performance run before</summary>

```console
🚀 Algorithm Comparison Benchmark

Running 23 scenarios across 2 harnesses...

clk: ~4.29 GHz
cpu: Apple M4
runtime: node 24.9.0 (arm64-darwin)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• Setup Cost (strategy + transformer creation)
------------------------------------------- -------------------------------
Looped IndexOf Anchored       20.20 ns/iter  19.82 ns     █                
                     (18.06 ns … 127.94 ns)  26.14 ns     █                
                    (106.28  b … 463.95  b) 234.19  b ▁▁▁▂█▃▂▁▁▁▁▁▁▁▁▁▁▁▁▂▁

Regex                        495.83 ns/iter 497.73 ns  ██                  
                    (485.68 ns … 621.70 ns) 571.04 ns ▆██▆                 
                    (  1.32 kb …   1.91 kb)   1.68 kb █████▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁

• Single chunk, multiple patterns
------------------------------------------- -------------------------------
Looped IndexOf Anchored      568.41 ns/iter 480.19 ns █                    
                      (421.16 ns … 2.61 µs)   1.35 µs █                    
                    (  2.52 kb …   3.01 kb)   2.83 kb ██▂▂▁▁▁▁▁▁▂▁▁▁▄▂▂▁▁▁▁

Regex                        646.79 ns/iter 483.52 ns █                    
                      (461.71 ns … 1.80 µs)   1.47 µs █                    
                    (  2.95 kb …   3.41 kb)   3.19 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▅▁▂

• Cross-chunk boundary (50/50 split)
------------------------------------------- -------------------------------
Looped IndexOf Anchored      564.83 ns/iter 468.36 ns █                    
                      (454.01 ns … 1.36 µs)   1.00 µs █                    
                    (  3.38 kb …   3.68 kb)   3.57 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▁▁

Regex                        666.52 ns/iter 563.88 ns █                    
                      (517.29 ns … 1.52 µs)   1.16 µs █                    
                    (  3.67 kb …   4.05 kb)   3.86 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆▃▁

• Multiple cross-chunk boundaries
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.02 µs/iter   1.31 µs █                    
                      (838.46 ns … 1.74 µs)   1.49 µs █                    
                    (  5.74 kb …   5.87 kb)   5.86 kb █▆▁▁▁▁▁▁▁▁▂▁▁▁▇█▂▂▁▁▁

Regex                          1.25 µs/iter   1.59 µs █                    
                      (977.63 ns … 2.02 µs)   1.67 µs █▂                ▇  
                    (  6.35 kb …   6.61 kb)   6.48 kb ██▂▁▁▁▁▁▁▁▁▁▁▁▁▂▁▅█▂▂

• No matches (10 chunks)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.53 µs/iter   1.56 µs              █       
                        (1.43 µs … 1.86 µs)   1.63 µs    ▇         █▆      
                    ( 11.29 kb …  11.29 kb)  11.29 kb ▅▂██▄▃▁▁▃▂█████▁▂▃▂▁▂

Regex                          1.91 µs/iter   1.93 µs            █         
                        (1.82 µs … 2.02 µs)   2.00 µs            ██        
                    ( 12.01 kb …  12.01 kb)  12.01 kb ▅█▇▁▅▃▃▁▂▂████▅█▃▁▃▂▅

• High match density (3 chunks, 3 per chunk)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.37 µs/iter   1.80 µs  █                   
                        (1.13 µs … 1.91 µs)   1.90 µs ██                   
                    (  5.64 kb …   5.78 kb)   5.64 kb ██▂▁▂▁▁▁▁▂▁▁▂▂▂▁▁▇█▃▄

Regex                          1.74 µs/iter   2.28 µs █                    
                        (1.25 µs … 2.41 µs)   2.35 µs █▅                ▂▇ 
                    (  6.83 kb …   6.98 kb)   6.98 kb ██▂▁▁▁▁▁▂▁▁▁▁▁▂▄▁▁██▅

• Consecutive patterns (no gap)
------------------------------------------- -------------------------------
Looped IndexOf Anchored      557.28 ns/iter 453.94 ns █                    
                      (440.12 ns … 1.50 µs)   1.19 µs █                    
                    (  2.48 kb …   2.75 kb)   2.75 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁

Regex                        638.53 ns/iter 471.59 ns █                    
                      (446.16 ns … 1.79 µs)   1.43 µs █                    
                    (  2.81 kb …   3.35 kb)   3.08 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▂▁

• Long content between anchors
------------------------------------------- -------------------------------
Looped IndexOf Anchored      451.69 ns/iter 358.39 ns █                    
                      (347.89 ns … 1.06 µs)   1.04 µs █                    
                    (  2.30 kb …   2.69 kb)   2.59 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▄▂

Regex                        513.52 ns/iter 389.86 ns █                    
                      (378.75 ns … 1.60 µs)   1.24 µs █                    
                    (  2.48 kb …   3.01 kb)   2.79 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▂▁

• Large chunks (~200 bytes each, 3 chunks)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.44 µs/iter   1.87 µs █                    
                        (1.17 µs … 1.98 µs)   1.96 µs █                 ▃  
                    (  5.90 kb …   6.42 kb)   6.16 kb █▄▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▂█▄▁

Regex                          1.91 µs/iter   2.40 µs █                    
                        (1.46 µs … 2.54 µs)   2.52 µs █                 █  
                    (  6.77 kb …   7.11 kb)   7.09 kb █▅▁▂▁▁▁▁▃▁▁▁▁▁▃▁▂▂█▄▂

• Pathological: Repeated prefix cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored      876.01 ns/iter   1.21 µs █                    
                      (728.90 ns … 1.26 µs)   1.26 µs █                    
                    (  4.47 kb …   4.78 kb)   4.66 kb █▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃█▂

Regex                        909.18 ns/iter   1.28 µs █                    
                      (714.39 ns … 1.35 µs)   1.33 µs █                  ▂ 
                    (  5.07 kb …   5.20 kb)   5.07 kb ██▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▃█▃

• Pathological: All-same-char tokens cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored      987.12 ns/iter   1.18 µs  █                ▆  
                      (846.81 ns … 1.27 µs)   1.22 µs ██                █  
                    (  6.31 kb …   6.54 kb)   6.32 kb ██▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂█▄▁

Regex                          1.03 µs/iter   1.27 µs █                    
                      (868.97 ns … 1.33 µs)   1.32 µs ██                █  
                    (  5.85 kb …   5.98 kb)   5.98 kb ██▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃█▆▁

• Pathological: Repetitive prefix tokens cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.04 µs/iter   1.32 µs █                    
                      (846.23 ns … 1.72 µs)   1.38 µs █                 ▄  
                    (  5.97 kb …   6.21 kb)   6.09 kb ██▂▁▁▁▁▁▁▁▁▁▁▂▁▁▁▄█▃▂

Regex                          1.20 µs/iter   1.52 µs  █                   
                      (934.73 ns … 1.63 µs)   1.59 µs  █                ▄  
                    (  1.23 kb …   6.44 kb)   6.38 kb ▅█▁▁▂▁▁▁▁▁▁▁▁▂▂▁▁▁█▅▃

• HTML template with cross-chunk boundaries
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.25 µs/iter   1.55 µs █                    
                        (1.02 µs … 1.97 µs)   1.60 µs █▄                 ▅ 
                    (  6.30 kb …   6.44 kb)   6.44 kb ██▃▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁██▃

Regex                          1.46 µs/iter   1.82 µs █                    
                        (1.14 µs … 2.15 µs)   1.92 µs █▅               █▂  
                    (  7.08 kb …   7.29 kb)   7.09 kb ██▁▂▂▁▁▁▂▁▁▁▂▂▂▁▁██▂▂

• Markdown with code blocks
------------------------------------------- -------------------------------
Looped IndexOf Anchored      575.58 ns/iter 463.52 ns █                    
                      (449.77 ns … 1.25 µs)   1.23 µs █                    
                    (  2.71 kb …   3.00 kb)   2.90 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁

Regex                        675.99 ns/iter 498.90 ns █                    
                      (479.00 ns … 1.86 µs)   1.54 µs █                    
                    (  3.02 kb …   3.36 kb)   3.23 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▄▂▁

• Bash script with $ and braces
------------------------------------------- -------------------------------
Looped IndexOf Anchored      561.24 ns/iter 453.98 ns █                    
                      (444.50 ns … 1.25 µs)   1.18 µs █                    
                    (  2.81 kb …   2.97 kb)   2.87 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▂▃▁

Regex                        662.11 ns/iter 492.87 ns █                    
                      (473.23 ns … 1.83 µs)   1.51 µs █                    
                    (  3.08 kb …   3.31 kb)   3.20 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▄▂▁

• EJS template (multiple delimiter types)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.15 µs/iter   1.32 µs  █                   
                      (984.76 ns … 1.44 µs)   1.39 µs  █               ▂   
                    (  6.96 kb …   7.14 kb)   7.00 kb ▅█▆▂▂▁▁▁▁▁▁▁▁▁▁▃██▅▂▂

Regex                          1.21 µs/iter   1.40 µs  █                   
                        (1.04 µs … 1.80 µs)   1.44 µs ▅█                ▇  
                    (  7.13 kb …   7.28 kb)   7.13 kb ██▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▃██▃

• MediaWiki template (triple braces)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.00 µs/iter   1.24 µs  █                   
                      (844.81 ns … 1.40 µs)   1.31 µs ██               ▅   
                    (  5.86 kb …   5.98 kb)   5.98 kb ██▃▃▁▁▁▁▁▁▁▁▁▁▁▁▄█▅▃▂

Regex                          1.20 µs/iter   1.50 µs  █                   
                      (974.39 ns … 1.58 µs)   1.55 µs ▅█                ▃▄ 
                    (  6.47 kb …   6.61 kb)   6.47 kb ██▂▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁██▂

• XSLT attribute value template
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.42 µs/iter   1.69 µs  █                   
                        (1.20 µs … 1.73 µs)   1.73 µs  █                 █ 
                    (  7.02 kb …   7.27 kb)   7.03 kb ██▄▂▂▁▁▁▁▁▁▁▁▁▂▂▂▂▅█▄

Regex                          1.81 µs/iter   2.16 µs █▂               ▆   
                        (1.39 µs … 2.56 µs)   2.27 µs ██               ██  
                    (  7.68 kb …   7.98 kb)   7.97 kb ██▂▁▁▁▁▁▁▁▁▁▁▁▃▃▁██▄▂

• Medium tokens (7 chars) - V8 threshold
------------------------------------------- -------------------------------
Looped IndexOf Anchored      534.16 ns/iter 428.62 ns █                    
                      (419.82 ns … 1.53 µs)   1.16 µs █                    
                    (  2.60 kb …   2.85 kb)   2.76 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▂▁

Regex                        600.60 ns/iter 439.31 ns █                    
                      (420.22 ns … 1.80 µs)   1.50 µs █                    
                    (  2.82 kb …   3.08 kb)   2.98 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▂▂▁

• Long tokens (15 chars) cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored      971.41 ns/iter   1.28 µs █                    
                      (804.86 ns … 1.55 µs)   1.33 µs █                 ▂  
                    (  5.20 kb …   5.45 kb)   5.32 kb ██▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁█▅▂

Regex                          1.04 µs/iter   1.40 µs █                    
                      (830.65 ns … 1.60 µs)   1.52 µs █▄               ▆   
                    (  5.40 kb …   5.53 kb)   5.40 kb ██▂▁▁▁▁▁▁▁▁▁▁▂▂▁▂█▂▂▁

• Django/Jinja2 template tags
------------------------------------------- -------------------------------
Looped IndexOf Anchored      755.56 ns/iter 584.28 ns █                    
                      (569.23 ns … 1.93 µs)   1.55 µs █                    
                    (  3.17 kb …   3.48 kb)   3.32 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▃▂

Regex                        866.59 ns/iter   1.41 µs █                    
                      (583.62 ns … 2.11 µs)   1.96 µs █                    
                    (  3.63 kb …   3.79 kb)   3.78 kb █▂▁▁▁▁▁▁▁▁▁▁▂▁▁▄▄▂▁▁▁

• Empty content between consecutive anchors
------------------------------------------- -------------------------------
Looped IndexOf Anchored      606.33 ns/iter 501.09 ns █                    
                      (490.12 ns … 1.30 µs)   1.24 µs █                    
                    (  2.80 kb …   2.99 kb)   2.87 kb █▂▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▃▂▁

Regex                        704.92 ns/iter 533.28 ns █                    
                      (500.85 ns … 1.59 µs)   1.57 µs █                    
                    (  3.23 kb …   3.46 kb)   3.33 kb █▃▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▃▄▂

• Single character between patterns
------------------------------------------- -------------------------------
Looped IndexOf Anchored      613.52 ns/iter 510.45 ns █                    
                      (494.71 ns … 1.26 µs)   1.22 µs █                    
                    (  2.80 kb …   2.90 kb)   2.89 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▂▁

Regex                        714.88 ns/iter 559.95 ns █                    
                      (519.06 ns … 1.88 µs)   1.51 µs █                    
                    (  3.14 kb …   3.25 kb)   3.24 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▅▁▂

• Asymmetric token lengths
------------------------------------------- -------------------------------
Looped IndexOf Anchored      626.82 ns/iter 514.32 ns █                    
                      (494.86 ns … 1.46 µs)   1.13 µs █                    
                    (  3.19 kb …   3.91 kb)   3.59 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆▂▁

Regex                        788.43 ns/iter 702.27 ns █▄                   
                      (626.06 ns … 1.51 µs)   1.28 µs ██                   
                    (  3.76 kb …   4.07 kb)   3.92 kb ██▂▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▄█▂
✨  Done in 37.94s.
```

</details>

<details>
<summary>Performance run after</summary>

```console
🚀 Algorithm Comparison Benchmark

Running 23 scenarios across 2 harnesses...

clk: ~4.39 GHz
cpu: Apple M4
runtime: node 24.9.0 (arm64-darwin)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• Setup Cost (strategy + transformer creation)
------------------------------------------- -------------------------------
Looped IndexOf Anchored       20.71 ns/iter  20.27 ns     █▆               
                      (18.12 ns … 58.06 ns)  27.01 ns     ██               
                    (133.08  b … 504.69  b) 250.21  b ▁▁▁▁██▅▂▃▂▁▁▁▁▁▁▁▂▃▁▁

Regex                        480.21 ns/iter 482.29 ns     █                
                    (457.01 ns … 588.31 ns) 555.14 ns     █▅               
                    (  1.44 kb …   1.96 kb)   1.66 kb ▁▁▂████▃▁▁▁▁▁▁▁▁▁▁▁▁▁

• Single chunk, multiple patterns
------------------------------------------- -------------------------------
Looped IndexOf Anchored      563.88 ns/iter 491.45 ns  █                   
                      (419.14 ns … 1.29 µs)   1.23 µs ██                   
                    (  2.70 kb …   3.24 kb)   2.90 kb ██▇▁▂▁▁▁▁▁▁▁▂▁▁▁▃▅▂▂▂

Regex                        653.02 ns/iter 491.89 ns █                    
                      (449.77 ns … 1.79 µs)   1.54 µs █▃                   
                    (  3.05 kb …   3.37 kb)   3.26 kb ██▁▁▁▁▁▁▁▁▁▁▂▁▁▁▂▅▂▂▁

• Cross-chunk boundary (50/50 split)
------------------------------------------- -------------------------------
Looped IndexOf Anchored      572.21 ns/iter 478.73 ns  █                   
                      (442.00 ns … 1.40 µs)   1.01 µs  █                   
                    (  3.65 kb …   3.76 kb)   3.65 kb ▄█▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▅▂▁

Regex                        668.36 ns/iter 583.88 ns  █                   
                      (501.36 ns … 1.51 µs)   1.18 µs  █                   
                    (  3.57 kb …   4.32 kb)   3.95 kb ▅█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▅▂▁

• Multiple cross-chunk boundaries
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.02 µs/iter   1.30 µs  █                   
                      (830.89 ns … 1.38 µs)   1.36 µs  █                   
                    (  5.90 kb …   6.02 kb)   6.02 kb ▃█▂▁▁▁▁▁▁▁▁▁▁▂▁▁▂▃█▄▂

Regex                          1.25 µs/iter   1.58 µs  █                   
                      (980.72 ns … 1.72 µs)   1.64 µs ██                █▂ 
                    (  6.53 kb …   6.66 kb)   6.66 kb ██▂▁▁▁▁▁▁▁▁▁▁▂▂▂▁▂██▂

• No matches (10 chunks)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.54 µs/iter   1.57 µs              ▂█      
                        (1.45 µs … 1.82 µs)   1.63 µs   ▃█▅      ▇▇██▆     
                    ( 11.54 kb …  11.54 kb)  11.54 kb ▄▄███▂▁▁▄▄██████▁█▅▁▂

Regex                          1.91 µs/iter   1.94 µs              █  ▂    
                        (1.79 µs … 1.99 µs)   1.98 µs             ▂█▆ █    
                    (  4.21 kb …  12.34 kb)  11.99 kb ▂▄▁▅▅▄▇▂▂▂▁▄█████▇▅▂▂

• High match density (3 chunks, 3 per chunk)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.39 µs/iter   1.81 µs █▄                   
                        (1.14 µs … 2.08 µs)   1.94 µs ██               ▅   
                    (  5.71 kb …   5.87 kb)   5.87 kb ██▃▂▁▁▁▁▁▂▁▁▂▂▂▁▃█▄▃▂

Regex                          1.75 µs/iter   2.26 µs █               ▂    
                        (1.24 µs … 2.65 µs)   2.53 µs █▅              █    
                    (  7.22 kb …   7.50 kb)   7.22 kb ██▁▁▁▁▁▂▁▁▁▁▄▂▁▆█▅▂▁▂

• Consecutive patterns (no gap)
------------------------------------------- -------------------------------
Looped IndexOf Anchored      553.77 ns/iter 456.16 ns █                    
                      (436.05 ns … 1.18 µs)   1.14 µs █                    
                    (  2.65 kb …   2.91 kb)   2.84 kb █▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▂

Regex                        653.51 ns/iter 496.22 ns █                    
                      (457.72 ns … 1.75 µs)   1.48 µs █                    
                    (  2.96 kb …   3.27 kb)   3.16 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▃▃▂▁

• Long content between anchors
------------------------------------------- -------------------------------
Looped IndexOf Anchored      459.77 ns/iter 363.04 ns █                    
                      (346.86 ns … 1.13 µs)   1.06 µs █                    
                    (  2.39 kb …   2.82 kb)   2.65 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▄▂

Regex                        521.18 ns/iter 395.31 ns █                    
                      (377.47 ns … 1.63 µs)   1.26 µs █                    
                    (  2.78 kb …   3.08 kb)   2.85 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▂▁

• Large chunks (~200 bytes each, 3 chunks)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.42 µs/iter   1.86 µs █                    
                        (1.14 µs … 2.05 µs)   1.96 µs █                    
                    (  6.34 kb …   6.61 kb)   6.34 kb █▆▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▆█▃▁

Regex                          1.90 µs/iter   2.40 µs █                    
                        (1.45 µs … 2.83 µs)   2.81 µs █             █      
                    (  3.46 kb …   7.57 kb)   7.22 kb █▅▁▁▁▁▁▁▁▁▁▃▃▁█▃▂▁▁▁▂

• Pathological: Repeated prefix cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored      876.68 ns/iter   1.19 µs  █                   
                      (717.89 ns … 1.44 µs)   1.27 µs  █                   
                    (  4.65 kb …   4.91 kb)   4.78 kb ▅█▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▂▆▄▂

Regex                        918.17 ns/iter   1.28 µs █                    
                      (718.27 ns … 1.37 µs)   1.33 µs █                  ▃ 
                    (  5.06 kb …   5.21 kb)   5.20 kb ██▂▁▂▁▁▁▁▁▁▁▁▁▂▂▁▁▄█▂

• Pathological: All-same-char tokens cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.01 µs/iter   1.20 µs ▅█                   
                      (865.26 ns … 1.26 µs)   1.25 µs ██               ▆▆  
                    (  6.44 kb …   6.56 kb)   6.44 kb ██▁▂▁▁▁▁▁▁▁▁▂▁▁▁▁██▂▂

Regex                          1.04 µs/iter   1.28 µs  █                   
                      (876.80 ns … 1.36 µs)   1.33 µs  █                ▆  
                    (  6.13 kb …   6.26 kb)   6.13 kb ██▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▃█▃▂

• Pathological: Repetitive prefix tokens cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.04 µs/iter   1.32 µs █▃                   
                      (849.96 ns … 1.36 µs)   1.36 µs ██                ▂▅ 
                    (  6.11 kb …   6.35 kb)   6.23 kb ██▁▁▁▁▁▁▁▁▁▁▁▁▂▂▁▂██▂

Regex                          1.21 µs/iter   1.52 µs █                    
                      (946.21 ns … 1.66 µs)   1.63 µs █▃               █   
                    (  6.61 kb …   6.74 kb)   6.61 kb ██▁▁▁▁▁▁▁▁▁▁▁▂▂▁▂█▅▂▂

• HTML template with cross-chunk boundaries
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.25 µs/iter   1.56 µs █                    
                        (1.02 µs … 1.98 µs)   1.74 µs █▆             ▇     
                    (  6.59 kb …   6.73 kb)   6.60 kb ██▁▁▁▁▁▁▁▁▁▁▂▁▁██▁▁▁▁

Regex                          1.48 µs/iter   1.83 µs █                    
                        (1.17 µs … 1.94 µs)   1.90 µs █                 ▇  
                    (  6.99 kb …   7.26 kb)   7.25 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁█▅▂

• Markdown with code blocks
------------------------------------------- -------------------------------
Looped IndexOf Anchored      578.07 ns/iter 461.42 ns █                    
                      (448.63 ns … 1.34 µs)   1.23 µs █                    
                    (  2.78 kb …   3.07 kb)   2.97 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▄▂

Regex                        687.93 ns/iter 512.15 ns █                    
                      (487.62 ns … 1.89 µs)   1.55 µs █                    
                    (709.95  b …   3.42 kb)   3.28 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▂▁

• Bash script with $ and braces
------------------------------------------- -------------------------------
Looped IndexOf Anchored      559.46 ns/iter 456.80 ns █                    
                      (440.26 ns … 1.23 µs)   1.19 µs █                    
                    (  2.74 kb …   3.03 kb)   2.94 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▂▁

Regex                        664.55 ns/iter 494.89 ns █                    
                      (476.05 ns … 1.84 µs)   1.49 µs █                    
                    (  3.07 kb …   3.39 kb)   3.27 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▁▁

• EJS template (multiple delimiter types)
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.16 µs/iter   1.32 µs █▃             ▅     
                        (1.01 µs … 1.47 µs)   1.42 µs ██             █     
                    (  7.00 kb …   7.29 kb)   7.14 kb ██▄▂▁▂▁▁▁▁▂▁▂▁▂██▃▂▁▂

Regex                          1.22 µs/iter   1.40 µs █▄               ▄   
                        (1.06 µs … 1.48 µs)   1.45 µs ██               █▅  
                    (  7.15 kb …   7.46 kb)   7.31 kb ██▂▁▁▂▁▁▁▁▁▂▁▁▂▁▁██▃▂

• MediaWiki template (triple braces)
------------------------------------------- -------------------------------
Looped IndexOf Anchored      997.40 ns/iter   1.23 µs █                    
                      (844.14 ns … 1.32 µs)   1.27 µs █▆                ▅  
                    (  6.00 kb …   6.12 kb)   6.12 kb ██▁▁▂▁▁▁▁▁▁▁▁▁▂▂▁▁██▂

Regex                          1.21 µs/iter   1.50 µs █▃                 ▆ 
                      (983.05 ns … 1.55 µs)   1.54 µs ██                 █ 
                    (  6.63 kb …   6.77 kb)   6.64 kb ██▂▁▁▂▁▁▁▁▁▁▁▁▃▁▂▂▅█▃

• XSLT attribute value template
------------------------------------------- -------------------------------
Looped IndexOf Anchored        1.43 µs/iter   1.71 µs  █                   
                        (1.19 µs … 2.14 µs)   1.81 µs ▃█               ▆   
                    (  6.94 kb …   7.49 kb)   7.21 kb ██▂▁▂▁▁▁▁▁▁▁▁▂▂▂▆█▆▁▂

Regex                          1.83 µs/iter   2.18 µs █▃                ▆  
                        (1.43 µs … 2.26 µs)   2.25 µs ██                ██ 
                    (  2.86 kb …   8.19 kb)   8.07 kb ██▁▁▂▁▁▁▁▁▁▃▁▁▂▄▁▂██▄

• Medium tokens (7 chars) - V8 threshold
------------------------------------------- -------------------------------
Looped IndexOf Anchored      534.93 ns/iter 434.03 ns █                    
                      (422.48 ns … 1.20 µs)   1.14 µs █                    
                    (  2.76 kb …   2.92 kb)   2.83 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▄▁

Regex                        601.60 ns/iter 443.44 ns █                    
                      (427.58 ns … 1.52 µs)   1.48 µs █                    
                    (  2.99 kb …   3.15 kb)   3.06 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▁▁

• Long tokens (15 chars) cross-chunk
------------------------------------------- -------------------------------
Looped IndexOf Anchored      979.62 ns/iter   1.28 µs █                    
                      (810.78 ns … 1.71 µs)   1.35 µs █▃                   
                    (  5.44 kb …   5.56 kb)   5.44 kb ██▃▁▁▁▁▁▁▁▁▁▁▂▁▁▁▅█▃▂

Regex                          1.06 µs/iter   1.41 µs █                    
                      (844.04 ns … 1.59 µs)   1.47 µs █                 ▄  
                    (  5.53 kb …   5.66 kb)   5.53 kb █▆▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁█▄▂

• Django/Jinja2 template tags
------------------------------------------- -------------------------------
Looped IndexOf Anchored      770.57 ns/iter 607.31 ns █                    
                      (576.16 ns … 1.59 µs)   1.58 µs █                    
                    (  3.42 kb …   3.58 kb)   3.42 kb █▃▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▄▃▁

Regex                        877.99 ns/iter 964.09 ns █                    
                      (594.76 ns … 1.91 µs)   1.89 µs █                    
                    (  3.88 kb …   4.04 kb)   3.88 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▅▂▂▁

• Empty content between consecutive anchors
------------------------------------------- -------------------------------
Looped IndexOf Anchored      608.03 ns/iter 499.93 ns █                    
                      (486.10 ns … 1.30 µs)   1.22 µs █                    
                    (  2.87 kb …   3.08 kb)   2.95 kb █▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▂▄▁

Regex                        726.65 ns/iter 544.26 ns █                    
                      (510.03 ns … 1.64 µs)   1.60 µs █                    
                    (  3.37 kb …   3.55 kb)   3.42 kb █▃▁▁▁▁▁▁▁▂▁▁▁▂▁▁▁▁▅▂▁

• Single character between patterns
------------------------------------------- -------------------------------
Looped IndexOf Anchored      615.37 ns/iter 508.28 ns █                    
                      (488.43 ns … 1.45 µs)   1.23 µs █                    
                    (  2.95 kb …   3.10 kb)   2.98 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▄▂

Regex                        726.69 ns/iter 559.50 ns █                    
                      (521.97 ns … 1.90 µs)   1.56 µs █                    
                    (  3.23 kb …   3.46 kb)   3.33 kb █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▂▄▂▁

• Asymmetric token lengths
------------------------------------------- -------------------------------
Looped IndexOf Anchored      642.71 ns/iter 531.09 ns █                    
                      (507.43 ns … 1.23 µs)   1.15 µs █                    
                    (  3.46 kb …   3.80 kb)   3.67 kb █▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆▂▁

Regex                        810.21 ns/iter 704.11 ns ▇█                   
                      (640.80 ns … 1.65 µs)   1.32 µs ██                ▂  
                    (  4.00 kb …   4.17 kb)   4.00 kb ██▂▁▁▁▁▁▁▁▁▁▁▂▁▁▁▂█▃▃
✨  Done in 38.08s.
```

</details>

</details>


## Scout rule

- Documentation:
  - Consistent prefix for examples in main README.
  - Fix typo in release process.
  - Remove reference to un-exported `BufferedIndexOfAnchoredSearchStrategy`, linking to benchmarking code within repo instead.
  - Note in regex JSDoc that lookahead support is positive only.
  - Clarify in the benchmarking README that `--experimental-strip-types` is a Node thing.
  - Update a `NOTE` in the main README to be a `CAUTION` and move under the example.
- No longer exporting internal use only types.  Not publicly documented, so not considering this a breaking change.

## Semantic Version Impact

<!-- Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/ -->

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [x] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
