### PR TITLE
[29] Ensure timely flush of buffer after stop replacing abort signal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed minor documentation issues in the README and search strategy docs
 - Fixed the type for the `AsyncReplaceContentTransformer`, this only outputs `string` unlike the sync version which can also output `Promise<string>`
 - Removed `"bun": ">=1.0.0", "deno": ">=1.40.0"` from `package.json` "engines" field, since not valid here
+- Ensured that mid-chunk enacting of the `stopReplacingSignal` causes buffered content to appear in-order, rather than at the end of the stream
 
 ## [1.1.0] - 2026-03-22
 

--- a/src/adapters/node/async-transform.test.ts
+++ b/src/adapters/node/async-transform.test.ts
@@ -27,6 +27,7 @@ describe("ReplaceContentTransform (async)", () => {
 
   it("flush writes flushed content to stream", async () => {
     const mockProcessor = mockAsyncProcessorFactory();
+    mockProcessor.flush.mockReturnValue("<FLUSHED>");
 
     const transform = new AsyncReplaceContentTransform(mockProcessor);
     const outputs: string[] = [];

--- a/src/adapters/node/sync-transform.test.ts
+++ b/src/adapters/node/sync-transform.test.ts
@@ -27,6 +27,7 @@ describe("ReplaceContentTransform (sync)", () => {
 
   it("flush writes flushed content to stream", () => {
     const mockProcessor = mockSyncProcessorFactory();
+    mockProcessor.flush.mockReturnValue("<FLUSHED>");
 
     const transform = new ReplaceContentTransform(mockProcessor);
     const outputs: string[] = [];

--- a/src/adapters/web/async-transformer.integration.test.ts
+++ b/src/adapters/web/async-transformer.integration.test.ts
@@ -106,7 +106,7 @@ describe("AsyncReplaceContentTransformer + AsyncIterableFunctionReplacementProce
       new TransformStream(transformer)
     );
 
-    expect(text(transformedStream)).resolves.toEqual(
+    await expect(text(transformedStream)).resolves.toEqual(
       `<div>Operation Cancelled</div><div><esi:include src="https://example.com/some-not-attempted-fragment" /></div>`
     );
   });

--- a/src/adapters/web/async-transformer.integration.test.ts
+++ b/src/adapters/web/async-transformer.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { AsyncIterableFunctionReplacementProcessor } from "../../replacement-processors/async-iterable-function-replacement-processor.ts";
 import { AsyncReplaceContentTransformer } from "./async-transformer.ts";
 import { http, HttpResponse } from "msw";
@@ -7,6 +7,60 @@ import { text } from "node:stream/consumers";
 import { StringAnchorSearchStrategy } from "../../search-strategies/index.ts";
 
 describe("AsyncReplaceContentTransformer + AsyncIterableFunctionReplacementProcessor + StringAnchorSearchStrategy", () => {
+  it("passes through new chunks after abort set between chunks when no buffered remainder exists", async () => {
+    const abortController = new AbortController();
+    const replacement = (match: string) => match.toUpperCase();
+    const transformer = new AsyncReplaceContentTransformer(
+      new AsyncIterableFunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{", "}}"]),
+        replacement: async (match: string) => {
+          return (async function* () {
+            yield replacement(match);
+          })();
+        }
+      }),
+      abortController.signal
+    );
+
+    const stream = new TransformStream(transformer);
+    const writer = stream.writable.getWriter();
+    const outputPromise = text(stream.readable);
+
+    await writer.write("plain ");
+    abortController.abort();
+    await writer.write("text");
+    await writer.close();
+
+    await expect(outputPromise).resolves.toBe("plain text");
+  });
+
+  it("flushes buffered partial content before passthrough when abort is set between chunks", async () => {
+    const abortController = new AbortController();
+    const replacement = (match: string) => match.toUpperCase();
+    const transformer = new AsyncReplaceContentTransformer(
+      new AsyncIterableFunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{", "}}"]),
+        replacement: async (match: string) => {
+          return (async function* () {
+            yield replacement(match);
+          })();
+        }
+      }),
+      abortController.signal
+    );
+
+    const stream = new TransformStream(transformer);
+    const writer = stream.writable.getWriter();
+    const outputPromise = text(stream.readable);
+
+    await writer.write("{{a");
+    abortController.abort();
+    await writer.write("}} next");
+    await writer.close();
+
+    await expect(outputPromise).resolves.toBe("{{a}} next");
+  });
+
   it("should support streaming ReadableStream into the output", async () => {
     const fragmentUrl = "https://example.com/fragment";
     server.use(

--- a/src/adapters/web/async-transformer.integration.test.ts
+++ b/src/adapters/web/async-transformer.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { AsyncIterableFunctionReplacementProcessor } from "../../replacement-processors/async-iterable-function-replacement-processor.ts";
 import { AsyncReplaceContentTransformer } from "./async-transformer.ts";
 import { http, HttpResponse } from "msw";
@@ -106,10 +106,75 @@ describe("AsyncReplaceContentTransformer + AsyncIterableFunctionReplacementProce
       new TransformStream(transformer)
     );
 
-    const resultPromise = text(transformedStream);
-
-    await expect(resultPromise).resolves.toEqual(
+    expect(text(transformedStream)).resolves.toEqual(
       `<div>Operation Cancelled</div><div><esi:include src="https://example.com/some-not-attempted-fragment" /></div>`
     );
+  });
+
+  it("flushes the unprocessed remainder of a chunk when abort is signaled mid-transform", async () => {
+    const abortController = new AbortController();
+    const transformer = new AsyncReplaceContentTransformer(
+      new AsyncIterableFunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{x}}"]),
+        replacement: async () => {
+          abortController.abort();
+          return (async function* () {
+            yield "REPLACED";
+          })();
+        }
+      }),
+      abortController.signal
+    );
+
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("{{x}}-tail"));
+        controller.enqueue(encoder.encode(" next"));
+        controller.close();
+      }
+    });
+
+    const transformed = readable
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TransformStream(transformer));
+
+    await expect(text(transformed)).resolves.toBe("REPLACED-tail next");
+  });
+
+  it("stops discovering additional matches in the current chunk after mid-transform abort", async () => {
+    const abortController = new AbortController();
+    const replacement = vi
+      .fn()
+      .mockImplementation((match: string) => match.toUpperCase());
+
+    const transformer = new AsyncReplaceContentTransformer(
+      new AsyncIterableFunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{", "}}"]),
+        replacement: async (match: string) => {
+          abortController.abort();
+          return (async function* () {
+            yield replacement(match);
+          })();
+        }
+      }),
+      abortController.signal
+    );
+
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("{{a}}{{b}}{{c}}"));
+        controller.enqueue(encoder.encode(" next"));
+        controller.close();
+      }
+    });
+
+    const transformed = readable
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TransformStream(transformer));
+
+    await expect(text(transformed)).resolves.toBe("{{A}}{{b}}{{c}} next");
+    expect(replacement).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/adapters/web/async-transformer.test.ts
+++ b/src/adapters/web/async-transformer.test.ts
@@ -37,7 +37,7 @@ describe("AsyncReplaceContentTransformer", () => {
     expect(mockProcessor.processChunk).not.toHaveBeenCalled();
   });
 
-  it("stops processing mid-transformation when abort signal is set", async () => {
+  it("stops processing mid-transformation when abort signal is set, and flushes remaining content", async () => {
     const abortController = new AbortController();
     const mockProcessor = mockAsyncProcessorFactory(() => {
       abortController.abort();
@@ -52,9 +52,9 @@ describe("AsyncReplaceContentTransformer", () => {
 
     await transformer.transform("input", controller);
 
-    expect(outputs).toContain("PART1");
-    expect(outputs).not.toContain("PART2");
+    expect(outputs).toEqual(["PART1", "<FLUSHED>"]);
     expect(mockProcessor.processChunk).toHaveBeenCalledWith("input");
+    expect(mockProcessor.flush).toHaveBeenCalledTimes(1);
   });
 
   it("enqueues content when flush is called", () => {

--- a/src/adapters/web/async-transformer.test.ts
+++ b/src/adapters/web/async-transformer.test.ts
@@ -43,6 +43,7 @@ describe("AsyncReplaceContentTransformer", () => {
       abortController.abort();
       return "PART1";
     }, "PART2");
+    mockProcessor.flush.mockReturnValue("<FLUSHED>");
     const transformer = new AsyncReplaceContentTransformer(
       mockProcessor,
       abortController.signal
@@ -57,8 +58,29 @@ describe("AsyncReplaceContentTransformer", () => {
     expect(mockProcessor.flush).toHaveBeenCalledTimes(1);
   });
 
+  it("flushes at most once after abort across multiple subsequent chunks", async () => {
+    const mockProcessor = mockAsyncProcessorFactory("OUT");
+    const abortController = new AbortController();
+    const transformer = new AsyncReplaceContentTransformer(
+      mockProcessor,
+      abortController.signal
+    );
+    const outputs: string[] = [];
+    const controller = mockTransformStreamDefaultControllerFactory(outputs);
+    mockProcessor.flush.mockReturnValue("");
+
+    abortController.abort();
+    await transformer.transform("first", controller);
+    await transformer.transform("second", controller);
+
+    expect(outputs).toEqual(["first", "second"]);
+    expect(mockProcessor.processChunk).not.toHaveBeenCalled();
+    expect(mockProcessor.flush).toHaveBeenCalledTimes(1);
+  });
+
   it("enqueues content when flush is called", () => {
     const mockProcessor = mockAsyncProcessorFactory();
+    mockProcessor.flush.mockReturnValue("<FLUSHED>");
 
     const transformer = new AsyncReplaceContentTransformer(mockProcessor);
     const outputs: string[] = [];

--- a/src/adapters/web/async-transformer.ts
+++ b/src/adapters/web/async-transformer.ts
@@ -40,6 +40,18 @@ export class AsyncReplaceContentTransformer
   protected processor: AsyncProcessor;
   #stopReplacingSignal?: AbortSignal;
   #cancelled = false;
+  #didFlushAfterAbort = false;
+
+  #flushAfterAbortIfNeeded(
+    controller: TransformStreamDefaultController<string>
+  ) {
+    if (this.#didFlushAfterAbort || !this.#stopReplacingSignal?.aborted) {
+      return;
+    }
+
+    this.#didFlushAfterAbort = true;
+    this.flush(controller);
+  }
 
   constructor(processor: AsyncProcessor, stopReplacingSignal?: AbortSignal) {
     super();
@@ -56,6 +68,7 @@ export class AsyncReplaceContentTransformer
     }
 
     if (this.#stopReplacingSignal?.aborted) {
+      this.#flushAfterAbortIfNeeded(controller);
       controller.enqueue(chunk);
       return;
     }
@@ -70,9 +83,7 @@ export class AsyncReplaceContentTransformer
       }
     }
 
-    if (this.#stopReplacingSignal?.aborted) {
-      this.flush(controller);
-    }
+    this.#flushAfterAbortIfNeeded(controller);
   }
 
   /**

--- a/src/adapters/web/async-transformer.ts
+++ b/src/adapters/web/async-transformer.ts
@@ -69,6 +69,10 @@ export class AsyncReplaceContentTransformer
         break;
       }
     }
+
+    if (this.#stopReplacingSignal?.aborted) {
+      this.flush(controller);
+    }
   }
 
   /**

--- a/src/adapters/web/sync-transformer.integration.test.ts
+++ b/src/adapters/web/sync-transformer.integration.test.ts
@@ -1,10 +1,56 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { text } from "node:stream/consumers";
 import { ReplaceContentTransformer } from "./sync-transformer.ts";
 import { FunctionReplacementProcessor } from "../../replacement-processors/function-replacement-processor.ts";
 import { StringAnchorSearchStrategy } from "../../search-strategies/index.ts";
 
 describe("ReplaceContentTransformer + StringAnchorSearchStrategy + stopReplacingSignal", () => {
+  it("passes through new chunks after abort set between chunks when no buffered remainder exists", async () => {
+    const abortController = new AbortController();
+    const replacement = (match: string) => match.toUpperCase();
+    const transformer = new ReplaceContentTransformer(
+      new FunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{", "}}"]),
+        replacement
+      }),
+      abortController.signal
+    );
+
+    const stream = new TransformStream(transformer);
+    const writer = stream.writable.getWriter();
+    const outputPromise = text(stream.readable);
+
+    await writer.write("plain ");
+    abortController.abort();
+    await writer.write("text");
+    await writer.close();
+
+    await expect(outputPromise).resolves.toBe("plain text");
+  });
+
+  it("flushes buffered partial content before passthrough when abort is set between chunks", async () => {
+    const abortController = new AbortController();
+    const replacement = (match: string) => match.toUpperCase();
+    const transformer = new ReplaceContentTransformer(
+      new FunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{", "}}"]),
+        replacement
+      }),
+      abortController.signal
+    );
+
+    const stream = new TransformStream(transformer);
+    const writer = stream.writable.getWriter();
+    const outputPromise = text(stream.readable);
+
+    await writer.write("{{a");
+    abortController.abort();
+    await writer.write("}} next");
+    await writer.close();
+
+    await expect(outputPromise).resolves.toBe("{{a}} next");
+  });
+
   it("flushes the unprocessed remainder of a chunk when abort is signaled mid-transform", async () => {
     const abortController = new AbortController();
     const transformer = new ReplaceContentTransformer(

--- a/src/adapters/web/sync-transformer.integration.test.ts
+++ b/src/adapters/web/sync-transformer.integration.test.ts
@@ -1,7 +1,73 @@
 import { describe, it, expect, vi } from "vitest";
+import { text } from "node:stream/consumers";
 import { ReplaceContentTransformer } from "./sync-transformer.ts";
 import { FunctionReplacementProcessor } from "../../replacement-processors/function-replacement-processor.ts";
 import { StringAnchorSearchStrategy } from "../../search-strategies/index.ts";
+
+describe("ReplaceContentTransformer + StringAnchorSearchStrategy + stopReplacingSignal", () => {
+  it("flushes the unprocessed remainder of a chunk when abort is signaled mid-transform", async () => {
+    const abortController = new AbortController();
+    const transformer = new ReplaceContentTransformer(
+      new FunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{x}}"]),
+        replacement: () => {
+          abortController.abort();
+          return "REPLACED";
+        }
+      }),
+      abortController.signal
+    );
+
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("{{x}}-tail"));
+        controller.enqueue(encoder.encode(" next"));
+        controller.close();
+      }
+    });
+
+    const transformed = readable
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TransformStream(transformer));
+
+    await expect(text(transformed)).resolves.toBe("REPLACED-tail next");
+  });
+
+  it("stops discovering additional matches in the current chunk after mid-transform abort", async () => {
+    const abortController = new AbortController();
+    const replacement = vi
+      .fn()
+      .mockImplementation((match: string) => {
+        abortController.abort();
+        return match.toUpperCase();
+      });
+
+    const transformer = new ReplaceContentTransformer(
+      new FunctionReplacementProcessor({
+        searchStrategy: new StringAnchorSearchStrategy(["{{", "}}"]),
+        replacement
+      }),
+      abortController.signal
+    );
+
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode("{{a}}{{b}}{{c}}"));
+        controller.enqueue(encoder.encode(" next"));
+        controller.close();
+      }
+    });
+
+    const transformed = readable
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TransformStream(transformer));
+
+    await expect(text(transformed)).resolves.toBe("{{A}}{{b}}{{c}} next");
+    expect(replacement).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("ReplaceContentTransformer + StringAnchorSearchStrategy + Promise-returning FunctionReplacementProcessor", () => {
   it("should handle promises returned by replacement function", async () => {

--- a/src/adapters/web/sync-transformer.test.ts
+++ b/src/adapters/web/sync-transformer.test.ts
@@ -42,6 +42,7 @@ describe("ReplaceContentTransformer (sync)", () => {
       abortController.abort();
       return "PART1";
     }, "PART2");
+    mockProcessor.flush.mockReturnValue("<FLUSHED>");
     const transformer = new ReplaceContentTransformer(
       mockProcessor,
       abortController.signal
@@ -56,12 +57,32 @@ describe("ReplaceContentTransformer (sync)", () => {
     expect(mockProcessor.flush).toHaveBeenCalledTimes(1);
   });
 
+  it.skip("flushes at most once after abort across multiple subsequent chunks", () => {
+    const mockProcessor = mockSyncProcessorFactory("OUT");
+    const abortController = new AbortController();
+    const transformer = new ReplaceContentTransformer(
+      mockProcessor,
+      abortController.signal
+    );
+    const outputs: string[] = [];
+    const controller = mockTransformStreamDefaultControllerFactory(outputs);
+
+    abortController.abort();
+    transformer.transform("first", controller);
+    transformer.transform("second", controller);
+    transformer.transform("third", controller);
+
+    expect(outputs).toEqual(["first", "second", "third"]);
+    expect(mockProcessor.processChunk).not.toHaveBeenCalled();
+  });
+
   it("flush enqueues flushed content", () => {
     const mockProcessor = mockSyncProcessorFactory();
 
     const transformer = new ReplaceContentTransformer(mockProcessor);
     const outputs: string[] = [];
     const controller = mockTransformStreamDefaultControllerFactory(outputs);
+    mockProcessor.flush.mockReturnValue("<FLUSHED>");
 
     transformer.flush(controller);
 

--- a/src/adapters/web/sync-transformer.test.ts
+++ b/src/adapters/web/sync-transformer.test.ts
@@ -36,7 +36,7 @@ describe("ReplaceContentTransformer (sync)", () => {
     expect(mockProcessor.processChunk).not.toHaveBeenCalled();
   });
 
-  it("stops processing mid-transformation when abort signal is set", () => {
+  it("stops processing mid-transformation when abort signal is set, and flushes remaining content", () => {
     const abortController = new AbortController();
     const mockProcessor = mockSyncProcessorFactory(() => {
       abortController.abort();
@@ -51,9 +51,9 @@ describe("ReplaceContentTransformer (sync)", () => {
 
     transformer.transform("input", controller);
 
-    expect(outputs).toContain("PART1");
-    expect(outputs).not.toContain("PART2");
+    expect(outputs).toEqual(["PART1", "<FLUSHED>"]);
     expect(mockProcessor.processChunk).toHaveBeenCalledWith("input");
+    expect(mockProcessor.flush).toHaveBeenCalledTimes(1);
   });
 
   it("flush enqueues flushed content", () => {

--- a/src/adapters/web/sync-transformer.test.ts
+++ b/src/adapters/web/sync-transformer.test.ts
@@ -57,7 +57,7 @@ describe("ReplaceContentTransformer (sync)", () => {
     expect(mockProcessor.flush).toHaveBeenCalledTimes(1);
   });
 
-  it.skip("flushes at most once after abort across multiple subsequent chunks", () => {
+  it("flushes at most once after abort across multiple subsequent chunks", () => {
     const mockProcessor = mockSyncProcessorFactory("OUT");
     const abortController = new AbortController();
     const transformer = new ReplaceContentTransformer(
@@ -70,9 +70,8 @@ describe("ReplaceContentTransformer (sync)", () => {
     abortController.abort();
     transformer.transform("first", controller);
     transformer.transform("second", controller);
-    transformer.transform("third", controller);
 
-    expect(outputs).toEqual(["first", "second", "third"]);
+    expect(outputs).toEqual(["first", "second"]);
     expect(mockProcessor.processChunk).not.toHaveBeenCalled();
   });
 

--- a/src/adapters/web/sync-transformer.ts
+++ b/src/adapters/web/sync-transformer.ts
@@ -52,5 +52,9 @@ export class ReplaceContentTransformer<
         break;
       }
     }
+
+    if (this.#stopReplacingSignal?.aborted) {
+      this.flush(controller);
+    }
   }
 }

--- a/src/adapters/web/sync-transformer.ts
+++ b/src/adapters/web/sync-transformer.ts
@@ -29,6 +29,18 @@ export class ReplaceContentTransformer<
 > extends ReplaceContentTransformerBase<T> {
   protected processor: SyncProcessor<T>;
   #stopReplacingSignal?: AbortSignal;
+  #didFlushAfterAbort = false;
+
+  #flushAfterAbortIfNeeded(
+    controller: TransformStreamDefaultController<T | string>
+  ) {
+    if (this.#didFlushAfterAbort || !this.#stopReplacingSignal?.aborted) {
+      return;
+    }
+
+    this.#didFlushAfterAbort = true;
+    this.flush(controller);
+  }
 
   constructor(processor: SyncProcessor<T>, stopReplacingSignal?: AbortSignal) {
     super();
@@ -41,6 +53,7 @@ export class ReplaceContentTransformer<
     controller: TransformStreamDefaultController<T | string>
   ) {
     if (this.#stopReplacingSignal?.aborted) {
+      this.#flushAfterAbortIfNeeded(controller);
       controller.enqueue(chunk);
       return;
     }
@@ -53,8 +66,6 @@ export class ReplaceContentTransformer<
       }
     }
 
-    if (this.#stopReplacingSignal?.aborted) {
-      this.flush(controller);
-    }
+    this.#flushAfterAbortIfNeeded(controller);
   }
 }

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -38,7 +38,7 @@ function mockSyncProcessorFactory<T extends string | Promise<string> = string>(.
         yield chunk;
       }
     }),
-    flush: vi.fn().mockReturnValue("<FLUSHED>")
+    flush: vi.fn().mockReturnValue("")
   };
 }
 
@@ -53,7 +53,7 @@ function mockAsyncProcessorFactory(...output: (string | (() => string))[]) {
         yield chunk;
       }
     }),
-    flush: vi.fn().mockReturnValue("<FLUSHED>")
+    flush: vi.fn().mockReturnValue("")
   };
 }
 


### PR DESCRIPTION
## Issue

resolves #29 

## Details

- Ensured that a `stopReplacingSignal`, when enacted mid-chunk, flushes any remainder of a chunk into the output before neutering the replacement processor, thus preventing buffered chunk tails from hanging around till the end of the stream, and being injected out-of-order.
- Also ensured a signal fired between chunks flushes any buffer before passing through the next chunk.

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
