### PR TITLE
[NO ISSUE] Replacement context

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ const transformer = new ReplaceContentTransformer(
     searchStrategy: searchStrategyFactory(
       /class="(?<before>[^"]*?\b)old-button(?<after>\b[^"]*?)"/
     ),
-    replacement: (match: RegExpExecArray, _context) => {
+    replacement: (match: RegExpExecArray) => {
       const { before, after } = match.groups;
       return `class="${before}new-button${after}"`;
     }
@@ -208,7 +208,7 @@ import { fileURLToPath } from "node:url";
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncFunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["<img", 'src="file://', '.png">']),
-    replacement: async (imgTag: string, _context) =>
+    replacement: async (imgTag: string) =>
       `<img src="data:image/png;base64,${(
         await fs.readFile(
           path.join(
@@ -239,7 +239,7 @@ const transformer = new ReplaceContentTransformer<Promise<string>>(
       'rel="stylesheet"',
       "/>"
     ]),
-    replacement: async (match: string, _context): Promise<string> => {
+    replacement: async (match: string): Promise<string> => {
       const {
         groups: { url }
       } = /href="(?<url>[^"]+)"/.exec(match)!;
@@ -256,7 +256,7 @@ const transformer = new ReplaceContentTransformer<Promise<string>>(
 ```typescript
 const maxConcurrent = 5;
 const active = new Set<Promise<string>>();
-const replacement = async (match: string, _context): Promise<string> => {
+const replacement = async (match: string): Promise<string> => {
   if (active.size >= maxConcurrent) {
     await Promise.race(active);
   }
@@ -281,7 +281,7 @@ import { IterableFunctionReplacementProcessor } from "replace-content-transforme
 const transformer = new ReplaceContentTransformer(
   new IterableFunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory("3 "),
-    replacement: (_match, _context) => [...Array(3)].map((_, i) => `3.${i + 1} `)
+    replacement: (_match) => [...Array(3)].map((_, i) => `3.${i + 1} `)
   })
 );
 ```
@@ -297,7 +297,7 @@ import { AsyncIterableFunctionReplacementProcessor } from "replace-content-trans
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncIterableFunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["<esi:include", "/>"]),
-    replacement: async (match: string, _context) => {
+    replacement: async (match: string) => {
       const {
         groups: { url }
       } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -319,7 +319,7 @@ function transformerFactory(currentDepth: number) {
   return new AsyncReplaceContentTransformer(
     new AsyncIterableFunctionReplacementProcessor({
       searchStrategy,
-      replacement: async (match: string, _context) => {
+      replacement: async (match: string) => {
         const {
           groups: { url }
         } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -373,7 +373,7 @@ const abortController = new AbortController();
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncIterableFunctionReplacementProcessor({
     searchStrategy: new StringAnchorSearchStrategy(["<esi:include", ">"]),
-    replacement: async (match, _context) => {
+    replacement: async (match) => {
       const {
         groups: { url }
       } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -417,7 +417,7 @@ function transformFactory(currentDepth: number) {
   return new AsyncReplaceContentTransform(
     new AsyncIterableFunctionReplacementProcessor({
       searchStrategy,
-      replacement: async (match: string, _context) => {
+      replacement: async (match: string) => {
         const {
           groups: { url }
         } = /src="(?<url>[^"]+)"/.exec(match)!;

--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ import { FunctionReplacementProcessor } from "replace-content-transformer";
 const transformer = new ReplaceContentTransformer(
   new FunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["{{", "}}"]),
-    replacement: (match: string, matchIndex: number) =>
+    replacement: (
+      match: string,
+      { matchIndex }: { matchIndex: number }
+    ) =>
       `${match.slice(2, -2)} was match ${matchIndex}`
   })
 );
@@ -151,7 +154,14 @@ Access the character indices of the match, relative to the start of the stream:
 const transformer = new ReplaceContentTransformer(
   new FunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["{{", "}}"]),
-    replacement: (match: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) =>
+    replacement: (
+      match: string,
+      {
+        streamIndices
+      }: {
+        streamIndices: [startIndex: number, endIndex: number];
+      }
+    ) =>
       `${match.slice(2, -2)}, found from ${streamIndices[0]} to ${streamIndices[1]}`
   })
 );
@@ -173,7 +183,7 @@ const transformer = new ReplaceContentTransformer(
     searchStrategy: searchStrategyFactory(
       /class="(?<before>[^"]*?\b)old-button(?<after>\b[^"]*?)"/
     ),
-    replacement: (match: RegExpExecArray) => {
+    replacement: (match: RegExpExecArray, _context) => {
       const { before, after } = match.groups;
       return `class="${before}new-button${after}"`;
     }
@@ -198,7 +208,7 @@ import { fileURLToPath } from "node:url";
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncFunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["<img", 'src="file://', '.png">']),
-    replacement: async (imgTag: string) =>
+    replacement: async (imgTag: string, _context) =>
       `<img src="data:image/png;base64,${(
         await fs.readFile(
           path.join(
@@ -229,7 +239,7 @@ const transformer = new ReplaceContentTransformer<Promise<string>>(
       'rel="stylesheet"',
       "/>"
     ]),
-    replacement: async (match: string): Promise<string> => {
+    replacement: async (match: string, _context): Promise<string> => {
       const {
         groups: { url }
       } = /href="(?<url>[^"]+)"/.exec(match)!;
@@ -246,7 +256,7 @@ const transformer = new ReplaceContentTransformer<Promise<string>>(
 ```typescript
 const maxConcurrent = 5;
 const active = new Set<Promise<string>>();
-const replacement = async (match: string): Promise<string> => {
+const replacement = async (match: string, _context): Promise<string> => {
   if (active.size >= maxConcurrent) {
     await Promise.race(active);
   }
@@ -271,7 +281,7 @@ import { IterableFunctionReplacementProcessor } from "replace-content-transforme
 const transformer = new ReplaceContentTransformer(
   new IterableFunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory("3 "),
-    replacement: () => [...Array(3)].map((_, i) => `3.${i + 1} `)
+    replacement: (_match, _context) => [...Array(3)].map((_, i) => `3.${i + 1} `)
   })
 );
 ```
@@ -287,7 +297,7 @@ import { AsyncIterableFunctionReplacementProcessor } from "replace-content-trans
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncIterableFunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory(["<esi:include", "/>"]),
-    replacement: async (match: string) => {
+    replacement: async (match: string, _context) => {
       const {
         groups: { url }
       } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -309,7 +319,7 @@ function transformerFactory(currentDepth: number) {
   return new AsyncReplaceContentTransformer(
     new AsyncIterableFunctionReplacementProcessor({
       searchStrategy,
-      replacement: async (match: string) => {
+      replacement: async (match: string, _context) => {
         const {
           groups: { url }
         } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -337,7 +347,7 @@ const abortController = new AbortController();
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncIterableFunctionReplacementProcessor({
     searchStrategy: new StringAnchorSearchStrategy(["<esi:include", ">"]),
-    replacement: async (match, matchIndex) => {
+    replacement: async (match, { matchIndex }) => {
       const {
         groups: { url }
       } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -363,7 +373,7 @@ const abortController = new AbortController();
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncIterableFunctionReplacementProcessor({
     searchStrategy: new StringAnchorSearchStrategy(["<esi:include", ">"]),
-    replacement: async (match) => {
+    replacement: async (match, _context) => {
       const {
         groups: { url }
       } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -407,7 +417,7 @@ function transformFactory(currentDepth: number) {
   return new AsyncReplaceContentTransform(
     new AsyncIterableFunctionReplacementProcessor({
       searchStrategy,
-      replacement: async (match: string) => {
+      replacement: async (match: string, _context) => {
         const {
           groups: { url }
         } = /src="(?<url>[^"]+)"/.exec(match)!;
@@ -532,7 +542,7 @@ flush(): string {
 There are 5 stream processors to select from, rather than the system figuring out the optimum based on supplied options. See [Replacement Processors](./src/replacement-processors/README.md) for detailed usage guidance.
 
 - **`StaticReplacementProcessor`** - Yields static strings
-- **`FunctionReplacementProcessor`** - Yields function results, passing the match and a match index / sequence number
+- **`FunctionReplacementProcessor`** - Yields function results, passing match as first parameter and context object `{ matchIndex, streamIndices }` as second parameter
 - **`IterableFunctionReplacementProcessor`** - Allows a function to return an iterable, flattened with [`yield*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield*)
 - **`AsyncFunctionReplacementProcessor`** - Allows an async function, as an async generators with [`for await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)
 - **`AsyncIterableFunctionReplacementProcessor`** - Flattens async iterables with `yield* await` (assumption that async iterator is itself accessed via a Promise)

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ There are 5 stream processors to select from, rather than the system figuring ou
 - **`FunctionReplacementProcessor`** - Yields function results, passing match as first parameter and context object `{ matchIndex, streamIndices }` as second parameter
 - **`IterableFunctionReplacementProcessor`** - Allows a function to return an iterable, flattened with [`yield*`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield*)
 - **`AsyncFunctionReplacementProcessor`** - Allows an async function, as an async generators with [`for await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)
-- **`AsyncIterableFunctionReplacementProcessor`** - Flattens async iterables with `yield* await` (assumption that async iterator is itself accessed via a Promise)
+- **`AsyncIterableFunctionReplacementProcessor`** - Flattens async iterable replacements, either via a `Promise` or functions that return an `AsyncIterable<string>` directly
 
 There is no reliable way in javascript to detect the output type of a function without calling it, and trying to adapt just-in-time based on the first replacement made would be complex. The type of function can be thought to have a ["colour"](https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/#what-color-is-your-function) that requires up-front selection.
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,11 @@ const transformer = new ReplaceContentTransformer(
 
 Interpolate [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)s, or other async iterables, into the output. Ensures each async operation completes before the next starts:
 
+You can return either form:
+
+- an async iterable directly (for example `async function*`)
+- a `Promise<AsyncIterable<string>>` (for example an `async` function returning a stream)
+
 ```typescript
 import { AsyncIterableFunctionReplacementProcessor } from "replace-content-transformer";
 
@@ -303,6 +308,17 @@ const transformer = new AsyncReplaceContentTransformer(
       } = /src="(?<url>[^"]+)"/.exec(match)!;
       const res = await fetch(url);
       return res.body!.pipeThrough(new TextDecoderStream());
+    }
+  })
+);
+
+// direct async iterable form
+const transformerWithGenerator = new AsyncReplaceContentTransformer(
+  new AsyncIterableFunctionReplacementProcessor({
+    searchStrategy: searchStrategyFactory("{{needle}}"),
+    replacement: async function* () {
+      yield "first chunk";
+      yield "second chunk";
     }
   })
 );

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ import { IterableFunctionReplacementProcessor } from "replace-content-transforme
 const transformer = new ReplaceContentTransformer(
   new IterableFunctionReplacementProcessor({
     searchStrategy: searchStrategyFactory("3 "),
-    replacement: (_match) => [...Array(3)].map((_, i) => `3.${i + 1} `)
+    replacement: () => [...Array(3)].map((_, i) => `3.${i + 1} `)
   })
 );
 ```

--- a/build.js
+++ b/build.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { execSync } from "child_process";
+import { rmSync, renameSync } from "fs";
+import { readdirSync } from "fs";
+import { join } from "path";
+
+// Clean output
+rmSync("lib", { recursive: true, force: true });
+
+// Build ESM with tsc
+console.log("Building ESM...");
+execSync("npx tsc -p tsconfig.build.json", { stdio: "inherit" });
+
+// Build CJS with tsc (to lib-cjs temporarily)
+console.log("Building CJS...");
+execSync("npx tsc -p tsconfig.build.cjs.json --outDir lib-cjs", {
+  stdio: "inherit",
+});
+
+// Rename .js to .cjs and .d.ts to .d.cts in lib-cjs recursively
+function renameFiles(dir) {
+  const files = readdirSync(dir, { withFileTypes: true });
+  for (const file of files) {
+    const fullPath = join(dir, file.name);
+    if (file.isDirectory()) {
+      renameFiles(fullPath);
+    } else if (file.name.endsWith(".js")) {
+      const newPath = fullPath.replace(/\.js$/, ".cjs");
+      renameSync(fullPath, newPath);
+    } else if (file.name.endsWith(".d.ts")) {
+      const newPath = fullPath.replace(/\.d\.ts$/, ".d.cts");
+      renameSync(fullPath, newPath);
+    }
+  }
+}
+
+renameFiles("lib-cjs");
+
+// Merge lib-cjs into lib
+execSync("cp -r lib-cjs/* lib/", { stdio: "inherit" });
+
+// Cleanup
+rmSync("lib-cjs", { recursive: true, force: true });
+
+console.log("Build complete: ESM (.js, .d.ts) and CJS (.cjs, .d.cts) in lib/");

--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from "child_process";
-import { cpSync, readdirSync, renameSync, rmSync } from "fs";
+import { readdirSync, renameSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 
 // Clean output
@@ -11,35 +11,26 @@ rmSync("lib", { recursive: true, force: true });
 console.log("Building ESM...");
 execSync("npx tsc -p tsconfig.build.json", { stdio: "inherit" });
 
-// Build CJS with tsc (to lib-cjs temporarily)
+// Build CJS with tsc
 console.log("Building CJS...");
-execSync("npx tsc -p tsconfig.build.cjs.json --outDir lib-cjs", {
-  stdio: "inherit",
-});
+execSync("npx tsc -p tsconfig.build.cjs.json", { stdio: "inherit" });
 
-// Rename .js to .cjs and .d.ts to .d.cts in lib-cjs recursively
-function renameFiles(dir) {
+// Mark lib/cjs as CommonJS so Node resolves .js files as CJS
+writeFileSync("lib/cjs/package.json", JSON.stringify({ type: "commonjs" }, null, 2) + "\n");
+
+// Rename .d.ts to .d.cts in lib/cjs recursively (for TypeScript CJS consumers)
+function renameDts(dir) {
   const files = readdirSync(dir, { withFileTypes: true });
   for (const file of files) {
     const fullPath = join(dir, file.name);
     if (file.isDirectory()) {
-      renameFiles(fullPath);
-    } else if (file.name.endsWith(".js")) {
-      const newPath = fullPath.replace(/\.js$/, ".cjs");
-      renameSync(fullPath, newPath);
+      renameDts(fullPath);
     } else if (file.name.endsWith(".d.ts")) {
-      const newPath = fullPath.replace(/\.d\.ts$/, ".d.cts");
-      renameSync(fullPath, newPath);
+      renameSync(fullPath, fullPath.replace(/\.d\.ts$/, ".d.cts"));
     }
   }
 }
 
-renameFiles("lib-cjs");
+renameDts("lib/cjs");
 
-// Merge lib-cjs into lib
-cpSync("lib-cjs", "lib", { recursive: true });
-
-// Cleanup
-rmSync("lib-cjs", { recursive: true, force: true });
-
-console.log("Build complete: ESM (.js, .d.ts) and CJS (.cjs, .d.cts) in lib/");
+console.log("Build complete: ESM in lib/esm/ (.js, .d.ts), CJS in lib/cjs/ (.js, .d.cts)");

--- a/build.js
+++ b/build.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from "child_process";
-import { readdirSync, renameSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
+import { rmSync, writeFileSync } from "fs";
 
 // Clean output
 rmSync("lib", { recursive: true, force: true });
@@ -18,19 +17,4 @@ execSync("npx tsc -p tsconfig.build.cjs.json", { stdio: "inherit" });
 // Mark lib/cjs as CommonJS so Node resolves .js files as CJS
 writeFileSync("lib/cjs/package.json", JSON.stringify({ type: "commonjs" }, null, 2) + "\n");
 
-// Rename .d.ts to .d.cts in lib/cjs recursively (for TypeScript CJS consumers)
-function renameDts(dir) {
-  const files = readdirSync(dir, { withFileTypes: true });
-  for (const file of files) {
-    const fullPath = join(dir, file.name);
-    if (file.isDirectory()) {
-      renameDts(fullPath);
-    } else if (file.name.endsWith(".d.ts")) {
-      renameSync(fullPath, fullPath.replace(/\.d\.ts$/, ".d.cts"));
-    }
-  }
-}
-
-renameDts("lib/cjs");
-
-console.log("Build complete: ESM in lib/esm/ (.js, .d.ts), CJS in lib/cjs/ (.js, .d.cts)");
+console.log("Build complete: ESM in lib/esm/ (.js, .d.ts), CJS in lib/cjs/ (.js, .d.ts)");

--- a/build.js
+++ b/build.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from "child_process";
-import { rmSync, renameSync } from "fs";
-import { readdirSync } from "fs";
+import { cpSync, readdirSync, renameSync, rmSync } from "fs";
 import { join } from "path";
 
 // Clean output
@@ -38,7 +37,7 @@ function renameFiles(dir) {
 renameFiles("lib-cjs");
 
 // Merge lib-cjs into lib
-execSync("cp -r lib-cjs/* lib/", { stdio: "inherit" });
+cpSync("lib-cjs", "lib", { recursive: true });
 
 // Cleanup
 rmSync("lib-cjs", { recursive: true, force: true });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `bench:compare-runtimes` package script, enacting the `runtime/compare.ts` script previously undocumented
 - Updated benchmark search strategies to include proper stream indices, to support parity of functionality
+- Added explicit CJS build step / exports, and add [`@arethetypeswrong`](https://github.com/arethetypeswrong/arethetypeswrong.github.io) validation
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Replacement callbacks now receive match as first parameter and context as second: `(match: string, context: ReplacementContext) => ...`
+- **BREAKING:** Replacement callbacks now receive `match` as the first parameter and `context` as the second: `(match, context: ReplacementContext) => ...`
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
 - Moved to extension-less imports for better type exports
 
-
 ### Added
 
 - `bench:compare-runtimes` package script, enacting the `runtime/compare.ts` script previously undocumented
@@ -27,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected some paths in docs for the runtime benchmarks
 - Corrected JSDoc example for `AsyncIterableFunctionReplacementProcessor` to properly handle multi-byte values in text decoder
 - Fixed some benchmark search strategies to avoid emitting empty chunks when consecutive matches without gaps exist
+- Clarified that `AsyncIterableFunctionReplacementProcessor` can replace with `AsyncIterable<string>` as well as `Promise<AsyncIterable<string>>`
 
 ## [1.2.0] - 2026-04-06
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
 
+### Added
+
+- `bench:compare-runtimes` package script, enacting the `runtime/compare.ts` script previously undocumented
+
+### Fixed
+
+- corrected some paths in docs for the runtime benchmarks
+
 ## [1.2.0] - 2026-04-06
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Replacement callbacks now receive `match` as the first parameter and `context` as the second: `(match, context: ReplacementContext) => ...`
+- **BREAKING:** Made Node minimum version 22 (LTS) - support for `import.meta.dirname` (Node 20) required
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
 - Moved to extension-less imports for better type exports
+
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Replacement callbacks now receive `match` as the first parameter and `context` as the second: `(match, context: ReplacementContext) => ...`
-- **BREAKING:** Made Node minimum version 22 (LTS) - support for `import.meta.dirname` (Node 20) required
+- **BREAKING:** Made Node minimum version 22 (LTS)
+  - support for `import.meta.dirname` required Node 20+
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
 - Moved to extension-less imports for better type exports

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- corrected some paths in docs for the runtime benchmarks
+- Corrected some paths in docs for the runtime benchmarks
+- Corrected JSDoc example for `AsyncIterableFunctionReplacementProcessor` to properly handle multi-byte values in text decoder.
 
 ## [1.2.0] - 2026-04-06
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Corrected some paths in docs for the runtime benchmarks
-- Corrected JSDoc example for `AsyncIterableFunctionReplacementProcessor` to properly handle multi-byte values in text decoder.
+- Corrected JSDoc example for `AsyncIterableFunctionReplacementProcessor` to properly handle multi-byte values in text decoder
+- Fixed some benchmark search strategies to avoid emitting empty chunks when consecutive matches without gaps exist
 
 ## [1.2.0] - 2026-04-06
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Replacement callbacks now receive match as first parameter and context as second: `(match: string, context: ReplacementContext) => ...`.
+- Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
+
 ## [1.2.0] - 2026-04-06
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Replacement callbacks now receive `match` as the first parameter and `context` as the second: `(match, context: ReplacementContext) => ...`
 - **BREAKING:** Made Node minimum version 22 (LTS)
-  - support for `import.meta.dirname` required Node 20+
+  - support for `import.meta.dirname` required Node 20+, and the project baseline was aligned to Node 22 LTS
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
 - Moved to extension-less imports for better type exports

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Replacement callbacks now receive `match` as the first parameter and `context` as the second: `(match, context: ReplacementContext) => ...`
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
+- Moved to extension-less imports for better type exports
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `bench:compare-runtimes` package script, enacting the `runtime/compare.ts` script previously undocumented
+- Updated benchmark search strategies to include proper stream indices, to support parity of functionality
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - support for `import.meta.dirname` required Node 20+, and the project baseline was aligned to Node 22 LTS
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
 - Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
-- Moved to extension-less imports for better type exports
+- Switched internal imports to explicit `.js` specifiers for better ESM/type export compatibility
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Replacement callbacks now receive match as first parameter and context as second: `(match: string, context: ReplacementContext) => ...`.
+- **BREAKING:** Replacement callbacks now receive match as first parameter and context as second: `(match: string, context: ReplacementContext) => ...`
 - Updated `regex-partial-match` to [v0.3.0](https://github.com/TomStrepsil/regex-partial-match/releases/tag/v0.3.0)
+- Updated eslint config to use [`projectService`](https://typescript-eslint.io/blog/project-service/) for improved typescript integration
 
 ## [1.2.0] - 2026-04-06
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,8 @@ export default [
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: "module",
-        project: "./tsconfig.json"
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname
       },
       globals: {
         ...globals.node,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "test/benchmarks"
       ],
       "dependencies": {
-        "regex-partial-match": "^0.2.0"
+        "regex-partial-match": "^0.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3124,9 +3124,9 @@
       }
     },
     "node_modules/regex-partial-match": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/regex-partial-match/-/regex-partial-match-0.2.1.tgz",
-      "integrity": "sha512-jmYBpOTQ0ZUUMdQ0xiONXlxVkkHOIVEW4XEsSb3YijTO+8WifAVRShZvXDcAIkif/RPO/6mHRP51tH049hkm7Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/regex-partial-match/-/regex-partial-match-0.3.0.tgz",
+      "integrity": "sha512-MOvrJdPrwMaPBj1lwUWQo5cFp0LUa58JGWzGDYGXz9Yn5A+GKIE1iunTd7Eo3tr8IxqaWYpZ3iQybURngrhNTw==",
       "license": "ISC"
     },
     "node_modules/require-directory": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,6 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "bun": ">=1.0.0",
-        "deno": ">=1.40.0",
         "node": ">=18"
       }
     },
@@ -99,26 +97,24 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -130,7 +126,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -516,9 +511,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -560,9 +555,9 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -570,9 +565,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -587,9 +582,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +599,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -621,9 +616,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -638,9 +633,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -655,9 +650,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -675,9 +670,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -695,9 +690,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -715,9 +710,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -735,9 +730,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -755,9 +750,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -775,9 +770,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -792,9 +787,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -802,16 +797,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -826,9 +823,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -843,9 +840,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3078,9 +3075,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -3194,14 +3191,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3210,21 +3207,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/semver": {
@@ -3439,14 +3436,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3590,17 +3587,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3617,7 +3614,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "regex-partial-match": "^0.3.0"
       },
       "devDependencies": {
+        "@arethetypeswrong/cli": "^0.18.2",
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.11",
         "@types/deno": "^2.5.0",
@@ -29,11 +30,84 @@
         "msw": "^2.12.14",
         "rimraf": "^6.1.3",
         "simple-git-hooks": "^2.13.1",
+        "tsup": "^8.5.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      }
+    },
+    "node_modules/@andrewbranch/untar.js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+      "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+      "dev": true
+    },
+    "node_modules/@arethetypeswrong/cli": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.2.tgz",
+      "integrity": "sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@arethetypeswrong/core": "0.18.2",
+        "chalk": "^4.1.2",
+        "cli-table3": "^0.6.3",
+        "commander": "^10.0.1",
+        "marked": "^9.1.2",
+        "marked-terminal": "^7.1.0",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "attw": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/cli/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@arethetypeswrong/core": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.2.tgz",
+      "integrity": "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@andrewbranch/untar.js": "^1.0.3",
+        "@loaderkit/resolve": "^1.0.2",
+        "cjs-module-lexer": "^1.2.3",
+        "fflate": "^0.8.2",
+        "lru-cache": "^11.0.1",
+        "semver": "^7.5.4",
+        "typescript": "5.6.1-rc",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+      "version": "5.6.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+      "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -96,6 +170,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@braidai/lang": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+      "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -128,6 +220,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -464,6 +998,17 @@
         }
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -490,6 +1035,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@loaderkit/resolve": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.5.tgz",
+      "integrity": "sha512-fhkdGM57xhJ7CO91MUgbQlb0ClP0AJ9vB3yoVnBTslYJqrJOCVEbOprZcxZlexdMbmTBPQqVcQYr+j4oRRtIZA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@braidai/lang": "^1.0.0"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -845,6 +1400,408 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1396,6 +2353,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1455,6 +2419,32 @@
         "@types/node": "*"
       }
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1464,6 +2454,72 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -1479,6 +2535,215 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-truncate": {
@@ -1642,6 +2907,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1720,6 +3002,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -1739,6 +3028,48 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2031,6 +3362,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2059,6 +3397,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
       }
     },
     "node_modules/flat-cache": {
@@ -2191,6 +3541,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2308,6 +3668,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -2635,6 +4005,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lint-staged": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -2675,6 +4065,16 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -2778,6 +4178,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -2823,6 +4271,19 @@
       "integrity": "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2886,6 +4347,18 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2911,6 +4384,32 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3003,6 +4502,30 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3074,6 +4597,28 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -3103,6 +4648,49 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3123,6 +4711,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/regex-partial-match": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/regex-partial-match/-/regex-partial-match-0.3.0.tgz",
@@ -3137,6 +4739,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/restore-cursor": {
@@ -3224,6 +4836,51 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3291,6 +4948,19 @@
         "simple-git-hooks": "cli.js"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
@@ -3306,6 +4976,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -3392,6 +5072,39 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3405,6 +5118,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -3416,6 +5146,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -3495,6 +5248,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -3508,6 +5271,13 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3515,6 +5285,66 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3559,12 +5389,29 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/until-async": {
       "version": "3.0.2",
@@ -3584,6 +5431,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "msw": "^2.12.14",
         "rimraf": "^6.1.3",
         "simple-git-hooks": "^2.13.1",
-        "tsup": "^8.5.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"
       },
@@ -998,17 +997,6 @@
         }
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1400,395 +1388,6 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -2419,32 +2018,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/bundle-require": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
-      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "load-tsconfig": "^0.2.3"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.18"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2496,22 +2069,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -2905,23 +2462,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -3399,18 +2939,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/fix-dts-default-cjs-exports": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
-      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.17",
-        "mlly": "^1.7.4",
-        "rollup": "^4.34.8"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -3468,6 +2996,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -3668,16 +3209,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/joycon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -4005,26 +3536,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lint-staged": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -4065,16 +3576,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/load-tsconfig": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
-      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -4271,19 +3772,6 @@
       "integrity": "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mlly": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4597,28 +4085,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -4648,49 +4114,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4711,20 +4134,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/regex-partial-match": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/regex-partial-match/-/regex-partial-match-0.3.0.tgz",
@@ -4741,14 +4150,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/restore-cursor": {
@@ -4834,51 +4243,6 @@
         "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/semver": {
@@ -4978,16 +4342,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5070,39 +4424,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/sucrase": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "tinyglobby": "^0.2.11",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/sucrase/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/supports-color": {
@@ -5248,16 +4569,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5271,13 +4582,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5286,65 +4590,25 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/tsup": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
-      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bundle-require": "^5.1.0",
-        "cac": "^6.7.14",
-        "chokidar": "^4.0.3",
-        "consola": "^3.4.0",
-        "debug": "^4.4.0",
-        "esbuild": "^0.27.0",
-        "fix-dts-default-cjs-exports": "^1.0.0",
-        "joycon": "^3.1.1",
-        "picocolors": "^1.1.1",
-        "postcss-load-config": "^6.0.1",
-        "resolve-from": "^5.0.0",
-        "rollup": "^4.34.8",
-        "source-map": "^0.7.6",
-        "sucrase": "^3.35.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.11",
-        "tree-kill": "^1.2.2"
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
       },
       "bin": {
-        "tsup": "dist/cli-default.js",
-        "tsup-node": "dist/cli-node.js"
+        "tsx": "dist/cli.mjs"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.0.0"
       },
-      "peerDependencies": {
-        "@microsoft/api-extractor": "^7.36.0",
-        "@swc/core": "^1",
-        "postcss": "^8.4.12",
-        "typescript": ">=4.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@microsoft/api-extractor": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
-    },
-    "node_modules/tsup/node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5388,13 +4652,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -5821,7 +5078,8 @@
     "test/benchmarks": {
       "version": "0.0.0",
       "devDependencies": {
-        "mitata": "^1.0.10"
+        "mitata": "^1.0.10",
+        "tsx": "^4.21.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,23 +27,47 @@
   },
   "homepage": "https://github.com/TomStrepsil/replace-content-transformer#readme",
   "type": "module",
+  "main": "./lib/index.cjs",
+  "module": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "web": [
+        "lib/adapters/web/index.d.ts"
+      ],
+      "node": [
+        "lib/adapters/node/index.d.ts"
+      ]
+    }
+  },
   "exports": {
     "./web": {
-      "types": "./lib/adapters/web/index.d.ts",
+      "types": {
+        "import": "./lib/adapters/web/index.d.ts",
+        "require": "./lib/adapters/web/index.d.cts"
+      },
       "deno": "./lib/adapters/web/index.js",
       "bun": "./lib/adapters/web/index.js",
       "browser": "./lib/adapters/web/index.js",
+      "require": "./lib/adapters/web/index.cjs",
       "import": "./lib/adapters/web/index.js",
       "default": "./lib/adapters/web/index.js"
     },
     "./node": {
-      "types": "./lib/adapters/node/index.d.ts",
-      "node": "./lib/adapters/node/index.js",
+      "types": {
+        "import": "./lib/adapters/node/index.d.ts",
+        "require": "./lib/adapters/node/index.d.cts"
+      },
+      "require": "./lib/adapters/node/index.cjs",
       "import": "./lib/adapters/node/index.js",
       "default": "./lib/adapters/node/index.js"
     },
     ".": {
-      "types": "./lib/index.d.ts",
+      "types": {
+        "import": "./lib/index.d.ts",
+        "require": "./lib/index.d.cts"
+      },
+      "require": "./lib/index.cjs",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
@@ -64,11 +88,12 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "rimraf lib && tsc -p tsconfig.build.json",
+    "build": "node build.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:ci": "vitest run --coverage",
     "test:watch": "vitest",
+    "check:attw": "npm run build && attw --pack .",
     "bench": "npm run bench:node -w test/benchmarks",
     "bench:runtimes": "npm run bench:runtimes -w test/benchmarks",
     "bench:algorithms": "npm run bench:algorithms -w test/benchmarks",
@@ -106,6 +131,7 @@
     "rimraf": "^6.1.3",
     "simple-git-hooks": "^2.13.1",
     "typescript": "^6.0.2",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "@arethetypeswrong/cli": "^0.18.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "./web": {
       "types": {
         "import": "./lib/esm/adapters/web/index.d.ts",
-        "require": "./lib/cjs/adapters/web/index.d.cts"
+        "require": "./lib/cjs/adapters/web/index.d.ts"
       },
       "deno": "./lib/esm/adapters/web/index.js",
       "bun": "./lib/esm/adapters/web/index.js",
@@ -56,7 +56,7 @@
     "./node": {
       "types": {
         "import": "./lib/esm/adapters/node/index.d.ts",
-        "require": "./lib/cjs/adapters/node/index.d.cts"
+        "require": "./lib/cjs/adapters/node/index.d.ts"
       },
       "require": "./lib/cjs/adapters/node/index.js",
       "import": "./lib/esm/adapters/node/index.js",
@@ -65,7 +65,7 @@
     ".": {
       "types": {
         "import": "./lib/esm/index.d.ts",
-        "require": "./lib/cjs/index.d.cts"
+        "require": "./lib/cjs/index.d.ts"
       },
       "require": "./lib/cjs/index.js",
       "import": "./lib/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -27,49 +27,49 @@
   },
   "homepage": "https://github.com/TomStrepsil/replace-content-transformer#readme",
   "type": "module",
-  "main": "./lib/index.cjs",
-  "module": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/esm/index.d.ts",
   "typesVersions": {
     "*": {
       "web": [
-        "lib/adapters/web/index.d.ts"
+        "lib/esm/adapters/web/index.d.ts"
       ],
       "node": [
-        "lib/adapters/node/index.d.ts"
+        "lib/esm/adapters/node/index.d.ts"
       ]
     }
   },
   "exports": {
     "./web": {
       "types": {
-        "import": "./lib/adapters/web/index.d.ts",
-        "require": "./lib/adapters/web/index.d.cts"
+        "import": "./lib/esm/adapters/web/index.d.ts",
+        "require": "./lib/cjs/adapters/web/index.d.cts"
       },
-      "deno": "./lib/adapters/web/index.js",
-      "bun": "./lib/adapters/web/index.js",
-      "browser": "./lib/adapters/web/index.js",
-      "require": "./lib/adapters/web/index.cjs",
-      "import": "./lib/adapters/web/index.js",
-      "default": "./lib/adapters/web/index.js"
+      "deno": "./lib/esm/adapters/web/index.js",
+      "bun": "./lib/esm/adapters/web/index.js",
+      "browser": "./lib/esm/adapters/web/index.js",
+      "require": "./lib/cjs/adapters/web/index.js",
+      "import": "./lib/esm/adapters/web/index.js",
+      "default": "./lib/esm/adapters/web/index.js"
     },
     "./node": {
       "types": {
-        "import": "./lib/adapters/node/index.d.ts",
-        "require": "./lib/adapters/node/index.d.cts"
+        "import": "./lib/esm/adapters/node/index.d.ts",
+        "require": "./lib/cjs/adapters/node/index.d.cts"
       },
-      "require": "./lib/adapters/node/index.cjs",
-      "import": "./lib/adapters/node/index.js",
-      "default": "./lib/adapters/node/index.js"
+      "require": "./lib/cjs/adapters/node/index.js",
+      "import": "./lib/esm/adapters/node/index.js",
+      "default": "./lib/esm/adapters/node/index.js"
     },
     ".": {
       "types": {
-        "import": "./lib/index.d.ts",
-        "require": "./lib/index.d.cts"
+        "import": "./lib/esm/index.d.ts",
+        "require": "./lib/cjs/index.d.cts"
       },
-      "require": "./lib/index.cjs",
-      "import": "./lib/index.js",
-      "default": "./lib/index.js"
+      "require": "./lib/cjs/index.js",
+      "import": "./lib/esm/index.js",
+      "default": "./lib/esm/index.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "regex-partial-match": "^0.2.0"
+    "regex-partial-match": "^0.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/adapters/node/async-transform.test.ts
+++ b/src/adapters/node/async-transform.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { AsyncReplaceContentTransform } from "./async-transform";
+import { AsyncReplaceContentTransform } from "./async-transform.js";
 import { Writable } from "node:stream";
-import { mockAsyncProcessorFactory } from "../../../test/utilities";
+import { mockAsyncProcessorFactory } from "../../../test/utilities.js";
 
 describe("ReplaceContentTransform (async)", () => {
   it("delegates to processor and writes output to stream", async () => {

--- a/src/adapters/node/benchmarking/async-transform-callback.ts
+++ b/src/adapters/node/benchmarking/async-transform-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformBase } from "../transform-base";
-import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import { ReplaceContentTransformBase } from "../transform-base.js";
+import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
 
 export class AsyncReplaceContentTransformCallback extends ReplaceContentTransformBase {
   protected processor: AsyncCallbackProcessor;

--- a/src/adapters/node/benchmarking/async-transform-callback.ts
+++ b/src/adapters/node/benchmarking/async-transform-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformBase } from "../transform-base.ts";
-import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import { ReplaceContentTransformBase } from "../transform-base";
+import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
 
 export class AsyncReplaceContentTransformCallback extends ReplaceContentTransformBase {
   protected processor: AsyncCallbackProcessor;

--- a/src/adapters/node/benchmarking/sync-transform-callback.ts
+++ b/src/adapters/node/benchmarking/sync-transform-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformBase } from "../transform-base.ts";
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import { ReplaceContentTransformBase } from "../transform-base";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
 
 export class ReplaceContentTransformCallback extends ReplaceContentTransformBase {
   protected processor: SyncCallbackProcessor;

--- a/src/adapters/node/benchmarking/sync-transform-callback.ts
+++ b/src/adapters/node/benchmarking/sync-transform-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformBase } from "../transform-base";
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import { ReplaceContentTransformBase } from "../transform-base.js";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
 
 export class ReplaceContentTransformCallback extends ReplaceContentTransformBase {
   protected processor: SyncCallbackProcessor;

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -1,2 +1,2 @@
-export * from "./async-transform";
-export * from "./sync-transform";
+export * from "./async-transform.js";
+export * from "./sync-transform.js";

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -1,2 +1,2 @@
-export * from "./async-transform.ts";
-export * from "./sync-transform.ts";
+export * from "./async-transform";
+export * from "./sync-transform";

--- a/src/adapters/node/sync-transform.test.ts
+++ b/src/adapters/node/sync-transform.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { ReplaceContentTransform } from "./sync-transform";
+import { ReplaceContentTransform } from "./sync-transform.js";
 import { Writable } from "node:stream";
-import { mockSyncProcessorFactory } from "../../../test/utilities";
+import { mockSyncProcessorFactory } from "../../../test/utilities.js";
 
 describe("ReplaceContentTransform (sync)", () => {
   it("delegates to processor and writes output to stream", () => {

--- a/src/adapters/node/sync-transform.test.ts
+++ b/src/adapters/node/sync-transform.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { ReplaceContentTransform } from "./sync-transform.ts";
+import { ReplaceContentTransform } from "./sync-transform";
 import { Writable } from "node:stream";
-import { mockSyncProcessorFactory } from "../../../test/utilities.ts";
+import { mockSyncProcessorFactory } from "../../../test/utilities";
 
 describe("ReplaceContentTransform (sync)", () => {
   it("delegates to processor and writes output to stream", () => {

--- a/src/adapters/node/transform-base.ts
+++ b/src/adapters/node/transform-base.ts
@@ -1,5 +1,5 @@
 import { Transform, type TransformCallback } from "node:stream";
-import type { Processor } from "../../replacement-processors/types";
+import type { Processor } from "../../replacement-processors/types.js";
 
 export abstract class ReplaceContentTransformBase extends Transform {
   protected abstract processor: Processor;

--- a/src/adapters/web/async-transformer.integration.test.ts
+++ b/src/adapters/web/async-transformer.integration.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { AsyncIterableFunctionReplacementProcessor } from "../../replacement-processors/async-iterable-function-replacement-processor";
-import { AsyncReplaceContentTransformer } from "./async-transformer";
+import { AsyncIterableFunctionReplacementProcessor } from "../../replacement-processors/async-iterable-function-replacement-processor.js";
+import { AsyncReplaceContentTransformer } from "./async-transformer.js";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../test/utilities";
+import { server } from "../../../test/utilities.js";
 import { text } from "node:stream/consumers";
-import { StringAnchorSearchStrategy } from "../../search-strategies/index";
+import { StringAnchorSearchStrategy } from "../../search-strategies/index.js";
 
 describe("AsyncReplaceContentTransformer + AsyncIterableFunctionReplacementProcessor + StringAnchorSearchStrategy", () => {
   it("passes through new chunks after abort set between chunks when no buffered remainder exists", async () => {

--- a/src/adapters/web/async-transformer.integration.test.ts
+++ b/src/adapters/web/async-transformer.integration.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { AsyncIterableFunctionReplacementProcessor } from "../../replacement-processors/async-iterable-function-replacement-processor.ts";
-import { AsyncReplaceContentTransformer } from "./async-transformer.ts";
+import { AsyncIterableFunctionReplacementProcessor } from "../../replacement-processors/async-iterable-function-replacement-processor";
+import { AsyncReplaceContentTransformer } from "./async-transformer";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../test/utilities.ts";
+import { server } from "../../../test/utilities";
 import { text } from "node:stream/consumers";
-import { StringAnchorSearchStrategy } from "../../search-strategies/index.ts";
+import { StringAnchorSearchStrategy } from "../../search-strategies/index";
 
 describe("AsyncReplaceContentTransformer + AsyncIterableFunctionReplacementProcessor + StringAnchorSearchStrategy", () => {
   it("passes through new chunks after abort set between chunks when no buffered remainder exists", async () => {

--- a/src/adapters/web/async-transformer.test.ts
+++ b/src/adapters/web/async-transformer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { AsyncReplaceContentTransformer } from "./async-transformer.ts";
+import { AsyncReplaceContentTransformer } from "./async-transformer";
 import {
   mockTransformStreamDefaultControllerFactory,
   mockAsyncProcessorFactory
-} from "../../../test/utilities.ts";
+} from "../../../test/utilities";
 
 describe("AsyncReplaceContentTransformer", () => {
   it("delegates to processor and enqueues output", async () => {

--- a/src/adapters/web/async-transformer.test.ts
+++ b/src/adapters/web/async-transformer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { AsyncReplaceContentTransformer } from "./async-transformer";
+import { AsyncReplaceContentTransformer } from "./async-transformer.js";
 import {
   mockTransformStreamDefaultControllerFactory,
   mockAsyncProcessorFactory
-} from "../../../test/utilities";
+} from "../../../test/utilities.js";
 
 describe("AsyncReplaceContentTransformer", () => {
   it("delegates to processor and enqueues output", async () => {

--- a/src/adapters/web/async-transformer.ts
+++ b/src/adapters/web/async-transformer.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "./transformer-base.ts";
-import type { AsyncProcessor } from "../../replacement-processors/types.ts";
+import { ReplaceContentTransformerBase } from "./transformer-base";
+import type { AsyncProcessor } from "../../replacement-processors/types";
 
 /**
  * Creates an asynchronous transformer for the WHATWG Streams API that replaces content in streaming text.

--- a/src/adapters/web/async-transformer.ts
+++ b/src/adapters/web/async-transformer.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "./transformer-base";
-import type { AsyncProcessor } from "../../replacement-processors/types";
+import { ReplaceContentTransformerBase } from "./transformer-base.js";
+import type { AsyncProcessor } from "../../replacement-processors/types.js";
 
 /**
  * Creates an asynchronous transformer for the WHATWG Streams API that replaces content in streaming text.

--- a/src/adapters/web/benchmarking/async-transformer-callback.ts
+++ b/src/adapters/web/benchmarking/async-transformer-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "../transformer-base.ts";
-import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import { ReplaceContentTransformerBase } from "../transformer-base";
+import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
 
 export class AsyncReplaceContentTransformerCallback extends ReplaceContentTransformerBase {
   protected processor: AsyncCallbackProcessor;

--- a/src/adapters/web/benchmarking/async-transformer-callback.ts
+++ b/src/adapters/web/benchmarking/async-transformer-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "../transformer-base";
-import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import { ReplaceContentTransformerBase } from "../transformer-base.js";
+import type { AsyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
 
 export class AsyncReplaceContentTransformerCallback extends ReplaceContentTransformerBase {
   protected processor: AsyncCallbackProcessor;

--- a/src/adapters/web/benchmarking/sync-transformer-callback.ts
+++ b/src/adapters/web/benchmarking/sync-transformer-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "../transformer-base.ts";
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import { ReplaceContentTransformerBase } from "../transformer-base";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
 
 export class ReplaceContentTransformerCallback<
   T extends string | Promise<string> = string

--- a/src/adapters/web/benchmarking/sync-transformer-callback.ts
+++ b/src/adapters/web/benchmarking/sync-transformer-callback.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "../transformer-base";
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import { ReplaceContentTransformerBase } from "../transformer-base.js";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
 
 export class ReplaceContentTransformerCallback<
   T extends string | Promise<string> = string

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -1,2 +1,2 @@
-export * from "./async-transformer";
-export * from "./sync-transformer";
+export * from "./async-transformer.js";
+export * from "./sync-transformer.js";

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -1,2 +1,2 @@
-export * from "./async-transformer.ts";
-export * from "./sync-transformer.ts";
+export * from "./async-transformer";
+export * from "./sync-transformer";

--- a/src/adapters/web/sync-transformer.integration.test.ts
+++ b/src/adapters/web/sync-transformer.integration.test.ts
@@ -3,6 +3,7 @@ import { text } from "node:stream/consumers";
 import { ReplaceContentTransformer } from "./sync-transformer.ts";
 import { FunctionReplacementProcessor } from "../../replacement-processors/function-replacement-processor.ts";
 import { StringAnchorSearchStrategy } from "../../search-strategies/index.ts";
+import type { ReplacementContext } from "../../replacement-processors/replacement-processor.base.ts";
 
 describe("ReplaceContentTransformer + StringAnchorSearchStrategy + stopReplacingSignal", () => {
   it("passes through new chunks after abort set between chunks when no buffered remainder exists", async () => {
@@ -123,9 +124,9 @@ describe("ReplaceContentTransformer + StringAnchorSearchStrategy + Promise-retur
 
     const processor = new FunctionReplacementProcessor({
       searchStrategy,
-      replacement: async (match: string, index: number): Promise<string> => {
+      replacement: async (match: string, { matchIndex }: ReplacementContext): Promise<string> => {
         await vi.waitFor(() => Promise.resolve(), { timeout: 10 });
-        return `[${index}:${match.slice(2, -2)}]`;
+        return `[${matchIndex}:${match.slice(2, -2)}]`;
       }
     });
 

--- a/src/adapters/web/sync-transformer.integration.test.ts
+++ b/src/adapters/web/sync-transformer.integration.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { text } from "node:stream/consumers";
-import { ReplaceContentTransformer } from "./sync-transformer";
-import { FunctionReplacementProcessor } from "../../replacement-processors/function-replacement-processor";
-import { StringAnchorSearchStrategy } from "../../search-strategies/index";
-import type { ReplacementContext } from "../../replacement-processors/replacement-processor.base";
+import { ReplaceContentTransformer } from "./sync-transformer.js";
+import { FunctionReplacementProcessor } from "../../replacement-processors/function-replacement-processor.js";
+import { StringAnchorSearchStrategy } from "../../search-strategies/index.js";
+import type { ReplacementContext } from "../../replacement-processors/replacement-processor.base.js";
 
 describe("ReplaceContentTransformer + StringAnchorSearchStrategy + stopReplacingSignal", () => {
   it("passes through new chunks after abort set between chunks when no buffered remainder exists", async () => {

--- a/src/adapters/web/sync-transformer.integration.test.ts
+++ b/src/adapters/web/sync-transformer.integration.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { text } from "node:stream/consumers";
-import { ReplaceContentTransformer } from "./sync-transformer.ts";
-import { FunctionReplacementProcessor } from "../../replacement-processors/function-replacement-processor.ts";
-import { StringAnchorSearchStrategy } from "../../search-strategies/index.ts";
-import type { ReplacementContext } from "../../replacement-processors/replacement-processor.base.ts";
+import { ReplaceContentTransformer } from "./sync-transformer";
+import { FunctionReplacementProcessor } from "../../replacement-processors/function-replacement-processor";
+import { StringAnchorSearchStrategy } from "../../search-strategies/index";
+import type { ReplacementContext } from "../../replacement-processors/replacement-processor.base";
 
 describe("ReplaceContentTransformer + StringAnchorSearchStrategy + stopReplacingSignal", () => {
   it("passes through new chunks after abort set between chunks when no buffered remainder exists", async () => {

--- a/src/adapters/web/sync-transformer.test.ts
+++ b/src/adapters/web/sync-transformer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { ReplaceContentTransformer } from "./sync-transformer";
+import { ReplaceContentTransformer } from "./sync-transformer.js";
 import {
   mockTransformStreamDefaultControllerFactory,
   mockSyncProcessorFactory
-} from "../../../test/utilities";
+} from "../../../test/utilities.js";
 
 describe("ReplaceContentTransformer (sync)", () => {
   it("delegates to processor and enqueues output", () => {

--- a/src/adapters/web/sync-transformer.test.ts
+++ b/src/adapters/web/sync-transformer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { ReplaceContentTransformer } from "./sync-transformer.ts";
+import { ReplaceContentTransformer } from "./sync-transformer";
 import {
   mockTransformStreamDefaultControllerFactory,
   mockSyncProcessorFactory
-} from "../../../test/utilities.ts";
+} from "../../../test/utilities";
 
 describe("ReplaceContentTransformer (sync)", () => {
   it("delegates to processor and enqueues output", () => {

--- a/src/adapters/web/sync-transformer.ts
+++ b/src/adapters/web/sync-transformer.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "./transformer-base";
-import type { SyncProcessor } from "../../replacement-processors/types";
+import { ReplaceContentTransformerBase } from "./transformer-base.js";
+import type { SyncProcessor } from "../../replacement-processors/types.js";
 
 /**
  * A synchronous transformer for the WHATWG Streams API that replaces content in streaming text.

--- a/src/adapters/web/sync-transformer.ts
+++ b/src/adapters/web/sync-transformer.ts
@@ -1,5 +1,5 @@
-import { ReplaceContentTransformerBase } from "./transformer-base.ts";
-import type { SyncProcessor } from "../../replacement-processors/types.ts";
+import { ReplaceContentTransformerBase } from "./transformer-base";
+import type { SyncProcessor } from "../../replacement-processors/types";
 
 /**
  * A synchronous transformer for the WHATWG Streams API that replaces content in streaming text.

--- a/src/adapters/web/transformer-base.ts
+++ b/src/adapters/web/transformer-base.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from "node:stream/web";
-import type { Processor } from "../../replacement-processors/types.ts";
+import type { Processor } from "../../replacement-processors/types";
 export abstract class ReplaceContentTransformerBase<T = string>
   implements Transformer<string, T | string>
 {

--- a/src/adapters/web/transformer-base.ts
+++ b/src/adapters/web/transformer-base.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from "node:stream/web";
-import type { Processor } from "../../replacement-processors/types";
+import type { Processor } from "../../replacement-processors/types.js";
 export abstract class ReplaceContentTransformerBase<T = string>
   implements Transformer<string, T | string>
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./search-strategies/index";
-export * from "./replacement-processors/index";
-export * from "./search-strategy-factory";
+export * from "./search-strategies/index.js";
+export * from "./replacement-processors/index.js";
+export * from "./search-strategy-factory.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./search-strategies/index.ts";
-export * from "./replacement-processors/index.ts";
-export * from "./search-strategy-factory.ts";
+export * from "./search-strategies/index";
+export * from "./replacement-processors/index";
+export * from "./search-strategy-factory";

--- a/src/replacement-processors/README.md
+++ b/src/replacement-processors/README.md
@@ -15,7 +15,7 @@ Replaces all pattern matches with the same static string value. Simplest and fas
 
 Replaces matches using a function that receives the matched content and a context object. Supports both sync and async replacement functions.
 
-- **Replacement Type**: `(match: string, context: ReplacementContext) => string | Promise<string>`
+- **Replacement Type**: `(match: TMatch, context: ReplacementContext) => string | Promise<string>`
 - **Execution**: Synchronous generator (can yield promises)
 - **Use Case**: Dynamic replacements, transformations, API calls
 - **Example**: `new FunctionReplacementProcessor({ searchStrategy, replacement: (match, { matchIndex }) => `[${matchIndex}]` })`
@@ -24,7 +24,7 @@ Replaces matches using a function that receives the matched content and a contex
 
 Replacement function returns an iterable that yields multiple string chunks for a single match. Useful for streaming large replacements or expanding matches into multiple parts.
 
-- **Replacement Type**: `(match: string, context: ReplacementContext) => Iterable<string>`
+- **Replacement Type**: `(match: TMatch, context: ReplacementContext) => Iterable<string>`
 - **Execution**: Synchronous generator
 - **Use Case**: Expanding matches, streaming large replacements, multi-part substitutions
 - **Example**: `new IterableFunctionReplacementProcessor({ searchStrategy, replacement: (match, { matchIndex }) => ['<', match, '>', `(${matchIndex})`] })`
@@ -33,7 +33,7 @@ Replacement function returns an iterable that yields multiple string chunks for 
 
 Async version of FunctionReplacementProcessor. Replacement function must return a Promise. Processor awaits each replacement before yielding.
 
-- **Replacement Type**: `(match: string, context: ReplacementContext) => Promise<string>`
+- **Replacement Type**: `(match: TMatch, context: ReplacementContext) => Promise<string>`
 - **Execution**: Async generator
 - **Use Case**: API calls, database lookups, async transformations
 - **Example**: `new AsyncFunctionReplacementProcessor({ searchStrategy, replacement: async (match, { matchIndex }) => await fetch(`/api/${matchIndex}`) })`
@@ -42,7 +42,7 @@ Async version of FunctionReplacementProcessor. Replacement function must return 
 
 Async version of IterableFunctionReplacementProcessor. Replacement function returns an async iterable that yields chunks asynchronously.
 
-- **Replacement Type**: `(match: string, context: ReplacementContext) => AsyncIterable<string>`
+- **Replacement Type**: `(match: TMatch, context: ReplacementContext) => AsyncIterable<string>`
 - **Execution**: Async generator
 - **Use Case**: Streaming API responses, async chunk generation
 - **Example**: `new AsyncIterableFunctionReplacementProcessor({ searchStrategy, replacement: async function* (match, { matchIndex }) { yield* streamData(matchIndex) } })`

--- a/src/replacement-processors/README.md
+++ b/src/replacement-processors/README.md
@@ -13,39 +13,39 @@ Replaces all pattern matches with the same static string value. Simplest and fas
 
 ### ⚡ Function Replacement
 
-Replaces matches using a function that receives the matched content, match index and stream indices. Supports both sync and async replacement functions.
+Replaces matches using a function that receives the matched content and a context object. Supports both sync and async replacement functions.
 
-- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => string | Promise<string>`
+- **Replacement Type**: `(match: string, context: ReplacementContext) => string | Promise<string>`
 - **Execution**: Synchronous generator (can yield promises)
 - **Use Case**: Dynamic replacements, transformations, API calls
-- **Example**: `new FunctionReplacementProcessor({ searchStrategy, replacement: (match, i) => `[${i}]` })`
+- **Example**: `new FunctionReplacementProcessor({ searchStrategy, replacement: (match, { matchIndex }) => `[${matchIndex}]` })`
 
 ### 🔄 Iterable Function Replacement
 
 Replacement function returns an iterable that yields multiple string chunks for a single match. Useful for streaming large replacements or expanding matches into multiple parts.
 
-- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Iterable<string>`
+- **Replacement Type**: `(match: string, context: ReplacementContext) => Iterable<string>`
 - **Execution**: Synchronous generator
 - **Use Case**: Expanding matches, streaming large replacements, multi-part substitutions
-- **Example**: `new IterableFunctionReplacementProcessor({ searchStrategy, replacement: (match) => ['<', match, '>'] })`
+- **Example**: `new IterableFunctionReplacementProcessor({ searchStrategy, replacement: (match, { matchIndex }) => ['<', match, '>', `(${matchIndex})`] })`
 
 ### ⏳ Async Function Replacement
 
 Async version of FunctionReplacementProcessor. Replacement function must return a Promise. Processor awaits each replacement before yielding.
 
-- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<string>`
+- **Replacement Type**: `(match: string, context: ReplacementContext) => Promise<string>`
 - **Execution**: Async generator
 - **Use Case**: API calls, database lookups, async transformations
-- **Example**: `new AsyncFunctionReplacementProcessor({ searchStrategy, replacement: async (match) => await fetch(...) })`
+- **Example**: `new AsyncFunctionReplacementProcessor({ searchStrategy, replacement: async (match, { matchIndex }) => await fetch(`/api/${matchIndex}`) })`
 
 ### 🌊 Async Iterable Function Replacement
 
 Async version of IterableFunctionReplacementProcessor. Replacement function returns an async iterable that yields chunks asynchronously.
 
-- **Replacement Type**: `(matchedContent: string, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => AsyncIterable<string>`
+- **Replacement Type**: `(match: string, context: ReplacementContext) => AsyncIterable<string>`
 - **Execution**: Async generator
 - **Use Case**: Streaming API responses, async chunk generation
-- **Example**: `new AsyncIterableFunctionReplacementProcessor({ searchStrategy, replacement: async function* (match) { yield* streamData() } })`
+- **Example**: `new AsyncIterableFunctionReplacementProcessor({ searchStrategy, replacement: async function* (match, { matchIndex }) { yield* streamData(matchIndex) } })`
 
 ## 🏗️ Architecture
 
@@ -73,7 +73,7 @@ const searchStrategy = new StringAnchorSearchStrategy(["[", "]"]);
 // 2. Create processor with replacement logic
 const processor = new FunctionReplacementProcessor({
   searchStrategy,
-  replacement: (match, index) => `<${index}>`
+  replacement: (match, { matchIndex }) => `<${matchIndex}>`
 });
 
 // 3. Process chunks

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { mockSearchStrategyFactory } from "../../test/utilities.ts";
 import { AsyncFunctionReplacementProcessor } from "./async-function-replacement-processor.ts";
-import type { ReplacementContext } from "./replacement-processor.base.ts";
 import { inspect } from "node:util";
 
 describe("AsyncFunctionReplacementProcessor", () => {
@@ -32,20 +31,13 @@ describe("AsyncFunctionReplacementProcessor", () => {
   });
 
   it("increments match index for subsequent async matches", async () => {
-    const calls: Array<[string, ReplacementContext]> = [];
-
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: true, content: "MATCH", streamIndices: [0, 5] },
       { isMatch: false, content: " and " },
       { isMatch: true, content: "MATCH", streamIndices: [10, 15] }
     );
 
-    const asyncReplacementFn = vi.fn(
-      (match: string, context: ReplacementContext) => {
-        calls.push([match, context]);
-        return Promise.resolve("ASYNC");
-      }
-    );
+    const asyncReplacementFn = vi.fn().mockResolvedValue("ASYNC");
 
     const processor = new AsyncFunctionReplacementProcessor({
       searchStrategy: mockStrategy,
@@ -58,21 +50,14 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(calls).toHaveLength(2);
-    expect(calls[0]).toEqual([
-      "MATCH",
-      {
-        matchIndex: 0,
-        streamIndices: [0, 5]
-      }
-    ]);
-    expect(calls[1]).toEqual([
-      "MATCH",
-      {
-        matchIndex: 1,
-        streamIndices: [10, 15]
-      }
-    ]);
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", {
+      matchIndex: 0,
+      streamIndices: [0, 5]
+    });
+    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", {
+      matchIndex: 1,
+      streamIndices: [10, 15]
+    });
   });
 
   it("handles string replacement with async processor", async () => {

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { mockSearchStrategyFactory } from "../../test/utilities.ts";
-import { AsyncFunctionReplacementProcessor } from "./async-function-replacement-processor.ts";
+import { mockSearchStrategyFactory } from "../../test/utilities";
+import { AsyncFunctionReplacementProcessor } from "./async-function-replacement-processor";
 import { inspect } from "node:util";
 
 describe("AsyncFunctionReplacementProcessor", () => {

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { mockSearchStrategyFactory } from "../../test/utilities";
-import { AsyncFunctionReplacementProcessor } from "./async-function-replacement-processor";
+import { mockSearchStrategyFactory } from "../../test/utilities.js";
+import { AsyncFunctionReplacementProcessor } from "./async-function-replacement-processor.js";
 import { inspect } from "node:util";
 
 describe("AsyncFunctionReplacementProcessor", () => {

--- a/src/replacement-processors/async-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-function-replacement-processor.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { mockSearchStrategyFactory } from "../../test/utilities.ts";
 import { AsyncFunctionReplacementProcessor } from "./async-function-replacement-processor.ts";
+import type { ReplacementContext } from "./replacement-processor.base.ts";
 import { inspect } from "node:util";
 
 describe("AsyncFunctionReplacementProcessor", () => {
-  it("calls async replacement function with matched content and index", async () => {
+  it("calls async replacement function with match and context", async () => {
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: false, content: "Hello " },
       { isMatch: true, content: "MATCH", streamIndices: [6, 11] },
@@ -23,18 +24,28 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", 0, [6, 11]);
+    expect(asyncReplacementFn).toHaveBeenCalledWith("MATCH", {
+      matchIndex: 0,
+      streamIndices: [6, 11]
+    });
     expect(outputChunks).toEqual(["Hello ", "ASYNC_RESULT", " world"]);
   });
 
   it("increments match index for subsequent async matches", async () => {
+    const calls: Array<[string, ReplacementContext]> = [];
+
     const mockStrategy = mockSearchStrategyFactory(
       { isMatch: true, content: "MATCH", streamIndices: [0, 5] },
       { isMatch: false, content: " and " },
       { isMatch: true, content: "MATCH", streamIndices: [10, 15] }
     );
 
-    const asyncReplacementFn = vi.fn().mockResolvedValue("ASYNC");
+    const asyncReplacementFn = vi.fn(
+      (match: string, context: ReplacementContext) => {
+        calls.push([match, context]);
+        return Promise.resolve("ASYNC");
+      }
+    );
 
     const processor = new AsyncFunctionReplacementProcessor({
       searchStrategy: mockStrategy,
@@ -47,8 +58,21 @@ describe("AsyncFunctionReplacementProcessor", () => {
       outputChunks.push(chunk);
     }
 
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, [0, 5]);
-    expect(asyncReplacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, [10, 15]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual([
+      "MATCH",
+      {
+        matchIndex: 0,
+        streamIndices: [0, 5]
+      }
+    ]);
+    expect(calls[1]).toEqual([
+      "MATCH",
+      {
+        matchIndex: 1,
+        streamIndices: [10, 15]
+      }
+    ]);
   });
 
   it("handles string replacement with async processor", async () => {

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -54,7 +54,7 @@ export type AsyncFunctionReplacementProcessorOptions<
  * 
  * const processor = new AsyncFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{user}}'),
- *   replacement: async (_match, { matchIndex }) => {
+ *   replacement: async (match, { matchIndex }) => {
  *     const response = await fetch(`/api/users/${matchIndex}`);
  *     return response.text();
  *   }

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -2,8 +2,8 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base";
-import { type AsyncProcessor } from "./types";
+} from "./replacement-processor.base.js";
+import { type AsyncProcessor } from "./types.js";
 
 /**
  * Configuration options for {@link AsyncFunctionReplacementProcessor}.

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -2,8 +2,8 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base.ts";
-import { type AsyncProcessor } from "./types.ts";
+} from "./replacement-processor.base";
+import { type AsyncProcessor } from "./types";
 
 /**
  * Configuration options for {@link AsyncFunctionReplacementProcessor}.

--- a/src/replacement-processors/async-function-replacement-processor.ts
+++ b/src/replacement-processors/async-function-replacement-processor.ts
@@ -1,5 +1,6 @@
 import {
   ReplacementProcessorBase,
+  type ReplacementContext,
   type ReplacementProcessorOptions
 } from "./replacement-processor.base.ts";
 import { type AsyncProcessor } from "./types.ts";
@@ -17,12 +18,10 @@ export type AsyncFunctionReplacementProcessorOptions<
   /**
    * Async function called for each match to generate the replacement content.
    * 
-   * @param match - The matched content
-   * @param matchIndex - Zero-based index of this match
-   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
+   * @param context - The match context
    * @returns Promise resolving to the replacement string
    */
-  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<string>;
+  replacement: (match: TMatch, context: ReplacementContext) => Promise<string>;
 };
 
 /**
@@ -55,7 +54,7 @@ export type AsyncFunctionReplacementProcessorOptions<
  * 
  * const processor = new AsyncFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{user}}'),
- *   replacement: async (match, matchIndex) => {
+ *   replacement: async (_match, { matchIndex }) => {
  *     const response = await fetch(`/api/users/${matchIndex}`);
  *     return response.text();
  *   }
@@ -69,7 +68,7 @@ export class AsyncFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
-  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<string>;
+  private readonly replacementFn: (match: TMatch, context: ReplacementContext) => Promise<string>;
   private matchIndex: number = 0;
 
   constructor({
@@ -89,11 +88,10 @@ export class AsyncFunctionReplacementProcessor<
         yield result.content;
         continue;
       }
-      yield await this.replacementFn(
-        result.content,
-        this.matchIndex++,
-        result.streamIndices
-      );
+      yield await this.replacementFn(result.content, {
+        matchIndex: this.matchIndex++,
+        streamIndices: result.streamIndices
+      });
     }
   }
 }

--- a/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { mockSearchStrategyFactory } from "../../test/utilities.ts";
 import { AsyncIterableFunctionReplacementProcessor } from "./async-iterable-function-replacement-processor.ts";
+import type { ReplacementContext } from "./replacement-processor.base.ts";
 
 describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("yields stream content chunk-by-chunk without buffering", async () => {
@@ -104,10 +105,10 @@ describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("handles stream replacement with match context and index", async () => {
     const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", streamIndices: [0, 5] });
 
-    const streamFactory = async (matchedContent: string, matchIndex: number) => {
+    const streamFactory = async (match: string, { matchIndex }: ReplacementContext) => {
       return new ReadableStream({
         start(controller) {
-          controller.enqueue(`[${matchedContent}:${matchIndex}]`);
+          controller.enqueue(`[${ match }:${matchIndex}]`);
           controller.close();
         }
       });

--- a/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { mockSearchStrategyFactory } from "../../test/utilities.ts";
-import { AsyncIterableFunctionReplacementProcessor } from "./async-iterable-function-replacement-processor.ts";
-import type { ReplacementContext } from "./replacement-processor.base.ts";
+import { mockSearchStrategyFactory } from "../../test/utilities";
+import { AsyncIterableFunctionReplacementProcessor } from "./async-iterable-function-replacement-processor";
+import type { ReplacementContext } from "./replacement-processor.base";
 
 describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("yields stream content chunk-by-chunk without buffering", async () => {

--- a/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { mockSearchStrategyFactory } from "../../test/utilities";
-import { AsyncIterableFunctionReplacementProcessor } from "./async-iterable-function-replacement-processor";
-import type { ReplacementContext } from "./replacement-processor.base";
+import { mockSearchStrategyFactory } from "../../test/utilities.js";
+import { AsyncIterableFunctionReplacementProcessor } from "./async-iterable-function-replacement-processor.js";
+import type { ReplacementContext } from "./replacement-processor.base.js";
 
 describe("AsyncIterableFunctionReplacementProcessor", () => {
   it("yields stream content chunk-by-chunk without buffering", async () => {

--- a/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.test.ts
@@ -211,4 +211,27 @@ describe("flush", () => {
     const flushed = processor.flush();
     expect(flushed).toBe("");
   });
+
+  it("accepts replacement that directly returns an async iterable", async () => {
+    const mockStrategy = mockSearchStrategyFactory(
+      { isMatch: false, content: "Hello " },
+      { isMatch: true, content: "OLD", streamIndices: [6, 9] },
+      { isMatch: false, content: " world" }
+    );
+
+    const processor = new AsyncIterableFunctionReplacementProcessor({
+      searchStrategy: mockStrategy,
+      replacement: async function* () {
+        yield "chunk1";
+        yield "chunk2";
+      }
+    });
+
+    const outputChunks: string[] = [];
+    for await (const chunk of processor.processChunk("Hello OLD world")) {
+      outputChunks.push(chunk);
+    }
+
+    expect(outputChunks).toEqual(["Hello ", "chunk1", "chunk2", " world"]);
+  });
 });

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -2,8 +2,8 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base";
-import { type AsyncProcessor } from "./types";
+} from "./replacement-processor.base.js";
+import { type AsyncProcessor } from "./types.js";
 
 /**
  * Configuration options for {@link AsyncIterableFunctionReplacementProcessor}.

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -19,9 +19,11 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
    * Async function called for each match that returns an async iterable of replacement strings.
    * 
    * @param context - The match context
-   * @returns Promise resolving to an async iterable of replacement strings
+   * @returns Async iterable of replacement strings, either directly or wrapped in a Promise
    */
-  replacement: (match: TMatch, context: ReplacementContext) => Promise<AsyncIterable<string>>;
+  replacement: (match: TMatch, context: ReplacementContext) =>
+    | AsyncIterable<string>
+    | Promise<AsyncIterable<string>>;
 };
 
 /**
@@ -91,7 +93,9 @@ export class AsyncIterableFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
-  private readonly replacementFn: (match: TMatch, context: ReplacementContext) => Promise<AsyncIterable<string>>;
+  private readonly replacementFn: (match: TMatch, context: ReplacementContext) =>
+    | AsyncIterable<string>
+    | Promise<AsyncIterable<string>>;
   private matchIndex: number = 0;
 
   constructor({

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -49,7 +49,7 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
  * 
  * const processor = new AsyncIterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{stream}}'),
- *   replacement: async function* (_match, { matchIndex }) {
+ *   replacement: async function* (match, { matchIndex }) {
  *     const response = await fetch(`/api/stream/${matchIndex}`);
  *     const reader = response.body.getReader();
  *     

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -56,7 +56,7 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
  *     while (true) {
  *       const { done, value } = await reader.read();
  *       if (done) break;
- *       yield new TextDecoder().decode(value);
+ *       yield new TextDecoder().decode(value, { stream: true });
  *     }
  *   }
  * });

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -2,8 +2,8 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base.ts";
-import { type AsyncProcessor } from "./types.ts";
+} from "./replacement-processor.base";
+import { type AsyncProcessor } from "./types";
 
 /**
  * Configuration options for {@link AsyncIterableFunctionReplacementProcessor}.

--- a/src/replacement-processors/async-iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/async-iterable-function-replacement-processor.ts
@@ -1,5 +1,6 @@
 import {
   ReplacementProcessorBase,
+  type ReplacementContext,
   type ReplacementProcessorOptions
 } from "./replacement-processor.base.ts";
 import { type AsyncProcessor } from "./types.ts";
@@ -17,12 +18,10 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
   /**
    * Async function called for each match that returns an async iterable of replacement strings.
    * 
-   * @param match - The matched content (type inferred from search strategy)
-   * @param matchIndex - Zero-based index of this match
-   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
+   * @param context - The match context
    * @returns Promise resolving to an async iterable of replacement strings
    */
-  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<AsyncIterable<string>>;
+  replacement: (match: TMatch, context: ReplacementContext) => Promise<AsyncIterable<string>>;
 };
 
 /**
@@ -50,7 +49,7 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
  * 
  * const processor = new AsyncIterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{stream}}'),
- *   replacement: async function* (match, matchIndex) {
+ *   replacement: async function* (_match, { matchIndex }) {
  *     const response = await fetch(`/api/stream/${matchIndex}`);
  *     const reader = response.body.getReader();
  *     
@@ -70,7 +69,7 @@ export type AsyncIterableFunctionReplacementProcessorOptions<
  * ```typescript
  * const processor = new AsyncIterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{users}}'),
- *   replacement: async function* (match, matchIndex) {
+ *   replacement: async function* () {
  *     let page = 0;
  *     let hasMore = true;
  *     
@@ -92,7 +91,7 @@ export class AsyncIterableFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements AsyncProcessor {
-  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Promise<AsyncIterable<string>>;
+  private readonly replacementFn: (match: TMatch, context: ReplacementContext) => Promise<AsyncIterable<string>>;
   private matchIndex: number = 0;
 
   constructor({
@@ -112,11 +111,10 @@ export class AsyncIterableFunctionReplacementProcessor<
         yield result.content;
         continue;
       }
-      yield* await this.replacementFn(
-        result.content,
-        this.matchIndex++,
-        result.streamIndices
-      );
+      yield* await this.replacementFn(result.content, {
+        matchIndex: this.matchIndex++,
+        streamIndices: result.streamIndices
+      });
     }
   }
 }

--- a/src/replacement-processors/benchmarking/types.ts
+++ b/src/replacement-processors/benchmarking/types.ts
@@ -1,4 +1,4 @@
-import type { Processor } from "../types";
+import type { Processor } from "../types.js";
 
 export interface SyncCallbackProcessor<
   T extends string | Promise<string> = string

--- a/src/replacement-processors/function-replacement-processor.integration.test.ts
+++ b/src/replacement-processors/function-replacement-processor.integration.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   StringAnchorSearchStrategy,
   RegexSearchStrategy
-} from "../search-strategies/index";
-import { FunctionReplacementProcessor } from "./function-replacement-processor";
+} from "../search-strategies/index.js";
+import { FunctionReplacementProcessor } from "./function-replacement-processor.js";
 
 describe("FunctionReplacementProcessor + StringAnchorSearchStrategy", () => {
   it("simple match", () => {

--- a/src/replacement-processors/function-replacement-processor.integration.test.ts
+++ b/src/replacement-processors/function-replacement-processor.integration.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   StringAnchorSearchStrategy,
   RegexSearchStrategy
-} from "../search-strategies/index.ts";
-import { FunctionReplacementProcessor } from "./function-replacement-processor.ts";
+} from "../search-strategies/index";
+import { FunctionReplacementProcessor } from "./function-replacement-processor";
 
 describe("FunctionReplacementProcessor + StringAnchorSearchStrategy", () => {
   it("simple match", () => {

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { FunctionReplacementProcessor } from "./function-replacement-processor.ts";
-import { mockSearchStrategyFactory } from "../../test/utilities.ts";
+import { FunctionReplacementProcessor } from "./function-replacement-processor";
+import { mockSearchStrategyFactory } from "../../test/utilities";
 
 describe("FunctionReplacementProcessor", () => {
   describe("processChunk", () => {

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { FunctionReplacementProcessor } from "./function-replacement-processor";
-import { mockSearchStrategyFactory } from "../../test/utilities";
+import { FunctionReplacementProcessor } from "./function-replacement-processor.js";
+import { mockSearchStrategyFactory } from "../../test/utilities.js";
 
 describe("FunctionReplacementProcessor", () => {
   describe("processChunk", () => {

--- a/src/replacement-processors/function-replacement-processor.test.ts
+++ b/src/replacement-processors/function-replacement-processor.test.ts
@@ -129,7 +129,7 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenCalledWith("MATCH", 0, [6, 11]);
+      expect(replacementFn).toHaveBeenCalledWith("MATCH", { matchIndex: 0, streamIndices: [6, 11] });
       expect(outputChunks).toEqual(["Hello ", "RESULT", " world"]);
     });
 
@@ -164,8 +164,8 @@ describe("FunctionReplacementProcessor", () => {
         outputChunks.push(chunk);
       }
 
-      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", 0, [0, 5]);
-      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", 1, [5, 10]);
+      expect(replacementFn).toHaveBeenNthCalledWith(1, "MATCH", { matchIndex: 0, streamIndices: [0, 5] });
+      expect(replacementFn).toHaveBeenNthCalledWith(2, "MATCH", { matchIndex: 1, streamIndices: [5, 10] });
     });
 
     it("continues processing after match to find subsequent matches", () => {

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -2,7 +2,7 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base";
+} from "./replacement-processor.base.js";
 
 /**
  * Configuration options for {@link FunctionReplacementProcessor}.

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -1,5 +1,6 @@
 import {
   ReplacementProcessorBase,
+  type ReplacementContext,
   type ReplacementProcessorOptions
 } from "./replacement-processor.base.ts";
 
@@ -18,12 +19,10 @@ export type FunctionReplacementProcessorOptions<
   /**
    * Function called for each match to generate the replacement content.
    * 
-   * @param match - The matched content (type inferred from search strategy)
-   * @param matchIndex - Zero-based index of this match (increments with each match)
-   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
+   * @param context - The match context
    * @returns The replacement string, or a Promise<string> for async operations
    */
-  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => R;
+  replacement: (match: TMatch, context: ReplacementContext) => R;
 };
 
 /**
@@ -51,7 +50,7 @@ export type FunctionReplacementProcessorOptions<
  * 
  * const processor = new FunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory(/{{(\w+)}}/g),
- *   replacement: (match, matchIndex) => `Replacement #${matchIndex}: ${match[1]}`
+ *   replacement: (match, { matchIndex }) => `Replacement #${matchIndex}: ${match[1]}`
  * });
  * 
  * const transformer = new ReplaceContentTransformer(processor);
@@ -64,7 +63,7 @@ export type FunctionReplacementProcessorOptions<
  * 
  * const processor = new FunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{id}}'),
- *   replacement: async (match, matchIndex) => {
+ *   replacement: async (_match, { matchIndex }) => {
  *     const data = await fetch(`/api/data/${matchIndex}`);
  *     return data.text();
  *   }
@@ -79,7 +78,7 @@ export class FunctionReplacementProcessor<
   TMatch = string,
   R extends string | Promise<string> = string
 > extends ReplacementProcessorBase<TState, TMatch> {
-  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => R;
+  private readonly replacementFn: (match: TMatch, context: ReplacementContext) => R;
   private matchIndex: number = 0;
 
   constructor({
@@ -99,11 +98,10 @@ export class FunctionReplacementProcessor<
         yield result.content;
         continue;
       }
-      yield this.replacementFn(
-        result.content,
-        this.matchIndex++,
-        result.streamIndices
-      );
+      yield this.replacementFn(result.content, {
+        matchIndex: this.matchIndex++,
+        streamIndices: result.streamIndices
+      });
     }
   }
 }

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -63,7 +63,7 @@ export type FunctionReplacementProcessorOptions<
  * 
  * const processor = new FunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{id}}'),
- *   replacement: async (_match, { matchIndex }) => {
+ *   replacement: async (match, { matchIndex }) => {
  *     const data = await fetch(`/api/data/${matchIndex}`);
  *     return data.text();
  *   }

--- a/src/replacement-processors/function-replacement-processor.ts
+++ b/src/replacement-processors/function-replacement-processor.ts
@@ -2,7 +2,7 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base.ts";
+} from "./replacement-processor.base";
 
 /**
  * Configuration options for {@link FunctionReplacementProcessor}.

--- a/src/replacement-processors/index.ts
+++ b/src/replacement-processors/index.ts
@@ -1,6 +1,6 @@
-export * from "./static-replacement-processor";
-export * from "./function-replacement-processor";
-export * from "./iterable-function-replacement-processor";
-export * from "./async-function-replacement-processor";
-export * from "./async-iterable-function-replacement-processor";
-export type { ReplacementContext } from "./replacement-processor.base";
+export * from "./static-replacement-processor.js";
+export * from "./function-replacement-processor.js";
+export * from "./iterable-function-replacement-processor.js";
+export * from "./async-function-replacement-processor.js";
+export * from "./async-iterable-function-replacement-processor.js";
+export type { ReplacementContext } from "./replacement-processor.base.js";

--- a/src/replacement-processors/index.ts
+++ b/src/replacement-processors/index.ts
@@ -1,6 +1,6 @@
-export * from "./static-replacement-processor.ts";
-export * from "./function-replacement-processor.ts";
-export * from "./iterable-function-replacement-processor.ts";
-export * from "./async-function-replacement-processor.ts";
-export * from "./async-iterable-function-replacement-processor.ts";
-export type { ReplacementContext } from "./replacement-processor.base.ts";
+export * from "./static-replacement-processor";
+export * from "./function-replacement-processor";
+export * from "./iterable-function-replacement-processor";
+export * from "./async-function-replacement-processor";
+export * from "./async-iterable-function-replacement-processor";
+export type { ReplacementContext } from "./replacement-processor.base";

--- a/src/replacement-processors/index.ts
+++ b/src/replacement-processors/index.ts
@@ -3,3 +3,4 @@ export * from "./function-replacement-processor.ts";
 export * from "./iterable-function-replacement-processor.ts";
 export * from "./async-function-replacement-processor.ts";
 export * from "./async-iterable-function-replacement-processor.ts";
+export type { ReplacementContext } from "./replacement-processor.base.ts";

--- a/src/replacement-processors/iterable-function-replacement-processor.integration.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor.ts";
-import { StringAnchorSearchStrategy } from "../search-strategies/index.ts";
+import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor";
+import { StringAnchorSearchStrategy } from "../search-strategies/index";
 
 describe("IterableFunctionReplacementProcessor + BufferedIndexOfCancellableSearchStrategy", () => {
   it("should support recursive replacement", async () => {

--- a/src/replacement-processors/iterable-function-replacement-processor.integration.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor";
-import { StringAnchorSearchStrategy } from "../search-strategies/index";
+import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor.js";
+import { StringAnchorSearchStrategy } from "../search-strategies/index.js";
 
 describe("IterableFunctionReplacementProcessor + BufferedIndexOfCancellableSearchStrategy", () => {
   it("should support recursive replacement", async () => {

--- a/src/replacement-processors/iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor.ts";
 import { mockSearchStrategyFactory } from "../../test/utilities.ts";
+import type { ReplacementContext } from "./replacement-processor.base.ts";
 
 describe("IterableFunctionReplacementProcessor", () => {
   const mockInput = "test input";
@@ -87,8 +88,8 @@ describe("IterableFunctionReplacementProcessor", () => {
   it("handles iterable replacement with match context and index", async () => {
     const mockStrategy = mockSearchStrategyFactory({ isMatch: true, content: "MATCH", streamIndices: [0, 5] });
 
-    const iterableFactory = (matchedContent: string, matchIndex: number) => {
-      return [`[${matchedContent}:${matchIndex}]`];
+    const iterableFactory = (match: string, { matchIndex }: ReplacementContext) => {
+      return [`[${ match }:${matchIndex}]`];
     };
 
     const processor = new IterableFunctionReplacementProcessor({

--- a/src/replacement-processors/iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor.ts";
-import { mockSearchStrategyFactory } from "../../test/utilities.ts";
-import type { ReplacementContext } from "./replacement-processor.base.ts";
+import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor";
+import { mockSearchStrategyFactory } from "../../test/utilities";
+import type { ReplacementContext } from "./replacement-processor.base";
 
 describe("IterableFunctionReplacementProcessor", () => {
   const mockInput = "test input";

--- a/src/replacement-processors/iterable-function-replacement-processor.test.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor";
-import { mockSearchStrategyFactory } from "../../test/utilities";
-import type { ReplacementContext } from "./replacement-processor.base";
+import { IterableFunctionReplacementProcessor } from "./iterable-function-replacement-processor.js";
+import { mockSearchStrategyFactory } from "../../test/utilities.js";
+import type { ReplacementContext } from "./replacement-processor.base.js";
 
 describe("IterableFunctionReplacementProcessor", () => {
   const mockInput = "test input";

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -1,5 +1,6 @@
 import {
   ReplacementProcessorBase,
+  type ReplacementContext,
   type ReplacementProcessorOptions
 } from "./replacement-processor.base.ts";
 import { type SyncProcessor } from "./types.ts";
@@ -17,12 +18,10 @@ export type IterableFunctionReplacementProcessorOptions<
   /**
    * Function called for each match that returns an iterable of replacement strings.
    *
-   * @param match - The matched content (type inferred from search strategy)
-   * @param matchIndex - Zero-based index of this match
-   * @param streamIndices - [startIndex, endIndex] of the match in the stream (endIndex is exclusive)
+   * @param context - The match context
    * @returns An iterable of replacement strings
    */
-  replacement: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Iterable<string>;
+  replacement: (match: TMatch, context: ReplacementContext) => Iterable<string>;
 };
 
 /**
@@ -48,7 +47,7 @@ export type IterableFunctionReplacementProcessorOptions<
  *
  * const processor = new IterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{list}}'),
- *   replacement: (match, matchIndex) => ['Item 1', 'Item 2', 'Item 3']
+ *   replacement: () => ['Item 1', 'Item 2', 'Item 3']
  * });
  *
  * const transformer = new ReplaceContentTransformer(processor);
@@ -58,7 +57,7 @@ export type IterableFunctionReplacementProcessorOptions<
  * ```typescript
  * const processor = new IterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{repeat}}'),
- *   replacement: function* (match, matchIndex) {
+ *   replacement: function* (_match, { matchIndex }) {
  *     for (let i = 0; i < 5; i++) {
  *       yield `Iteration ${i}\n`;
  *     }
@@ -70,7 +69,7 @@ export class IterableFunctionReplacementProcessor<
   TState,
   TMatch = string
 > extends ReplacementProcessorBase<TState, TMatch> implements SyncProcessor {
-  private readonly replacementFn: (match: TMatch, matchIndex: number, streamIndices: [startIndex: number, endIndex: number]) => Iterable<string>;
+  private readonly replacementFn: (match: TMatch, context: ReplacementContext) => Iterable<string>;
   private matchIndex: number = 0;
 
   constructor({
@@ -90,11 +89,10 @@ export class IterableFunctionReplacementProcessor<
         yield result.content;
         continue;
       }
-      yield* this.replacementFn(
-        result.content,
-        this.matchIndex++,
-        result.streamIndices
-      );
+      yield* this.replacementFn(result.content, {
+        matchIndex: this.matchIndex++,
+        streamIndices: result.streamIndices
+      });
     }
   }
 }

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -57,7 +57,7 @@ export type IterableFunctionReplacementProcessorOptions<
  * ```typescript
  * const processor = new IterableFunctionReplacementProcessor({
  *   searchStrategy: searchStrategyFactory('{{repeat}}'),
- *   replacement: function* (_match, { matchIndex }) {
+ *   replacement: function* () {
  *     for (let i = 0; i < 5; i++) {
  *       yield `Iteration ${i}\n`;
  *     }

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -2,8 +2,8 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base";
-import { type SyncProcessor } from "./types";
+} from "./replacement-processor.base.js";
+import { type SyncProcessor } from "./types.js";
 
 /**
  * Configuration options for {@link IterableFunctionReplacementProcessor}.

--- a/src/replacement-processors/iterable-function-replacement-processor.ts
+++ b/src/replacement-processors/iterable-function-replacement-processor.ts
@@ -2,8 +2,8 @@ import {
   ReplacementProcessorBase,
   type ReplacementContext,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base.ts";
-import { type SyncProcessor } from "./types.ts";
+} from "./replacement-processor.base";
+import { type SyncProcessor } from "./types";
 
 /**
  * Configuration options for {@link IterableFunctionReplacementProcessor}.

--- a/src/replacement-processors/replacement-processor.base.ts
+++ b/src/replacement-processors/replacement-processor.base.ts
@@ -1,4 +1,4 @@
-import type { SearchStrategy } from "../search-strategies/types";
+import type { SearchStrategy } from "../search-strategies/types.js";
 
 /**
  * Base options for all replacement processors.

--- a/src/replacement-processors/replacement-processor.base.ts
+++ b/src/replacement-processors/replacement-processor.base.ts
@@ -9,6 +9,17 @@ export type ReplacementProcessorOptions<TState, TMatch> = {
 };
 
 /**
+ * Context passed to replacement callbacks.
+ *
+ * @property matchIndex - Zero-based ordinal for the current match in the stream.
+ * @property streamIndices - Absolute stream offsets as [startIndex, endIndex], where endIndex is exclusive.
+ */
+export type ReplacementContext = {
+  matchIndex: number;
+  streamIndices: [startIndex: number, endIndex: number];
+};
+
+/**
  * Base class for replacement processors.
  * Uses separate generics for state and match to avoid type casts.
  */

--- a/src/replacement-processors/static-replacement-processor.test.ts
+++ b/src/replacement-processors/static-replacement-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { mockSearchStrategyFactory } from "../../test/utilities.ts";
-import { StaticReplacementProcessor } from "./static-replacement-processor.ts";
+import { mockSearchStrategyFactory } from "../../test/utilities";
+import { StaticReplacementProcessor } from "./static-replacement-processor";
 
 describe("StaticReplacementProcessor", () => {
   const mockInput = "test input";

--- a/src/replacement-processors/static-replacement-processor.test.ts
+++ b/src/replacement-processors/static-replacement-processor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { mockSearchStrategyFactory } from "../../test/utilities";
-import { StaticReplacementProcessor } from "./static-replacement-processor";
+import { mockSearchStrategyFactory } from "../../test/utilities.js";
+import { StaticReplacementProcessor } from "./static-replacement-processor.js";
 
 describe("StaticReplacementProcessor", () => {
   const mockInput = "test input";

--- a/src/replacement-processors/static-replacement-processor.ts
+++ b/src/replacement-processors/static-replacement-processor.ts
@@ -1,8 +1,8 @@
 import {
   ReplacementProcessorBase,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base.ts";
-import { type SyncProcessor } from "./types.ts";
+} from "./replacement-processor.base";
+import { type SyncProcessor } from "./types";
 
 /**
  * Configuration options for {@link StaticReplacementProcessor}.

--- a/src/replacement-processors/static-replacement-processor.ts
+++ b/src/replacement-processors/static-replacement-processor.ts
@@ -1,8 +1,8 @@
 import {
   ReplacementProcessorBase,
   type ReplacementProcessorOptions
-} from "./replacement-processor.base";
-import { type SyncProcessor } from "./types";
+} from "./replacement-processor.base.js";
+import { type SyncProcessor } from "./types.js";
 
 /**
  * Configuration options for {@link StaticReplacementProcessor}.

--- a/src/search-strategies/benchmarking/anchor-sequence/index.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-strategy.ts";
+export * from "./search-strategy";

--- a/src/search-strategies/benchmarking/anchor-sequence/index.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-strategy";
+export * from "./search-strategy.js";

--- a/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { AnchorSequenceSearchStrategy } from "./search-strategy";
-import { BufferedIndexOfCancellableSearchStrategy } from "../buffered-indexOf-cancellable/search-strategy";
+import { AnchorSequenceSearchStrategy } from "./search-strategy.js";
+import { BufferedIndexOfCancellableSearchStrategy } from "../buffered-indexOf-cancellable/search-strategy.js";
 
 describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrategy", () => {
   it("simple two-delimiter match", () => {

--- a/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { AnchorSequenceSearchStrategy } from "./search-strategy.ts";
-import { BufferedIndexOfCancellableSearchStrategy } from "../buffered-indexOf-cancellable/search-strategy.ts";
+import { AnchorSequenceSearchStrategy } from "./search-strategy";
+import { BufferedIndexOfCancellableSearchStrategy } from "../buffered-indexOf-cancellable/search-strategy";
 
 describe("AnchorSequenceSearchStrategy + BufferedIndexOfCancellableSearchStrategy", () => {
   it("simple two-delimiter match", () => {

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
-import { AnchorSequenceSearchStrategy } from "./search-strategy";
-import { IndexOfKnuthMorrisPrattSearchStrategy } from "../indexOf-knuth-morris-pratt/index";
-import type { MatchResult } from "../../types";
+import { AnchorSequenceSearchStrategy } from "./search-strategy.js";
+import { IndexOfKnuthMorrisPrattSearchStrategy } from "../indexOf-knuth-morris-pratt/index.js";
+import type { MatchResult } from "../../types.js";
 
 describe("AnchorSequenceSearchStrategy", () => {
   describe("findMatch - single call scenarios", () => {

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
-import { AnchorSequenceSearchStrategy } from "./search-strategy.ts";
-import { IndexOfKnuthMorrisPrattSearchStrategy } from "../indexOf-knuth-morris-pratt/index.ts";
-import type { MatchResult } from "../../types.ts";
+import { AnchorSequenceSearchStrategy } from "./search-strategy";
+import { IndexOfKnuthMorrisPrattSearchStrategy } from "../indexOf-knuth-morris-pratt/index";
+import type { MatchResult } from "../../types";
 
 describe("AnchorSequenceSearchStrategy", () => {
   describe("findMatch - single call scenarios", () => {

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
@@ -1,7 +1,7 @@
-import type { MatchResult, SearchStrategy } from "../../types.ts";
+import type { MatchResult, SearchStrategy } from "../../types";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base.ts";
+} from "../../string-buffer-strategy-base";
 export interface AnchorSequenceSearchState<TState> extends StringBufferState {
   currentNeedleIndex: number;
   strategyStates: TState[];

--- a/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
+++ b/src/search-strategies/benchmarking/anchor-sequence/search-strategy.ts
@@ -1,7 +1,7 @@
-import type { MatchResult, SearchStrategy } from "../../types";
+import type { MatchResult, SearchStrategy } from "../../types.js";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base";
+} from "../../string-buffer-strategy-base.js";
 export interface AnchorSequenceSearchState<TState> extends StringBufferState {
   currentNeedleIndex: number;
   strategyStates: TState[];

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/index.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/index.ts
@@ -1,1 +1,1 @@
-export { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./search-strategy";
+export { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./search-strategy.js";

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.test.ts
@@ -319,12 +319,12 @@ describe("BufferedIndexOfAnchoredCallbackSearchStrategy", () => {
       expect(flushed).toBe("}");
     });
 
-    it("handles replacement function with index parameter", () => {
+    it("handles replacement function with match context", () => {
       const replacements: string[] = [];
       const strategy = new BufferedIndexOfAnchoredCallbackSearchStrategy(
-        (match, index) => {
-          replacements.push(`Match${index}`);
-          return `[${index}]`;
+        (match, context) => {
+          replacements.push(`Match${context.matchIndex}`);
+          return `[${context.matchIndex}]`;
         },
         ["{{", "}}"]
       );

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./search-strategy";
+import { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./search-strategy.js";
 
 describe("BufferedIndexOfAnchoredCallbackSearchStrategy", () => {
   // Helper to collect outputs from callback-based processor

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./search-strategy.ts";
+import { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./search-strategy";
 
 describe("BufferedIndexOfAnchoredCallbackSearchStrategy", () => {
   // Helper to collect outputs from callback-based processor

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
@@ -8,6 +8,7 @@ export class BufferedIndexOfAnchoredCallbackSearchStrategy
   private readonly replacement: (match: string, context: ReplacementContext) => string;
   private readonly delimiters: string[];
   private matchIndex: number = 0;
+  private totalStreamOffset: number = 0;
 
   constructor(
     replacement: (match: string, context: ReplacementContext) => string,
@@ -19,51 +20,57 @@ export class BufferedIndexOfAnchoredCallbackSearchStrategy
   }
 
   processChunk(chunk: string, enqueue: (output: string) => void): void {
+    const bufferLength = this.partialChunk.length;
+    const baseOffset = this.totalStreamOffset - bufferLength;
     chunk = this.partialChunk + chunk;
     this.partialChunk = "";
     let position = 0;
 
-    while (position < chunk.length) {
-      const startIndex = chunk.indexOf(this.delimiters[0], position);
+    try {
+      while (position < chunk.length) {
+        const startIndex = chunk.indexOf(this.delimiters[0], position);
 
-      if (startIndex === -1) {
-        const bufferSize = this.delimiters[0].length - 1;
-        const splitPoint = Math.max(position, chunk.length - bufferSize);
-        this.partialChunk = chunk.slice(splitPoint);
-        if (position !== splitPoint) {
-          enqueue(chunk.slice(position, splitPoint));
-        }
-        return;
-      }
-
-      if (startIndex > position) {
-        enqueue(chunk.substring(position, startIndex));
-      }
-
-      let currentPos = startIndex + this.delimiters[0].length;
-      let delimiterIndex = 1;
-
-      while (delimiterIndex < this.delimiters.length) {
-        const delimiter = this.delimiters[delimiterIndex];
-        const delimIndex = chunk.indexOf(delimiter, currentPos);
-
-        if (delimIndex === -1) {
-          this.partialChunk = chunk.substring(startIndex);
+        if (startIndex === -1) {
+          const bufferSize = this.delimiters[0].length - 1;
+          const splitPoint = Math.max(position, chunk.length - bufferSize);
+          this.partialChunk = chunk.slice(splitPoint);
+          if (position !== splitPoint) {
+            enqueue(chunk.slice(position, splitPoint));
+          }
           return;
         }
 
-        currentPos = delimIndex + delimiter.length;
-        delimiterIndex++;
-      }
+        if (startIndex > position) {
+          enqueue(chunk.substring(position, startIndex));
+        }
 
-      const matchEnd = currentPos;
-      const match = chunk.substring(startIndex, matchEnd);
-      const replacement = this.replacement(match, {
-        matchIndex: this.matchIndex++,
-        streamIndices: [startIndex, matchEnd]
-      });
-      enqueue(replacement);
-      position = matchEnd;
+        let currentPos = startIndex + this.delimiters[0].length;
+        let delimiterIndex = 1;
+
+        while (delimiterIndex < this.delimiters.length) {
+          const delimiter = this.delimiters[delimiterIndex];
+          const delimIndex = chunk.indexOf(delimiter, currentPos);
+
+          if (delimIndex === -1) {
+            this.partialChunk = chunk.substring(startIndex);
+            return;
+          }
+
+          currentPos = delimIndex + delimiter.length;
+          delimiterIndex++;
+        }
+
+        const matchEnd = currentPos;
+        const match = chunk.substring(startIndex, matchEnd);
+        const replacement = this.replacement(match, {
+          matchIndex: this.matchIndex++,
+          streamIndices: [baseOffset + startIndex, baseOffset + matchEnd]
+        });
+        enqueue(replacement);
+        position = matchEnd;
+      }
+    } finally {
+      this.totalStreamOffset += chunk.length - bufferLength;
     }
   }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.js";
 
 export class BufferedIndexOfAnchoredCallbackSearchStrategy
   implements SyncCallbackProcessor

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
@@ -1,15 +1,16 @@
 import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
 
 export class BufferedIndexOfAnchoredCallbackSearchStrategy
   implements SyncCallbackProcessor
 {
   private partialChunk: string;
-  private readonly replacement: (match: string, index: number) => string;
+  private readonly replacement: (match: string, context: ReplacementContext) => string;
   private readonly delimiters: string[];
   private matchIndex: number = 0;
 
   constructor(
-    replacement: (match: string, index: number) => string,
+    replacement: (match: string, context: ReplacementContext) => string,
     delimiters: string[]
   ) {
     this.replacement = replacement;
@@ -57,7 +58,10 @@ export class BufferedIndexOfAnchoredCallbackSearchStrategy
 
       const matchEnd = currentPos;
       const match = chunk.substring(startIndex, matchEnd);
-      const replacement = this.replacement(match, this.matchIndex++);
+      const replacement = this.replacement(match, {
+        matchIndex: this.matchIndex++,
+        streamIndices: [startIndex, matchEnd]
+      });
       enqueue(replacement);
       position = matchEnd;
     }

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
 
 export class BufferedIndexOfAnchoredCallbackSearchStrategy
   implements SyncCallbackProcessor

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/index.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/index.ts
@@ -1,4 +1,4 @@
 export {
   BufferedIndexOfAnchoredSearchStrategy,
   type BufferedIndexOfAnchoredSearchState
-} from "./search-strategy.ts";
+} from "./search-strategy";

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/index.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/index.ts
@@ -1,4 +1,4 @@
 export {
   BufferedIndexOfAnchoredSearchStrategy,
   type BufferedIndexOfAnchoredSearchState
-} from "./search-strategy";
+} from "./search-strategy.js";

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { BufferedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
-import { MatchResult } from "../../types.ts";
+import { BufferedIndexOfAnchoredSearchStrategy } from "./search-strategy";
+import { MatchResult } from "../../types";
 
 // Helper function to extract string value from MatchResult
 function getValue(result: MatchResult): string {

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { BufferedIndexOfAnchoredSearchStrategy } from "./search-strategy";
-import { MatchResult } from "../../types";
+import { BufferedIndexOfAnchoredSearchStrategy } from "./search-strategy.js";
+import { MatchResult } from "../../types.js";
 
 // Helper function to extract string value from MatchResult
 function getValue(result: MatchResult): string {

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { MatchResult, SearchStrategy } from "../../types.ts";
-import StringBufferStrategyBase from "../../string-buffer-strategy-base.ts";
+import type { MatchResult, SearchStrategy } from "../../types";
+import StringBufferStrategyBase from "../../string-buffer-strategy-base";
 
 export type BufferedIndexOfAnchoredSearchState = {
   /** Buffer holding partial content that may contain incomplete matches spanning chunks */

--- a/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { MatchResult, SearchStrategy } from "../../types";
-import StringBufferStrategyBase from "../../string-buffer-strategy-base";
+import type { MatchResult, SearchStrategy } from "../../types.js";
+import StringBufferStrategyBase from "../../string-buffer-strategy-base.js";
 
 export type BufferedIndexOfAnchoredSearchState = {
   /** Buffer holding partial content that may contain incomplete matches spanning chunks */

--- a/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
 
 export class BufferedIndexOfCallbackSearchStrategy
   implements SyncCallbackProcessor

--- a/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
@@ -10,6 +10,7 @@ export class BufferedIndexOfCallbackSearchStrategy
   private readonly startToken: string;
   private readonly endToken: string;
   private matchIndex: number = 0;
+  private totalStreamOffset: number = 0;
 
   constructor(
     replacement: (match: string, context: ReplacementContext) => string,
@@ -23,43 +24,49 @@ export class BufferedIndexOfCallbackSearchStrategy
   }
 
   processChunk(chunk: string, enqueue: (output: string) => void): void {
+    const bufferLength = this.partialChunk.length;
+    const baseOffset = this.totalStreamOffset - bufferLength;
     chunk = this.partialChunk + chunk;
     this.partialChunk = "";
     this.lastIndex = 0;
 
-    while (this.lastIndex < chunk.length) {
-      let index = chunk.indexOf(this.startToken, this.lastIndex);
-      if (index === -1) {
-        const bufferSize = this.startToken.length - 1;
-        const splitPoint = Math.max(this.lastIndex, chunk.length - bufferSize);
-        this.partialChunk = chunk.slice(splitPoint);
-        const content = chunk.slice(this.lastIndex, splitPoint);
-        if (content) {
-          enqueue(content);
+    try {
+      while (this.lastIndex < chunk.length) {
+        let index = chunk.indexOf(this.startToken, this.lastIndex);
+        if (index === -1) {
+          const bufferSize = this.startToken.length - 1;
+          const splitPoint = Math.max(this.lastIndex, chunk.length - bufferSize);
+          this.partialChunk = chunk.slice(splitPoint);
+          const content = chunk.slice(this.lastIndex, splitPoint);
+          if (content) {
+            enqueue(content);
+          }
+          return;
         }
-        return;
-      }
 
-      if (index > this.lastIndex) {
-        enqueue(chunk.substring(this.lastIndex, index));
-      }
+        if (index > this.lastIndex) {
+          enqueue(chunk.substring(this.lastIndex, index));
+        }
 
-      const endIndex = chunk.indexOf(
-        this.endToken,
-        index + this.startToken.length
-      );
-      if (endIndex !== -1) {
-        this.lastIndex = endIndex + this.endToken.length;
-        const match = chunk.substring(index, this.lastIndex);
-        let replacement = this.replacement(match, {
-          matchIndex: this.matchIndex++,
-          streamIndices: [index, this.lastIndex]
-        });
-        enqueue(replacement);
-      } else {
-        this.partialChunk = chunk.substring(index);
-        return;
+        const endIndex = chunk.indexOf(
+          this.endToken,
+          index + this.startToken.length
+        );
+        if (endIndex !== -1) {
+          this.lastIndex = endIndex + this.endToken.length;
+          const match = chunk.substring(index, this.lastIndex);
+          let replacement = this.replacement(match, {
+            matchIndex: this.matchIndex++,
+            streamIndices: [baseOffset + index, baseOffset + this.lastIndex]
+          });
+          enqueue(replacement);
+        } else {
+          this.partialChunk = chunk.substring(index);
+          return;
+        }
       }
+    } finally {
+      this.totalStreamOffset += chunk.length - bufferLength;
     }
   }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.js";
 
 export class BufferedIndexOfCallbackSearchStrategy
   implements SyncCallbackProcessor

--- a/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-callback/search-strategy.ts
@@ -1,17 +1,18 @@
 import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
 
 export class BufferedIndexOfCallbackSearchStrategy
   implements SyncCallbackProcessor
 {
   private partialChunk: string;
-  private readonly replacement: (match: string, index: number) => string;
+  private readonly replacement: (match: string, context: ReplacementContext) => string;
   private lastIndex: number | undefined;
   private readonly startToken: string;
   private readonly endToken: string;
   private matchIndex: number = 0;
 
   constructor(
-    replacement: (match: string, index: number) => string,
+    replacement: (match: string, context: ReplacementContext) => string,
     tokens: string[]
   ) {
     this.replacement = replacement;
@@ -49,10 +50,11 @@ export class BufferedIndexOfCallbackSearchStrategy
       );
       if (endIndex !== -1) {
         this.lastIndex = endIndex + this.endToken.length;
-        let replacement = this.replacement(
-          chunk.substring(index, this.lastIndex),
-          this.matchIndex++
-        );
+        const match = chunk.substring(index, this.lastIndex);
+        let replacement = this.replacement(match, {
+          matchIndex: this.matchIndex++,
+          streamIndices: [index, this.lastIndex]
+        });
         enqueue(replacement);
       } else {
         this.partialChunk = chunk.substring(index);

--- a/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { MatchResult, SearchStrategy } from "../../types";
-import StringBufferStrategyBase from "../../string-buffer-strategy-base";
+import type { MatchResult, SearchStrategy } from "../../types.js";
+import StringBufferStrategyBase from "../../string-buffer-strategy-base.js";
 
 export type BufferedIndexOfCancellableSearchState = {
   buffer: string;

--- a/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-cancellable/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { MatchResult, SearchStrategy } from "../../types.ts";
-import StringBufferStrategyBase from "../../string-buffer-strategy-base.ts";
+import type { MatchResult, SearchStrategy } from "../../types";
+import StringBufferStrategyBase from "../../string-buffer-strategy-base";
 
 export type BufferedIndexOfCancellableSearchState = {
   buffer: string;

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
@@ -1,8 +1,8 @@
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base.ts";
-import type { SyncProcessor } from "../../../replacement-processors/types.ts";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
+} from "../../string-buffer-strategy-base";
+import type { SyncProcessor } from "../../../replacement-processors/types";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
 
 export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
   extends StringBufferStrategyBase

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
@@ -28,44 +28,56 @@ export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
   }
 
   *processChunk(chunk: string): Generator<string, void, undefined> {
+    const bufferLength = this.state.buffer.length;
+    const baseOffset = this.state.streamOffset - bufferLength;
     chunk = this.state.buffer + chunk;
     this.state.buffer = "";
+    const chunkLength = chunk.length;
     this.lastIndex = 0;
-    while (this.lastIndex < chunk.length) {
-      let index = chunk.indexOf(this.startToken, this.lastIndex);
-      if (index === -1) {
-        const splitPoint = Math.max(
-          this.lastIndex,
-          chunk.length - this.startToken.length - 1
-        );
-        this.state.buffer = chunk.slice(splitPoint);
-        const content = chunk.slice(this.lastIndex, splitPoint);
-        if (content) {
-          yield content;
+    try {
+      while (this.lastIndex < chunkLength) {
+        let index = chunk.indexOf(this.startToken, this.lastIndex);
+        if (index === -1) {
+          const splitPoint = Math.max(
+            this.lastIndex,
+            chunkLength - this.startToken.length - 1
+          );
+          this.state.buffer = chunk.slice(splitPoint);
+          const content = chunk.slice(this.lastIndex, splitPoint);
+          if (content) {
+            yield content;
+          }
+          this.lastIndex = chunkLength;
+          return;
         }
-        return;
-      }
 
-      if (index > 0) {
-        yield chunk.substring(this.lastIndex, index);
-      }
+        if (index > 0) {
+          yield chunk.substring(this.lastIndex, index);
+        }
 
-      const endIndex = chunk.indexOf(
-        this.endToken,
-        index + this.startToken.length
-      );
-      if (endIndex !== -1) {
-        this.lastIndex = endIndex + this.endToken.length;
-        const match = chunk.substring(index, this.lastIndex);
-        let replacement = this.replacement(match, {
-          matchIndex: this.matchIndex++,
-          streamIndices: [index, this.lastIndex]
-        });
-        yield replacement;
-      } else {
-        this.state.buffer = chunk.substring(index);
-        return;
+        const endIndex = chunk.indexOf(
+          this.endToken,
+          index + this.startToken.length
+        );
+        if (endIndex !== -1) {
+          this.lastIndex = endIndex + this.endToken.length;
+          const match = chunk.substring(index, this.lastIndex);
+          let replacement = this.replacement(match, {
+            matchIndex: this.matchIndex++,
+            streamIndices: [baseOffset + index, baseOffset + this.lastIndex]
+          });
+          yield replacement;
+        } else {
+          this.state.buffer = chunk.substring(index);
+          this.lastIndex = chunkLength;
+          return;
+        }
       }
+    } finally {
+      if (this.lastIndex < chunkLength && !this.state.buffer) {
+        this.state.buffer += chunk.slice(this.lastIndex);
+      }
+      this.state.streamOffset += chunkLength - bufferLength;
     }
   }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
@@ -1,8 +1,8 @@
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base";
-import type { SyncProcessor } from "../../../replacement-processors/types";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
+} from "../../string-buffer-strategy-base.js";
+import type { SyncProcessor } from "../../../replacement-processors/types.js";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.js";
 
 export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
   extends StringBufferStrategyBase

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
@@ -51,7 +51,7 @@ export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
           return;
         }
 
-        if (index > 0) {
+        if (index > this.lastIndex!) {
           yield chunk.substring(this.lastIndex, index);
         }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
@@ -2,12 +2,13 @@ import StringBufferStrategyBase, {
   type StringBufferState
 } from "../../string-buffer-strategy-base.ts";
 import type { SyncProcessor } from "../../../replacement-processors/types.ts";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
 
 export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
   extends StringBufferStrategyBase
   implements SyncProcessor<string>
 {
-  private readonly replacement: (match: string, index: number) => string;
+  private readonly replacement: (match: string, context: ReplacementContext) => string;
   private lastIndex: number | undefined;
   private readonly startToken: string;
   private readonly endToken: string;
@@ -15,7 +16,7 @@ export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
   private state: StringBufferState;
 
   constructor(
-    replacement: (match: string, index: number) => string,
+    replacement: (match: string, context: ReplacementContext) => string,
     tokens: string[]
   ) {
     super();
@@ -55,10 +56,11 @@ export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
       );
       if (endIndex !== -1) {
         this.lastIndex = endIndex + this.endToken.length;
-        let replacement = this.replacement(
-          chunk.substring(index, this.lastIndex),
-          this.matchIndex++
-        );
+        const match = chunk.substring(index, this.lastIndex);
+        let replacement = this.replacement(match, {
+          matchIndex: this.matchIndex++,
+          streamIndices: [index, this.lastIndex]
+        });
         yield replacement;
       } else {
         this.state.buffer = chunk.substring(index);

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical-generator/search-strategy.ts
@@ -51,7 +51,7 @@ export class BufferedIndexOfCanonicalAsGeneratorSearchStrategy
           return;
         }
 
-        if (index > this.lastIndex!) {
+        if (index > this.lastIndex) {
           yield chunk.substring(this.lastIndex, index);
         }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
@@ -1,18 +1,19 @@
 import type { Transformer } from "node:stream/web";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
 
 // based on https://streams.spec.whatwg.org/#example-ts-lipfuzz
 export class BufferedIndexOfReplaceContentTransformer
   implements Transformer<string>
 {
   private partialChunk: string;
-  private readonly replacement: (match: string, index: number) => string;
+  private readonly replacement: (match: string, context: ReplacementContext) => string;
   private lastIndex: number | undefined;
   private readonly startToken: string;
   private readonly endToken: string;
   private matchIndex: number = 0;
 
   constructor(
-    replacement: (match: string, index: number) => string,
+    replacement: (match: string, context: ReplacementContext) => string,
     tokens: string[]
   ) {
     this.replacement = replacement;
@@ -54,10 +55,11 @@ export class BufferedIndexOfReplaceContentTransformer
       );
       if (endIndex !== -1) {
         this.lastIndex = endIndex + this.endToken.length;
-        let replacement = this.replacement(
-          chunk.substring(index, this.lastIndex),
-          this.matchIndex++
-        );
+        const match = chunk.substring(index, this.lastIndex);
+        let replacement = this.replacement(match, {
+          matchIndex: this.matchIndex++,
+          streamIndices: [index, this.lastIndex]
+        });
         controller.enqueue(replacement);
       } else {
         this.partialChunk = chunk.substring(index);

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from "node:stream/web";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.js";
 
 // based on https://streams.spec.whatwg.org/#example-ts-lipfuzz
 export class BufferedIndexOfReplaceContentTransformer

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from "node:stream/web";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
 
 // based on https://streams.spec.whatwg.org/#example-ts-lipfuzz
 export class BufferedIndexOfReplaceContentTransformer

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
@@ -51,7 +51,7 @@ export class BufferedIndexOfReplaceContentTransformer
           return;
         }
 
-        if (index > this.lastIndex!) {
+        if (index > this.lastIndex) {
           controller.enqueue(chunk.substring(this.lastIndex, index));
         }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
@@ -51,7 +51,7 @@ export class BufferedIndexOfReplaceContentTransformer
           return;
         }
 
-        if (index > 0) {
+        if (index > this.lastIndex!) {
           controller.enqueue(chunk.substring(this.lastIndex, index));
         }
 

--- a/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/buffered-indexOf-canonical/search-strategy.ts
@@ -11,6 +11,7 @@ export class BufferedIndexOfReplaceContentTransformer
   private readonly startToken: string;
   private readonly endToken: string;
   private matchIndex: number = 0;
+  private totalStreamOffset: number = 0;
 
   constructor(
     replacement: (match: string, context: ReplacementContext) => string,
@@ -27,44 +28,52 @@ export class BufferedIndexOfReplaceContentTransformer
     chunk: string,
     controller: TransformStreamDefaultController<string>
   ) {
+    const bufferLength = this.partialChunk.length;
+    const baseOffset = this.totalStreamOffset - bufferLength;
     chunk = this.partialChunk + chunk;
     this.partialChunk = "";
     this.lastIndex = 0;
-    while (this.lastIndex < chunk.length) {
-      let index = chunk.indexOf(this.startToken, this.lastIndex);
-      if (index === -1) {
-        const splitPoint = Math.max(
-          this.lastIndex,
-          chunk.length - this.startToken.length - 1
-        );
-        this.partialChunk = chunk.slice(splitPoint);
-        const content = chunk.slice(this.lastIndex, splitPoint);
-        if (content) {
-          controller.enqueue(content);
+    const chunkLength = chunk.length;
+    
+    try {
+      while (this.lastIndex < chunkLength) {
+        let index = chunk.indexOf(this.startToken, this.lastIndex);
+        if (index === -1) {
+          const splitPoint = Math.max(
+            this.lastIndex,
+            chunkLength - this.startToken.length - 1
+          );
+          this.partialChunk = chunk.slice(splitPoint);
+          const content = chunk.slice(this.lastIndex, splitPoint);
+          if (content) {
+            controller.enqueue(content);
+          }
+          return;
         }
-        return;
-      }
 
-      if (index > 0) {
-        controller.enqueue(chunk.substring(this.lastIndex, index));
-      }
+        if (index > 0) {
+          controller.enqueue(chunk.substring(this.lastIndex, index));
+        }
 
-      const endIndex = chunk.indexOf(
-        this.endToken,
-        index + this.startToken.length
-      );
-      if (endIndex !== -1) {
-        this.lastIndex = endIndex + this.endToken.length;
-        const match = chunk.substring(index, this.lastIndex);
-        let replacement = this.replacement(match, {
-          matchIndex: this.matchIndex++,
-          streamIndices: [index, this.lastIndex]
-        });
-        controller.enqueue(replacement);
-      } else {
-        this.partialChunk = chunk.substring(index);
-        return;
+        const endIndex = chunk.indexOf(
+          this.endToken,
+          index + this.startToken.length
+        );
+        if (endIndex !== -1) {
+          this.lastIndex = endIndex + this.endToken.length;
+          const match = chunk.substring(index, this.lastIndex);
+          let replacement = this.replacement(match, {
+            matchIndex: this.matchIndex++,
+            streamIndices: [baseOffset + index, baseOffset + this.lastIndex]
+          });
+          controller.enqueue(replacement);
+        } else {
+          this.partialChunk = chunk.substring(index);
+          return;
+        }
       }
+    } finally {
+      this.totalStreamOffset += chunkLength - bufferLength;
     }
   }
 

--- a/src/search-strategies/benchmarking/index.ts
+++ b/src/search-strategies/benchmarking/index.ts
@@ -5,24 +5,24 @@
  * For production use, see the main search-strategies exports (regex and buffered-indexOf-anchored).
  */
 
-export { AnchorSequenceSearchStrategy } from "./anchor-sequence/search-strategy.ts";
-export { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./buffered-indexOf-anchored-callback/search-strategy.ts";
-export { BufferedIndexOfReplaceContentTransformer } from "./buffered-indexOf-canonical/search-strategy.ts";
-export { BufferedIndexOfCanonicalAsGeneratorSearchStrategy } from "./buffered-indexOf-canonical-generator/search-strategy.ts";
+export { AnchorSequenceSearchStrategy } from "./anchor-sequence/search-strategy";
+export { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./buffered-indexOf-anchored-callback/search-strategy";
+export { BufferedIndexOfReplaceContentTransformer } from "./buffered-indexOf-canonical/search-strategy";
+export { BufferedIndexOfCanonicalAsGeneratorSearchStrategy } from "./buffered-indexOf-canonical-generator/search-strategy";
 export {
   BufferedIndexOfCancellableSearchStrategy,
   type BufferedIndexOfCancellableSearchState
-} from "./buffered-indexOf-cancellable/search-strategy.ts";
-export { BufferedIndexOfCallbackSearchStrategy } from "./buffered-indexOf-callback/search-strategy.ts";
+} from "./buffered-indexOf-cancellable/search-strategy";
+export { BufferedIndexOfCallbackSearchStrategy } from "./buffered-indexOf-callback/search-strategy";
 export {
   LoopedIndexOfCancellableSearchStrategy,
   type LoopedIndexOfCancellableSearchState
-} from "./looped-indexOf-cancellable/search-strategy.ts";
-export { LoopedIndexOfCallbackSearchStrategy } from "./looped-indexOf-callback/search-strategy.ts";
-export { LoopedIndexOfAnchoredSearchStrategy } from "../looped-indexOf-anchored/search-strategy.ts";
+} from "./looped-indexOf-cancellable/search-strategy";
+export { LoopedIndexOfCallbackSearchStrategy } from "./looped-indexOf-callback/search-strategy";
+export { LoopedIndexOfAnchoredSearchStrategy } from "../looped-indexOf-anchored/search-strategy";
 export {
   IndexOfKnuthMorrisPrattSearchStrategy,
   type IndexOfKnuthMorrisPrattSearchState
-} from "./indexOf-knuth-morris-pratt/search-strategy.ts";
-export { RegexReplaceContentTransformer } from "./regex-canonical/search-strategy.ts";
-export { RegexCallbackSearchStrategy } from "./regex-callback/search-strategy.ts";
+} from "./indexOf-knuth-morris-pratt/search-strategy";
+export { RegexReplaceContentTransformer } from "./regex-canonical/search-strategy";
+export { RegexCallbackSearchStrategy } from "./regex-callback/search-strategy";

--- a/src/search-strategies/benchmarking/index.ts
+++ b/src/search-strategies/benchmarking/index.ts
@@ -5,24 +5,24 @@
  * For production use, see the main search-strategies exports (regex and buffered-indexOf-anchored).
  */
 
-export { AnchorSequenceSearchStrategy } from "./anchor-sequence/search-strategy";
-export { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./buffered-indexOf-anchored-callback/search-strategy";
-export { BufferedIndexOfReplaceContentTransformer } from "./buffered-indexOf-canonical/search-strategy";
-export { BufferedIndexOfCanonicalAsGeneratorSearchStrategy } from "./buffered-indexOf-canonical-generator/search-strategy";
+export { AnchorSequenceSearchStrategy } from "./anchor-sequence/search-strategy.js";
+export { BufferedIndexOfAnchoredCallbackSearchStrategy } from "./buffered-indexOf-anchored-callback/search-strategy.js";
+export { BufferedIndexOfReplaceContentTransformer } from "./buffered-indexOf-canonical/search-strategy.js";
+export { BufferedIndexOfCanonicalAsGeneratorSearchStrategy } from "./buffered-indexOf-canonical-generator/search-strategy.js";
 export {
   BufferedIndexOfCancellableSearchStrategy,
   type BufferedIndexOfCancellableSearchState
-} from "./buffered-indexOf-cancellable/search-strategy";
-export { BufferedIndexOfCallbackSearchStrategy } from "./buffered-indexOf-callback/search-strategy";
+} from "./buffered-indexOf-cancellable/search-strategy.js";
+export { BufferedIndexOfCallbackSearchStrategy } from "./buffered-indexOf-callback/search-strategy.js";
 export {
   LoopedIndexOfCancellableSearchStrategy,
   type LoopedIndexOfCancellableSearchState
-} from "./looped-indexOf-cancellable/search-strategy";
-export { LoopedIndexOfCallbackSearchStrategy } from "./looped-indexOf-callback/search-strategy";
-export { LoopedIndexOfAnchoredSearchStrategy } from "../looped-indexOf-anchored/search-strategy";
+} from "./looped-indexOf-cancellable/search-strategy.js";
+export { LoopedIndexOfCallbackSearchStrategy } from "./looped-indexOf-callback/search-strategy.js";
+export { LoopedIndexOfAnchoredSearchStrategy } from "../looped-indexOf-anchored/search-strategy.js";
 export {
   IndexOfKnuthMorrisPrattSearchStrategy,
   type IndexOfKnuthMorrisPrattSearchState
-} from "./indexOf-knuth-morris-pratt/search-strategy";
-export { RegexReplaceContentTransformer } from "./regex-canonical/search-strategy";
-export { RegexCallbackSearchStrategy } from "./regex-callback/search-strategy";
+} from "./indexOf-knuth-morris-pratt/search-strategy.js";
+export { RegexReplaceContentTransformer } from "./regex-canonical/search-strategy.js";
+export { RegexCallbackSearchStrategy } from "./regex-callback/search-strategy.js";

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/index.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-strategy.ts";
+export * from "./search-strategy";

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/index.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-strategy";
+export * from "./search-strategy.js";

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { IndexOfKnuthMorrisPrattSearchStrategy } from "./search-strategy.ts";
-import type { MatchResult } from "../../types.ts";
+import { IndexOfKnuthMorrisPrattSearchStrategy } from "./search-strategy";
+import type { MatchResult } from "../../types";
 
 describe("IndexOfKnuthMorrisPratt", () => {
   describe("complete matches in single chunk", () => {

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { IndexOfKnuthMorrisPrattSearchStrategy } from "./search-strategy";
-import type { MatchResult } from "../../types";
+import { IndexOfKnuthMorrisPrattSearchStrategy } from "./search-strategy.js";
+import type { MatchResult } from "../../types.js";
 
 describe("IndexOfKnuthMorrisPratt", () => {
   describe("complete matches in single chunk", () => {

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
@@ -1,8 +1,8 @@
-import type { SearchStrategy, MatchResult } from "../../types";
-import KMP from "./knuth-morris-pratt";
+import type { SearchStrategy, MatchResult } from "../../types.js";
+import KMP from "./knuth-morris-pratt.js";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base";
+} from "../../string-buffer-strategy-base.js";
 
 export interface IndexOfKnuthMorrisPrattSearchState extends StringBufferState {
   needleIndex: number;

--- a/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
+++ b/src/search-strategies/benchmarking/indexOf-knuth-morris-pratt/search-strategy.ts
@@ -1,8 +1,8 @@
-import type { SearchStrategy, MatchResult } from "../../types.ts";
-import KMP from "./knuth-morris-pratt.ts";
+import type { SearchStrategy, MatchResult } from "../../types";
+import KMP from "./knuth-morris-pratt";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base.ts";
+} from "../../string-buffer-strategy-base";
 
 export interface IndexOfKnuthMorrisPrattSearchState extends StringBufferState {
   needleIndex: number;

--- a/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.js";
 
 export class LoopedIndexOfCallbackSearchStrategy
   implements SyncCallbackProcessor

--- a/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
@@ -1,17 +1,18 @@
 import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
 
 export class LoopedIndexOfCallbackSearchStrategy
   implements SyncCallbackProcessor
 {
   private partialChunk: string;
-  private readonly replacement: (match: string, index: number) => string;
+  private readonly replacement: (match: string, context: ReplacementContext) => string;
   private lastIndex: number | undefined;
   private readonly startToken: string;
   private readonly endToken: string;
   private matchIndex: number = 0;
 
   constructor(
-    replacement: (match: string, index: number) => string,
+    replacement: (match: string, context: ReplacementContext) => string,
     tokens: string[]
   ) {
     this.replacement = replacement;
@@ -70,10 +71,11 @@ export class LoopedIndexOfCallbackSearchStrategy
       );
       if (endIndex !== -1) {
         this.lastIndex = endIndex + this.endToken.length;
-        let replacement = this.replacement(
-          chunk.substring(index, this.lastIndex),
-          this.matchIndex++
-        );
+        const match = chunk.substring(index, this.lastIndex);
+        let replacement = this.replacement(match, {
+          matchIndex: this.matchIndex++,
+          streamIndices: [index, this.lastIndex]
+        });
         enqueue(replacement);
       } else {
         this.partialChunk = chunk.substring(index);

--- a/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
 
 export class LoopedIndexOfCallbackSearchStrategy
   implements SyncCallbackProcessor

--- a/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-callback/search-strategy.ts
@@ -10,6 +10,7 @@ export class LoopedIndexOfCallbackSearchStrategy
   private readonly startToken: string;
   private readonly endToken: string;
   private matchIndex: number = 0;
+  private totalStreamOffset: number = 0;
 
   constructor(
     replacement: (match: string, context: ReplacementContext) => string,
@@ -50,37 +51,44 @@ export class LoopedIndexOfCallbackSearchStrategy
   }
 
   processChunk(chunk: string, enqueue: (output: string) => void): void {
+    const bufferLength = this.partialChunk.length;
+    const baseOffset = this.totalStreamOffset - bufferLength;
     chunk = this.partialChunk + chunk;
     this.partialChunk = "";
     this.lastIndex = 0;
+    const chunkLength = chunk.length;
 
-    while (this.lastIndex < chunk.length) {
-      let index = chunk.indexOf(this.startToken, this.lastIndex);
-      if (index === -1) {
-        this.attemptPartialMatchAtEnd(chunk, this.lastIndex, enqueue);
-        return;
-      }
+    try {
+      while (this.lastIndex < chunkLength) {
+        let index = chunk.indexOf(this.startToken, this.lastIndex);
+        if (index === -1) {
+          this.attemptPartialMatchAtEnd(chunk, this.lastIndex, enqueue);
+          return;
+        }
 
-      if (index > this.lastIndex) {
-        enqueue(chunk.substring(this.lastIndex, index));
-      }
+        if (index > this.lastIndex) {
+          enqueue(chunk.substring(this.lastIndex, index));
+        }
 
-      const endIndex = chunk.indexOf(
-        this.endToken,
-        index + this.startToken.length
-      );
-      if (endIndex !== -1) {
-        this.lastIndex = endIndex + this.endToken.length;
-        const match = chunk.substring(index, this.lastIndex);
-        let replacement = this.replacement(match, {
-          matchIndex: this.matchIndex++,
-          streamIndices: [index, this.lastIndex]
-        });
-        enqueue(replacement);
-      } else {
-        this.partialChunk = chunk.substring(index);
-        return;
+        const endIndex = chunk.indexOf(
+          this.endToken,
+          index + this.startToken.length
+        );
+        if (endIndex !== -1) {
+          this.lastIndex = endIndex + this.endToken.length;
+          const match = chunk.substring(index, this.lastIndex);
+          let replacement = this.replacement(match, {
+            matchIndex: this.matchIndex++,
+            streamIndices: [baseOffset + index, baseOffset + this.lastIndex]
+          });
+          enqueue(replacement);
+        } else {
+          this.partialChunk = chunk.substring(index);
+          return;
+        }
       }
+    } finally {
+      this.totalStreamOffset += chunkLength - bufferLength;
     }
   }
 

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
@@ -1,7 +1,7 @@
-import type { SearchStrategy, MatchResult } from "../../types.ts";
+import type { SearchStrategy, MatchResult } from "../../types";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base.ts";
+} from "../../string-buffer-strategy-base";
 export interface LoopedIndexOfCancellableSearchState extends StringBufferState {
   needleIndex: number;
 }

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
@@ -1,7 +1,7 @@
-import type { SearchStrategy, MatchResult } from "../../types";
+import type { SearchStrategy, MatchResult } from "../../types.js";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../../string-buffer-strategy-base";
+} from "../../string-buffer-strategy-base.js";
 export interface LoopedIndexOfCancellableSearchState extends StringBufferState {
   needleIndex: number;
 }

--- a/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
+++ b/src/search-strategies/benchmarking/looped-indexOf-cancellable/search-strategy.ts
@@ -84,7 +84,9 @@ export class LoopedIndexOfCancellableSearchStrategy
           return;
         }
 
-        yield { isMatch: false, content: haystack.slice(0, matchPos) };
+        if (matchPos) {
+          yield { isMatch: false, content: haystack.slice(0, matchPos) };
+        }
         const startIndex = absoluteCursor + matchPos;
         const endIndex = startIndex + this.needle.length;
         absoluteCursor += matchPos + this.needle.length;

--- a/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
 import createPartialMatchRegex from "regex-partial-match";
 
 export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {

--- a/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
@@ -1,16 +1,17 @@
 import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.ts";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
 import createPartialMatchRegex from "regex-partial-match";
 
 export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
   private partialChunk: string;
-  private readonly replacement: (match: string, index: number) => string;
+  private readonly replacement: (match: string, context: ReplacementContext) => string;
   private lastIndex: number | undefined;
   private readonly openRegex: RegExp;
   private readonly partialAtEndRegex: RegExp;
   private matchIndex: number = 0;
 
   constructor(
-    replacement: (match: string, index: number) => string,
+    replacement: (match: string, context: ReplacementContext) => string,
     needle: RegExp
   ) {
     this.replacement = replacement;
@@ -44,7 +45,10 @@ export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
   }
 
   private replaceTag(match: string, p1: string, offset: number): string {
-    let replacement = this.replacement(match, this.matchIndex++);
+    let replacement = this.replacement(match, {
+      matchIndex: this.matchIndex++,
+      streamIndices: [offset, offset + match.length]
+    });
     if (replacement === undefined) {
       replacement = "";
     }

--- a/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
@@ -53,8 +53,10 @@ export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
   }
 
   private replaceTag(match: string, ...args: unknown[]): string {
-    // offset is always the second-to-last argument in the replace callback:
-    // (match, ...captures, offset, string) or (match, ...captures, offset, string, namedGroups)
+    // NOTE: This benchmark strategy assumes offset is args.at(-2), i.e.
+    // (match, ...captures, offset, string). This is intentionally simplified
+    // for harness brevity and does not handle named groups
+    // (match, ...captures, offset, string, namedGroups), where offset is -3.
     const numericOffset = args.at(-2) as number;
     const transformedOffset = numericOffset + this.replacementDelta;
 

--- a/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
@@ -1,5 +1,5 @@
-import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
+import type { SyncCallbackProcessor } from "../../../replacement-processors/benchmarking/types.js";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.js";
 import createPartialMatchRegex from "regex-partial-match";
 
 export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {

--- a/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
@@ -9,6 +9,9 @@ export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
   private readonly openRegex: RegExp;
   private readonly partialAtEndRegex: RegExp;
   private matchIndex: number = 0;
+  private totalStreamOffset: number = 0;
+  private currentChunkBaseOffset: number = 0;
+  private replacementDelta: number = 0;
 
   constructor(
     replacement: (match: string, context: ReplacementContext) => string,
@@ -22,10 +25,14 @@ export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
   }
 
   processChunk(chunk: string, enqueue: (output: string) => void): void {
+    const bufferLength = this.partialChunk.length;
+    this.currentChunkBaseOffset = this.totalStreamOffset - bufferLength;
     chunk = this.partialChunk + chunk;
     this.partialChunk = "";
     // lastIndex is the index of the first character after the last substitution.
     this.lastIndex = 0;
+    this.replacementDelta = 0;
+    const originalLength = chunk.length;
     chunk = chunk.replace(this.openRegex, this.replaceTag.bind(this));
     // Regular expression for an incomplete template at the end of a string.
     // Avoid looking at any characters that have already been substituted.
@@ -38,6 +45,7 @@ export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
       chunk = chunk.substring(0, match.index);
     }
     enqueue(chunk);
+    this.totalStreamOffset += originalLength - bufferLength;
   }
 
   flush(): string {
@@ -45,14 +53,28 @@ export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
   }
 
   private replaceTag(match: string, p1: string, offset: number): string {
+    // String.replace callback argument shape depends on capture groups.
+    // Resolve the numeric offset robustly for regexes with or without captures.
+    const offsetValue =
+      typeof p1 === "number"
+        ? p1
+        : typeof offset === "number"
+          ? offset
+          : 0;
+    const transformedOffset = offsetValue + this.replacementDelta;
+
     let replacement = this.replacement(match, {
       matchIndex: this.matchIndex++,
-      streamIndices: [offset, offset + match.length]
+      streamIndices: [
+        this.currentChunkBaseOffset + offsetValue,
+        this.currentChunkBaseOffset + offsetValue + match.length
+      ]
     });
     if (replacement === undefined) {
       replacement = "";
     }
-    this.lastIndex = offset + replacement.length;
+    this.replacementDelta += replacement.length - match.length;
+    this.lastIndex = transformedOffset + replacement.length;
     return replacement;
   }
 }

--- a/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-callback/search-strategy.ts
@@ -52,22 +52,17 @@ export class RegexCallbackSearchStrategy implements SyncCallbackProcessor {
     return this.partialChunk;
   }
 
-  private replaceTag(match: string, p1: string, offset: number): string {
-    // String.replace callback argument shape depends on capture groups.
-    // Resolve the numeric offset robustly for regexes with or without captures.
-    const offsetValue =
-      typeof p1 === "number"
-        ? p1
-        : typeof offset === "number"
-          ? offset
-          : 0;
-    const transformedOffset = offsetValue + this.replacementDelta;
+  private replaceTag(match: string, ...args: unknown[]): string {
+    // offset is always the second-to-last argument in the replace callback:
+    // (match, ...captures, offset, string) or (match, ...captures, offset, string, namedGroups)
+    const numericOffset = args.at(-2) as number;
+    const transformedOffset = numericOffset + this.replacementDelta;
 
     let replacement = this.replacement(match, {
       matchIndex: this.matchIndex++,
       streamIndices: [
-        this.currentChunkBaseOffset + offsetValue,
-        this.currentChunkBaseOffset + offsetValue + match.length
+        this.currentChunkBaseOffset + numericOffset,
+        this.currentChunkBaseOffset + numericOffset + match.length
       ]
     });
     if (replacement === undefined) {

--- a/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
@@ -58,22 +58,17 @@ export class RegexReplaceContentTransformer implements Transformer<string> {
     }
   }
 
-  replaceTag(match: string, p1: string, offset: number) {
-    // String.replace callback argument shape depends on capture groups.
-    // Resolve the numeric offset robustly for regexes with or without captures.
-    const offsetValue =
-      typeof p1 === "number"
-        ? p1
-        : typeof offset === "number"
-          ? offset
-          : 0;
-    const transformedOffset = offsetValue + this.replacementDelta;
+  replaceTag(match: string, ...args: unknown[]) {
+    // offset is always the second-to-last argument in the replace callback:
+    // (match, ...captures, offset, string) or (match, ...captures, offset, string, namedGroups)
+    const numericOffset = args.at(-2) as number;
+    const transformedOffset = numericOffset + this.replacementDelta;
 
     let replacement = this.replacement(match, {
       matchIndex: this.matchIndex++,
       streamIndices: [
-        this.currentChunkBaseOffset + offsetValue,
-        this.currentChunkBaseOffset + offsetValue + match.length
+        this.currentChunkBaseOffset + numericOffset,
+        this.currentChunkBaseOffset + numericOffset + match.length
       ]
     });
     if (replacement === undefined) {

--- a/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
@@ -1,16 +1,17 @@
 import type { Transformer } from "node:stream/web";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
 
 // based on https://streams.spec.whatwg.org/#example-ts-lipfuzz
 export class RegexReplaceContentTransformer implements Transformer<string> {
   private partialChunk: string;
-  private readonly replacement: (match: string, index: number) => string;
+  private readonly replacement: (match: string, context: ReplacementContext) => string;
   private lastIndex: number | undefined;
   private readonly openRegex: RegExp;
   private readonly partialAtEndRegex: RegExp;
   private matchIndex: number = 0;
 
   constructor(
-    replacement: (match: string, index: number) => string,
+    replacement: (match: string, context: ReplacementContext) => string,
     openRegex: RegExp,
     partialAtEndRegex: RegExp
   ) {
@@ -50,7 +51,10 @@ export class RegexReplaceContentTransformer implements Transformer<string> {
   }
 
   replaceTag(match: string, p1: string, offset: number) {
-    let replacement = this.replacement(match, this.matchIndex++);
+    let replacement = this.replacement(match, {
+      matchIndex: this.matchIndex++,
+      streamIndices: [offset, offset + match.length]
+    });
     if (replacement === undefined) {
       replacement = "";
     }

--- a/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from "node:stream/web";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.js";
 
 // based on https://streams.spec.whatwg.org/#example-ts-lipfuzz
 export class RegexReplaceContentTransformer implements Transformer<string> {

--- a/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
@@ -9,6 +9,9 @@ export class RegexReplaceContentTransformer implements Transformer<string> {
   private readonly openRegex: RegExp;
   private readonly partialAtEndRegex: RegExp;
   private matchIndex: number = 0;
+  private totalStreamOffset: number = 0;
+  private currentChunkBaseOffset: number = 0;
+  private replacementDelta: number = 0;
 
   constructor(
     replacement: (match: string, context: ReplacementContext) => string,
@@ -26,10 +29,14 @@ export class RegexReplaceContentTransformer implements Transformer<string> {
     chunk: string,
     controller: TransformStreamDefaultController<string>
   ) {
+    const bufferLength = this.partialChunk.length;
+    this.currentChunkBaseOffset = this.totalStreamOffset - bufferLength;
     chunk = this.partialChunk + chunk;
     this.partialChunk = "";
     // lastIndex is the index of the first character after the last substitution.
     this.lastIndex = 0;
+    this.replacementDelta = 0;
+    const originalLength = chunk.length;
     chunk = chunk.replace(this.openRegex, this.replaceTag.bind(this));
     // Regular expression for an incomplete template at the end of a string.
     // Avoid looking at any characters that have already been substituted.
@@ -42,6 +49,7 @@ export class RegexReplaceContentTransformer implements Transformer<string> {
       chunk = chunk.substring(0, match.index);
     }
     controller.enqueue(chunk);
+    this.totalStreamOffset += originalLength - bufferLength;
   }
 
   flush(controller: TransformStreamDefaultController<string>) {
@@ -51,14 +59,28 @@ export class RegexReplaceContentTransformer implements Transformer<string> {
   }
 
   replaceTag(match: string, p1: string, offset: number) {
+    // String.replace callback argument shape depends on capture groups.
+    // Resolve the numeric offset robustly for regexes with or without captures.
+    const offsetValue =
+      typeof p1 === "number"
+        ? p1
+        : typeof offset === "number"
+          ? offset
+          : 0;
+    const transformedOffset = offsetValue + this.replacementDelta;
+
     let replacement = this.replacement(match, {
       matchIndex: this.matchIndex++,
-      streamIndices: [offset, offset + match.length]
+      streamIndices: [
+        this.currentChunkBaseOffset + offsetValue,
+        this.currentChunkBaseOffset + offsetValue + match.length
+      ]
     });
     if (replacement === undefined) {
       replacement = "";
     }
-    this.lastIndex = offset + replacement.length;
+    this.replacementDelta += replacement.length - match.length;
+    this.lastIndex = transformedOffset + replacement.length;
     return replacement;
   }
 }

--- a/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
@@ -1,5 +1,5 @@
 import type { Transformer } from "node:stream/web";
-import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base.ts";
+import type { ReplacementContext } from "../../../replacement-processors/replacement-processor.base";
 
 // based on https://streams.spec.whatwg.org/#example-ts-lipfuzz
 export class RegexReplaceContentTransformer implements Transformer<string> {

--- a/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
+++ b/src/search-strategies/benchmarking/regex-canonical/search-strategy.ts
@@ -59,8 +59,10 @@ export class RegexReplaceContentTransformer implements Transformer<string> {
   }
 
   replaceTag(match: string, ...args: unknown[]) {
-    // offset is always the second-to-last argument in the replace callback:
-    // (match, ...captures, offset, string) or (match, ...captures, offset, string, namedGroups)
+    // NOTE: This benchmark strategy assumes offset is args.at(-2), i.e.
+    // (match, ...captures, offset, string). This is intentionally simplified
+    // for harness brevity and does not handle named groups
+    // (match, ...captures, offset, string, namedGroups), where offset is -3.
     const numericOffset = args.at(-2) as number;
     const transformedOffset = numericOffset + this.replacementDelta;
 

--- a/src/search-strategies/index.ts
+++ b/src/search-strategies/index.ts
@@ -1,4 +1,4 @@
 export {
   LoopedIndexOfAnchoredSearchStrategy as StringAnchorSearchStrategy
-} from "./looped-indexOf-anchored/index.ts";
-export * from "./regex/index.ts";
+} from "./looped-indexOf-anchored/index";
+export * from "./regex/index";

--- a/src/search-strategies/index.ts
+++ b/src/search-strategies/index.ts
@@ -1,4 +1,4 @@
 export {
   LoopedIndexOfAnchoredSearchStrategy as StringAnchorSearchStrategy
-} from "./looped-indexOf-anchored/index";
-export * from "./regex/index";
+} from "./looped-indexOf-anchored/index.js";
+export * from "./regex/index.js";

--- a/src/search-strategies/looped-indexOf-anchored/index.ts
+++ b/src/search-strategies/looped-indexOf-anchored/index.ts
@@ -1,1 +1,1 @@
-export { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy";
+export { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.js";

--- a/src/search-strategies/looped-indexOf-anchored/index.ts
+++ b/src/search-strategies/looped-indexOf-anchored/index.ts
@@ -1,1 +1,1 @@
-export { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
+export { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy";

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.ts";
+import { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy";
 
 describe("LoopedIndexOfAnchoredSearchStrategy", () => {
   it("should match single token", () => {

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy";
+import { LoopedIndexOfAnchoredSearchStrategy } from "./search-strategy.js";
 
 describe("LoopedIndexOfAnchoredSearchStrategy", () => {
   it("should match single token", () => {

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
@@ -1,7 +1,7 @@
-import type { MatchResult, SearchStrategy } from "../types.ts";
+import type { MatchResult, SearchStrategy } from "../types";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../string-buffer-strategy-base.ts";
+} from "../string-buffer-strategy-base";
 
 export type LoopedIndexOfAnchoredSearchState = StringBufferState & {
   /** Index of the current needle being matched in a multi-needle sequence */

--- a/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
+++ b/src/search-strategies/looped-indexOf-anchored/search-strategy.ts
@@ -1,7 +1,7 @@
-import type { MatchResult, SearchStrategy } from "../types";
+import type { MatchResult, SearchStrategy } from "../types.js";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../string-buffer-strategy-base";
+} from "../string-buffer-strategy-base.js";
 
 export type LoopedIndexOfAnchoredSearchState = StringBufferState & {
   /** Index of the current needle being matched in a multi-needle sequence */

--- a/src/search-strategies/regex/index.ts
+++ b/src/search-strategies/regex/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-strategy.ts";
+export * from "./search-strategy";

--- a/src/search-strategies/regex/index.ts
+++ b/src/search-strategies/regex/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-strategy";
+export * from "./search-strategy.js";

--- a/src/search-strategies/regex/input-validation.test.ts
+++ b/src/search-strategies/regex/input-validation.test.ts
@@ -1,4 +1,4 @@
-import inputValidation from "./input-validation";
+import inputValidation from "./input-validation.js";
 
 describe("input validation", () => {
   it("should not allow negative lookahead to be part of the needle", () => {

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { RegexSearchStrategy } from "./search-strategy";
-import type { MatchResult } from "../types";
-import validateInput from "./input-validation";
+import { RegexSearchStrategy } from "./search-strategy.js";
+import type { MatchResult } from "../types.js";
+import validateInput from "./input-validation.js";
 
-vi.mock("./input-validation");
+vi.mock("./input-validation.js");
 
 // Helper to extract string value from MatchResult
 function getValue(result: MatchResult<RegExpExecArray>): string {

--- a/src/search-strategies/regex/search-strategy.test.ts
+++ b/src/search-strategies/regex/search-strategy.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { RegexSearchStrategy } from "./search-strategy.ts";
-import type { MatchResult } from "../types.ts";
-import validateInput from "./input-validation.ts";
+import { RegexSearchStrategy } from "./search-strategy";
+import type { MatchResult } from "../types";
+import validateInput from "./input-validation";
 
-vi.mock("./input-validation.ts");
+vi.mock("./input-validation");
 
 // Helper to extract string value from MatchResult
 function getValue(result: MatchResult<RegExpExecArray>): string {

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -1,9 +1,9 @@
-import type { MatchResult, SearchStrategy } from "../types";
+import type { MatchResult, SearchStrategy } from "../types.js";
 import createPartialMatchRegex from "regex-partial-match";
-import validateInput from "./input-validation";
+import validateInput from "./input-validation.js";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../string-buffer-strategy-base";
+} from "../string-buffer-strategy-base.js";
 
 /**
  * Corrected version of {@link RegExpIndicesArray} that models `undefined`

--- a/src/search-strategies/regex/search-strategy.ts
+++ b/src/search-strategies/regex/search-strategy.ts
@@ -1,9 +1,9 @@
-import type { MatchResult, SearchStrategy } from "../types.ts";
+import type { MatchResult, SearchStrategy } from "../types";
 import createPartialMatchRegex from "regex-partial-match";
-import validateInput from "./input-validation.ts";
+import validateInput from "./input-validation";
 import StringBufferStrategyBase, {
   type StringBufferState
-} from "../string-buffer-strategy-base.ts";
+} from "../string-buffer-strategy-base";
 
 /**
  * Corrected version of {@link RegExpIndicesArray} that models `undefined`

--- a/src/search-strategy-factory.test.ts
+++ b/src/search-strategy-factory.test.ts
@@ -1,8 +1,8 @@
 import {
   StringAnchorSearchStrategy,
   RegexSearchStrategy
-} from "./search-strategies/index.ts";
-import { searchStrategyFactory } from "./search-strategy-factory.ts";
+} from "./search-strategies/index";
+import { searchStrategyFactory } from "./search-strategy-factory";
 import { describe, it, expect } from "vitest";
 
 vi.mock("./search-strategies/index.ts");

--- a/src/search-strategy-factory.test.ts
+++ b/src/search-strategy-factory.test.ts
@@ -5,7 +5,7 @@ import {
 import { searchStrategyFactory } from "./search-strategy-factory";
 import { describe, it, expect } from "vitest";
 
-vi.mock("./search-strategies/index.ts");
+vi.mock("./search-strategies/index");
 
 describe("search strategy factory", () => {
   describe("given a RegExp needle", () => {

--- a/src/search-strategy-factory.test.ts
+++ b/src/search-strategy-factory.test.ts
@@ -1,11 +1,11 @@
 import {
   StringAnchorSearchStrategy,
   RegexSearchStrategy
-} from "./search-strategies/index";
-import { searchStrategyFactory } from "./search-strategy-factory";
+} from "./search-strategies/index.js";
+import { searchStrategyFactory } from "./search-strategy-factory.js";
 import { describe, it, expect } from "vitest";
 
-vi.mock("./search-strategies/index");
+vi.mock("./search-strategies/index.js");
 
 describe("search strategy factory", () => {
   describe("given a RegExp needle", () => {

--- a/src/search-strategy-factory.ts
+++ b/src/search-strategy-factory.ts
@@ -1,7 +1,7 @@
 import {
   StringAnchorSearchStrategy,
   RegexSearchStrategy
-} from "./search-strategies/index";
+} from "./search-strategies/index.js";
 
 /**
  * Creates an appropriate search strategy based on the needle type.

--- a/src/search-strategy-factory.ts
+++ b/src/search-strategy-factory.ts
@@ -1,7 +1,7 @@
 import {
   StringAnchorSearchStrategy,
   RegexSearchStrategy
-} from "./search-strategies/index.ts";
+} from "./search-strategies/index";
 
 /**
  * Creates an appropriate search strategy based on the needle type.

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -96,6 +96,9 @@ npm run bench:deno
 
 # Run on all installed runtimes
 npm run bench:runtimes
+
+# Compare all runtimes
+npm run bench:compare-runtimes
 ```
 
 #### What's Measured

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -129,4 +129,4 @@ Stream processing performance with the same code across different JavaScript eng
 - Algorithm benchmarks focus on **algorithmic differences** (same runtime, different approaches)
 - Runtime benchmarks focus on **engine differences** (same code, different engines)
 - All benchmarks run in the workspace context with access to `../../src/` for imports
-- Scripts use `--experimental-strip-types` on Node, for TypeScript execution without compilation
+- Node scripts use `node --import tsx`, so local TypeScript execution resolves source `.ts` files behind `.js` import specifiers without a prebuild

--- a/test/benchmarks/algorithm/export-results.ts
+++ b/test/benchmarks/algorithm/export-results.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-strip-types
+#!/usr/bin/env -S node --import tsx
 
 /**
  * Exports succinct harness comparison results for tracking over time
@@ -10,8 +10,8 @@
  * - Winner per scenario
  *
  * Usage:
- *   node --experimental-strip-types test/benchmarks/algorithm/comparison.bench.ts --json | \
- *   node --experimental-strip-types test/benchmarks/algorithm/export-results.ts > test/benchmarks/algorithm/results/comparison-YYYY-MM-DD.json
+ *   node --import tsx test/benchmarks/algorithm/comparison.bench.ts --json | \
+ *   node --import tsx test/benchmarks/algorithm/export-results.ts > test/benchmarks/algorithm/results/comparison-YYYY-MM-DD.json
  */
 
 import type { ReadStream } from "node:fs";

--- a/test/benchmarks/algorithm/validate-functionality.test.ts
+++ b/test/benchmarks/algorithm/validate-functionality.test.ts
@@ -300,6 +300,8 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
 
         expect([...outputs, flushed].join("")).toBe("FIRSTSECONDTHIRD");
         expect(matchCount).toBe(3);
+        // Ensure no empty strings were enqueued between consecutive matches
+        expect(outputs.every(o => o.length > 0)).toBe(true);
       });
 
       // Scenario 7: Long pattern content

--- a/test/benchmarks/algorithm/validate-functionality.test.ts
+++ b/test/benchmarks/algorithm/validate-functionality.test.ts
@@ -711,7 +711,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         const capturedIndices: Array<{ matchIndex: number; streamIndices: [number, number]; match: string }> = [];
         
         const replacement = (match: string, { matchIndex, streamIndices }: ReplacementContext) => {
-          capturedIndices.push({ matchIndex, streamIndices: streamIndices as [number, number], match });
+          capturedIndices.push({ matchIndex, streamIndices, match });
           return "REPLACED";
         };
 
@@ -743,7 +743,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         const capturedMatches: Array<{ streamIndices: [number, number]; match: string }> = [];
         
         const replacement = (match: string, { streamIndices }: ReplacementContext) => {
-          capturedMatches.push({ streamIndices: streamIndices as [number, number], match });
+          capturedMatches.push({ streamIndices, match });
           return "X";
         };
 
@@ -778,7 +778,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         const capturedIndices: Array<{ streamIndices: [number, number] }> = [];
         
         const replacement = (match: string, { streamIndices }: ReplacementContext) => {
-          capturedIndices.push({ streamIndices: streamIndices as [number, number] });
+          capturedIndices.push({ streamIndices });
           return "REPLACED";
         };
 
@@ -809,7 +809,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         const capturedMatches: Array<{ streamIndices: [number, number]; match: string }> = [];
         
         const replacement = (match: string, { streamIndices }: ReplacementContext) => {
-          capturedMatches.push({ streamIndices: streamIndices as [number, number], match });
+          capturedMatches.push({ streamIndices, match });
           return "X";
         };
 
@@ -847,7 +847,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         const capturedMatches: Array<{ streamIndices: [number, number]; match: string }> = [];
         
         const replacement = (match: string, { streamIndices }: ReplacementContext) => {
-          capturedMatches.push({ streamIndices: streamIndices as [number, number], match });
+          capturedMatches.push({ streamIndices, match });
           return "X";
         };
 

--- a/test/benchmarks/algorithm/validate-functionality.test.ts
+++ b/test/benchmarks/algorithm/validate-functionality.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import * as harnesses from "../../harnesses/index.ts";
 import type { BaseHarness } from "../../harnesses/types.ts";
 import { mockTransformStreamDefaultControllerFactory } from "../../utilities.ts";
+import type { ReplacementContext } from "../../../src/replacement-processors/replacement-processor.base.ts";
 
 for (const harness of Object.values(harnesses) as BaseHarness[]) {
   const { name, createSearchStrategy, createTransformer, isAsync } = harness;
@@ -18,12 +19,12 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
     wrapper(
       substitutionData[match.slice(2, -2) as keyof typeof substitutionData]
     );
-  let indexedReplacement = (_: string, index: number) =>
-    wrapper(["Hello", "World"][index]);
+  let indexedReplacement = (_match: string, { matchIndex }: ReplacementContext) =>
+    wrapper(["Hello", "World"][matchIndex]);
 
   const setupTransformer = (
     tokens: string[],
-    replacement: (match: string, index: number) => string | Promise<string>
+    replacement: (match: string, context: ReplacementContext) => string | Promise<string>
   ) => {
     const strategy = createSearchStrategy({ tokens, replacement });
     return createTransformer({ strategy, replacement });

--- a/test/benchmarks/algorithm/validate-functionality.test.ts
+++ b/test/benchmarks/algorithm/validate-functionality.test.ts
@@ -700,5 +700,174 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         expect(matchCount).toBe(1);
       });
     });
+
+    describe("stream indices validation", () => {
+      it("Stream indices should be absolute positions in the overall stream", async () => {
+        const chunks = ["before {{", "hello}} after"];
+        const fullStream = chunks.join("");
+        
+        const capturedIndices: Array<{ matchIndex: number; streamIndices: [number, number]; match: string }> = [];
+        
+        const replacement = (match: string, { matchIndex, streamIndices }: ReplacementContext) => {
+          capturedIndices.push({ matchIndex, streamIndices: streamIndices as [number, number], match });
+          return "REPLACED";
+        };
+
+        const outputs: string[] = [];
+        const transformer = setupTransformer(["{{", "}}"], replacement);
+        const controller = mockTransformStreamDefaultControllerFactory(outputs);
+
+        for await (const chunk of chunks) {
+          await transformer.transform(chunk, controller);
+        }
+        transformer.flush(controller);
+
+        expect(capturedIndices).toHaveLength(1);
+        const [startIndex, endIndex] = capturedIndices[0].streamIndices;
+        
+        // Verify the match content at the absolute position
+        const matchContent = fullStream.substring(startIndex, endIndex);
+        expect(matchContent).toBe("{{hello}}");
+        
+        // Verify indices point to the right positions
+        expect(startIndex).toBe(7); // Position of {{ in "before {{hello}} after"
+        expect(endIndex).toBe(16); // Position after }}
+      });
+
+      it("Stream indices remain correct across multiple chunks with multiple matches", async () => {
+        const chunks = ["{{a}}text{{", "b}}more{{c", "}}"];
+        const fullStream = chunks.join("");
+        
+        const capturedMatches: Array<{ streamIndices: [number, number]; match: string }> = [];
+        
+        const replacement = (match: string, { streamIndices }: ReplacementContext) => {
+          capturedMatches.push({ streamIndices: streamIndices as [number, number], match });
+          return "X";
+        };
+
+        const outputs: string[] = [];
+        const transformer = setupTransformer(["{{", "}}"], replacement);
+        const controller = mockTransformStreamDefaultControllerFactory(outputs);
+
+        for await (const chunk of chunks) {
+          await transformer.transform(chunk, controller);
+        }
+        transformer.flush(controller);
+
+        expect(capturedMatches).toHaveLength(3);
+        
+        // Check first match: {{a}}
+        expect(fullStream.substring(capturedMatches[0].streamIndices[0], capturedMatches[0].streamIndices[1])).toBe("{{a}}");
+        expect(capturedMatches[0].streamIndices).toEqual([0, 5]);
+        
+        // Check second match: {{b}}
+        expect(fullStream.substring(capturedMatches[1].streamIndices[0], capturedMatches[1].streamIndices[1])).toBe("{{b}}");
+        expect(capturedMatches[1].streamIndices[0]).toBeGreaterThan(5);
+        
+        // Check third match: {{c}}
+        expect(fullStream.substring(capturedMatches[2].streamIndices[0], capturedMatches[2].streamIndices[1])).toBe("{{c}}");
+        expect(capturedMatches[2].streamIndices[0]).toBeGreaterThan(capturedMatches[1].streamIndices[0]);
+      });
+
+      it("Stream indices are correct for matches split across chunk boundaries", async () => {
+        const chunks = ["start {{he", "llo}} end"];
+        const fullStream = chunks.join("");
+        
+        const capturedIndices: Array<{ streamIndices: [number, number] }> = [];
+        
+        const replacement = (match: string, { streamIndices }: ReplacementContext) => {
+          capturedIndices.push({ streamIndices: streamIndices as [number, number] });
+          return "REPLACED";
+        };
+
+        const outputs: string[] = [];
+        const transformer = setupTransformer(["{{", "}}"], replacement);
+        const controller = mockTransformStreamDefaultControllerFactory(outputs);
+
+        for await (const chunk of chunks) {
+          await transformer.transform(chunk, controller);
+        }
+        transformer.flush(controller);
+
+        expect(capturedIndices).toHaveLength(1);
+        const [startIndex, endIndex] = capturedIndices[0].streamIndices;
+        
+        // The match spans chunks: "{{hello}}"
+        // In "start {{hello}} end", it starts at position 6
+        const matchContent = fullStream.substring(startIndex, endIndex);
+        expect(matchContent).toBe("{{hello}}");
+        expect(startIndex).toBe(6);
+        expect(endIndex).toBe(15);
+      });
+
+      it("Stream indices are monotonically increasing and correct", async () => {
+        const chunks = ["Hello {{a}}", " World {{b", "}} Foo {{c}}"];
+        const fullStream = chunks.join("");
+        
+        const capturedMatches: Array<{ streamIndices: [number, number]; match: string }> = [];
+        
+        const replacement = (match: string, { streamIndices }: ReplacementContext) => {
+          capturedMatches.push({ streamIndices: streamIndices as [number, number], match });
+          return "X";
+        };
+
+        const outputs: string[] = [];
+        const transformer = setupTransformer(["{{", "}}"], replacement);
+        const controller = mockTransformStreamDefaultControllerFactory(outputs);
+
+        for await (const chunk of chunks) {
+          await transformer.transform(chunk, controller);
+        }
+        transformer.flush(controller);
+
+        expect(capturedMatches).toHaveLength(3);
+        
+        // Verify each match can be found in the stream at its reported indices
+        for (const captured of capturedMatches) {
+          const [start, end] = captured.streamIndices;
+          const extractedMatch = fullStream.substring(start, end);
+          expect(extractedMatch).toBe(captured.match);
+        }
+        
+        // Verify indices are monotonically increasing (non-overlapping)
+        for (let i = 1; i < capturedMatches.length; i++) {
+          expect(capturedMatches[i].streamIndices[0]).toBeGreaterThanOrEqual(
+            capturedMatches[i - 1].streamIndices[1]
+          );
+        }
+      });
+
+      it("Stream indices point to correct match content in the stream", async () => {
+        // Test with padding and multiple matches to ensure indices are absolute
+        const chunks = ["start{{one}}mi", "ddle{{two}}end"];
+        const fullStream = chunks.join("");
+        
+        const capturedMatches: Array<{ streamIndices: [number, number]; match: string }> = [];
+        
+        const replacement = (match: string, { streamIndices }: ReplacementContext) => {
+          capturedMatches.push({ streamIndices: streamIndices as [number, number], match });
+          return "X";
+        };
+
+        const outputs: string[] = [];
+        const transformer = setupTransformer(["{{", "}}"], replacement);
+        const controller = mockTransformStreamDefaultControllerFactory(outputs);
+
+        for await (const chunk of chunks) {
+          await transformer.transform(chunk, controller);
+        }
+        transformer.flush(controller);
+
+        expect(capturedMatches).toHaveLength(2);
+
+        // Verify each captured match can be extracted from the stream using its indices
+        capturedMatches.forEach((captured) => {
+          const [start, end] = captured.streamIndices;
+          const matchContent = fullStream.substring(start, end);
+          // The extracted content should be the match
+          expect(matchContent).toBe(captured.match);
+        });
+      });
+    });
   });
 }

--- a/test/benchmarks/algorithm/validate-functionality.test.ts
+++ b/test/benchmarks/algorithm/validate-functionality.test.ts
@@ -19,7 +19,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
     wrapper(
       substitutionData[match.slice(2, -2) as keyof typeof substitutionData]
     );
-  let indexedReplacement = (_match: string, { matchIndex }: ReplacementContext) =>
+  let indexedReplacement = (_: string, { matchIndex }: ReplacementContext) =>
     wrapper(["Hello", "World"][matchIndex]);
 
   const setupTransformer = (

--- a/test/benchmarks/algorithm/visualise-results.ts
+++ b/test/benchmarks/algorithm/visualise-results.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-strip-types
+#!/usr/bin/env -S node --import tsx
 
 /**
  * Visualise harness comparison results
@@ -12,13 +12,13 @@
  *   cd test/benchmarks/algorithm
  * 
  *   # Single run terminal chart
- *   node --experimental-strip-types visualise-results.ts results/comparison-2025-11-07.json
+ *   node --import tsx visualise-results.ts results/comparison-2025-11-07.json
  *
  *   # Generate HTML chart
- *   node --experimental-strip-types visualise-results.ts results/comparison-2025-11-07.json --html > chart.html
+ *   node --import tsx visualise-results.ts results/comparison-2025-11-07.json --html > chart.html
  *
  *   # Time-series comparison (multiple files)
- *   node --experimental-strip-types visualise-results.ts results/*.json --timeseries --html > trends.html
+ *   node --import tsx visualise-results.ts results/*.json --timeseries --html > trends.html
  */
 
 import { readFile } from "node:fs/promises";
@@ -854,13 +854,13 @@ Usage:
   cd test/benchmarks/algorithm
 
   # Terminal visualization (single run)
-  node --experimental-strip-types visualise-results.ts <file.json>
+  node --import tsx visualise-results.ts <file.json>
 
   # HTML chart (single run)
-  node --experimental-strip-types visualise-results.ts <file.json> --html > chart.html
+  node --import tsx visualise-results.ts <file.json> --html > chart.html
 
   # Time-series trends (multiple runs)
-  node --experimental-strip-types visualise-results.ts results/*.json --timeseries --html > trends.html
+  node --import tsx visualise-results.ts results/*.json --timeseries --html > trends.html
     `);
     process.exit(0);
   }

--- a/test/benchmarks/package.json
+++ b/test/benchmarks/package.json
@@ -5,18 +5,19 @@
   "type": "module",
   "description": "Benchmark tooling and harnesses for replace-content-transformer",
   "scripts": {
-    "bench": "node --experimental-strip-types runtime/benchmarks.ts",
+    "bench": "node --import tsx runtime/benchmarks.ts",
     "bench:bun": "bun run runtime/benchmarks.ts",
     "bench:deno": "deno run --allow-read --allow-write --allow-env --allow-sys runtime/benchmarks.ts",
-    "bench:node": "node --experimental-strip-types runtime/benchmarks.ts",
+    "bench:node": "node --import tsx runtime/benchmarks.ts",
     "bench:runtimes": "./runtime/bench-all.sh",
-    "bench:compare-runtimes": "node --experimental-strip-types runtime/compare.ts",
-    "bench:algorithms": "node --experimental-strip-types algorithm/comparison.bench.ts",
+    "bench:compare-runtimes": "node --import tsx runtime/compare.ts",
+    "bench:algorithms": "node --import tsx algorithm/comparison.bench.ts",
     "bench:algorithms:json": "./algorithm/run.sh",
     "bench:algorithms:json:succinct": "./algorithm/run-succinct.sh",
-    "bench:algorithms:visualise": "node --experimental-strip-types algorithm/visualise-results.ts"
+    "bench:algorithms:visualise": "node --import tsx algorithm/visualise-results.ts"
   },
   "devDependencies": {
-    "mitata": "^1.0.10"
+    "mitata": "^1.0.10",
+    "tsx": "^4.21.0"
   }
 }

--- a/test/benchmarks/package.json
+++ b/test/benchmarks/package.json
@@ -10,6 +10,7 @@
     "bench:deno": "deno run --allow-read --allow-write --allow-env --allow-sys runtime/benchmarks.ts",
     "bench:node": "node --experimental-strip-types runtime/benchmarks.ts",
     "bench:runtimes": "./runtime/bench-all.sh",
+    "bench:compare-runtimes": "node --experimental-strip-types runtime/compare.ts",
     "bench:algorithms": "node --experimental-strip-types algorithm/comparison.bench.ts",
     "bench:algorithms:json": "./algorithm/run.sh",
     "bench:algorithms:json:succinct": "./algorithm/run-succinct.sh",

--- a/test/benchmarks/runtime/benchmark-definitions.ts
+++ b/test/benchmarks/runtime/benchmark-definitions.ts
@@ -8,6 +8,7 @@ import {
   StringAnchorSearchStrategy
 } from "../../../src/search-strategies/index.ts";
 import type { LoopedIndexOfAnchoredSearchState as SearchState } from "../../../src/search-strategies/looped-indexOf-anchored/search-strategy.ts";
+import type { ReplacementContext } from "../../../src/replacement-processors/replacement-processor.base.ts";
 
 /**
  * Core benchmark definitions - categorized object
@@ -97,7 +98,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new FunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: (matchedContent: string, index: number) => `NEW-${index}`
+          replacement: (_match: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
         }),
         input: ["Hello OLD world OLD test OLD content"]
       }),
@@ -328,7 +329,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new FunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: (content, index) => `NEW-${index}`
+          replacement: (_match: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
         }),
         input: ["Replace OLD and OLD and OLD content"]
       }),
@@ -367,7 +368,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (content, index) => `NEW-${index}`
+          replacement: async (_match: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
         }),
         input: ["Replace OLD and OLD and OLD content"]
       }),
@@ -387,9 +388,9 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (content, index) => {
+          replacement: async (_match: string, { matchIndex }: ReplacementContext) => {
             await Promise.resolve();
-            return `NEW-${index}`;
+            return `NEW-${matchIndex}`;
           }
         }),
         input: ["Replace OLD and OLD and OLD content"]
@@ -410,8 +411,8 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (content, index) => {
-            return Promise.resolve(`NEW-${index}`);
+          replacement: async (_match: string, { matchIndex }: ReplacementContext) => {
+            return Promise.resolve(`NEW-${matchIndex}`);
           }
         }),
         input: ["Replace OLD and OLD and OLD content"]
@@ -455,13 +456,13 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncIterableFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (content, index) => {
+          replacement: async (_match: string, { matchIndex }: ReplacementContext) => {
             return new ReadableStream({
               start(controller) {
                 controller.enqueue("N");
                 controller.enqueue("E");
                 controller.enqueue("W");
-                controller.enqueue(`-${index}`);
+                controller.enqueue(`-${matchIndex}`);
                 controller.close();
               }
             });

--- a/test/benchmarks/runtime/benchmark-definitions.ts
+++ b/test/benchmarks/runtime/benchmark-definitions.ts
@@ -98,7 +98,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new FunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: (_match: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
+          replacement: (_: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
         }),
         input: ["Hello OLD world OLD test OLD content"]
       }),
@@ -329,7 +329,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new FunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: (_match: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
+          replacement: (_: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
         }),
         input: ["Replace OLD and OLD and OLD content"]
       }),
@@ -368,7 +368,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (_match: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
+          replacement: async (_: string, { matchIndex }: ReplacementContext) => `NEW-${matchIndex}`
         }),
         input: ["Replace OLD and OLD and OLD content"]
       }),
@@ -388,7 +388,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (_match: string, { matchIndex }: ReplacementContext) => {
+          replacement: async (_: string, { matchIndex }: ReplacementContext) => {
             await Promise.resolve();
             return `NEW-${matchIndex}`;
           }
@@ -411,7 +411,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (_match: string, { matchIndex }: ReplacementContext) => {
+          replacement: async (_: string, { matchIndex }: ReplacementContext) => {
             return Promise.resolve(`NEW-${matchIndex}`);
           }
         }),
@@ -456,7 +456,7 @@ export const benchmarkDefinitions: {
       setup: () => ({
         processor: new AsyncIterableFunctionReplacementProcessor({
           searchStrategy: new StringAnchorSearchStrategy(["OLD"]),
-          replacement: async (_match: string, { matchIndex }: ReplacementContext) => {
+          replacement: async (_: string, { matchIndex }: ReplacementContext) => {
             return new ReadableStream({
               start(controller) {
                 controller.enqueue("N");

--- a/test/benchmarks/runtime/benchmarks.ts
+++ b/test/benchmarks/runtime/benchmarks.ts
@@ -16,7 +16,7 @@ import {
  * Usage:
  * - Bun: bun run test/benchmarks/runtime/benchmarks.ts
  * - Deno: deno run --allow-read --allow-write --allow-env --allow-sys test/benchmarks/runtime/benchmarks.ts
- * - Node: node --experimental-strip-types test/benchmarks/runtime/benchmarks.ts
+ * - Node: node --import tsx test/benchmarks/runtime/benchmarks.ts
  */
 
 const runtime = (() => {

--- a/test/benchmarks/runtime/benchmarks.ts
+++ b/test/benchmarks/runtime/benchmarks.ts
@@ -14,9 +14,9 @@ import {
  * - Cross-runtime comparison (Bun vs Deno vs Node.js)
  *
  * Usage:
- * - Bun: bun run test/benchmarks/runtime-comparison/benchmarks.ts
- * - Deno: deno run --allow-read --allow-write --allow-env --allow-sys test/benchmarks/runtime-comparison/benchmarks.ts
- * - Node: node --experimental-strip-types test/benchmarks/runtime-comparison/benchmarks.ts
+ * - Bun: bun run test/benchmarks/runtime/benchmarks.ts
+ * - Deno: deno run --allow-read --allow-write --allow-env --allow-sys test/benchmarks/runtime/benchmarks.ts
+ * - Node: node --experimental-strip-types test/benchmarks/runtime/benchmarks.ts
  */
 
 const runtime = (() => {

--- a/test/benchmarks/runtime/compare.ts
+++ b/test/benchmarks/runtime/compare.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --experimental-strip-types
+#!/usr/bin/env -S node --import tsx
 
 /**
  * Cross-Runtime Benchmark Comparison Tool
@@ -54,7 +54,8 @@ const RUNTIMES: RuntimeInfo[] = [
     name: "Node",
     command: "node",
     args: [
-      "--experimental-strip-types",
+      "--import",
+      "tsx",
       "./runtime/benchmarks.ts",
       "--json"
     ],

--- a/test/benchmarks/runtime/compare.ts
+++ b/test/benchmarks/runtime/compare.ts
@@ -31,7 +31,7 @@ const RUNTIMES: RuntimeInfo[] = [
     command: "bun",
     args: [
       "run",
-      "./test/benchmarks/runtime-comparison/benchmarks.ts",
+      "./runtime/benchmarks.ts",
       "--json"
     ],
     available: false
@@ -45,7 +45,7 @@ const RUNTIMES: RuntimeInfo[] = [
       "--allow-write",
       "--allow-env",
       "--allow-sys",
-      "./test/benchmarks/runtime-comparison/benchmarks.ts",
+      "./runtime/benchmarks.ts",
       "--json"
     ],
     available: false
@@ -55,7 +55,7 @@ const RUNTIMES: RuntimeInfo[] = [
     command: "node",
     args: [
       "--experimental-strip-types",
-      "./test/benchmarks/runtime-comparison/benchmarks.ts",
+      "./runtime/benchmarks.ts",
       "--json"
     ],
     available: false

--- a/test/harnesses/buffered-indexOf-anchor-sequence.ts
+++ b/test/harnesses/buffered-indexOf-anchor-sequence.ts
@@ -1,5 +1,6 @@
 import { FunctionReplacementProcessor } from "../../src/replacement-processors/function-replacement-processor.ts";
 import { ReplaceContentTransformer } from "../../src/adapters/web/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 import {
   AnchorSequenceSearchStrategy,
   BufferedIndexOfCancellableSearchStrategy,
@@ -13,7 +14,7 @@ export const BufferedIndexOfAnchorSequenceHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) =>
     new AnchorSequenceSearchStrategy<BufferedIndexOfCancellableSearchState>(
       tokens.map((token) => new BufferedIndexOfCancellableSearchStrategy(token))
@@ -23,7 +24,7 @@ export const BufferedIndexOfAnchorSequenceHarness = {
     replacement
   }: {
     strategy: AnchorSequenceSearchStrategy<BufferedIndexOfCancellableSearchState>;
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) =>
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({

--- a/test/harnesses/buffered-indexOf-anchored-async.ts
+++ b/test/harnesses/buffered-indexOf-anchored-async.ts
@@ -1,6 +1,7 @@
 import { AsyncFunctionReplacementProcessor } from "../../src/replacement-processors/async-function-replacement-processor.ts";
 import { AsyncReplaceContentTransformer } from "../../src/adapters/web/index.ts";
 import { BufferedIndexOfAnchoredSearchStrategy } from "../../src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const BufferedIndexOfAnchoredAsyncHarness = {
   name: "Buffered IndexOf Anchored (Async)",
@@ -9,7 +10,7 @@ export const BufferedIndexOfAnchoredAsyncHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) => {
     return new BufferedIndexOfAnchoredSearchStrategy(tokens);
   },
@@ -18,7 +19,7 @@ export const BufferedIndexOfAnchoredAsyncHarness = {
     replacement
   }: {
     strategy: BufferedIndexOfAnchoredSearchStrategy;
-    replacement: (match: string, index: number) => Promise<string>;
+    replacement: (match: string, context: ReplacementContext) => Promise<string>;
   }) =>
     new AsyncReplaceContentTransformer(
       new AsyncFunctionReplacementProcessor({

--- a/test/harnesses/buffered-indexOf-anchored-callback.ts
+++ b/test/harnesses/buffered-indexOf-anchored-callback.ts
@@ -1,5 +1,6 @@
 import { ReplaceContentTransformerCallback } from "../../src/adapters/web/benchmarking/sync-transformer-callback.ts";
 import { BufferedIndexOfAnchoredCallbackSearchStrategy } from "../../src/search-strategies/benchmarking/buffered-indexOf-anchored-callback/search-strategy.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const BufferedIndexOfAnchoredCallbackHarness = {
   name: "Buffered IndexOf Anchored Callback",
@@ -10,7 +11,7 @@ export const BufferedIndexOfAnchoredCallbackHarness = {
     replacement
   }: {
     tokens: string[];
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) => {
     return new BufferedIndexOfAnchoredCallbackSearchStrategy(
       replacement,

--- a/test/harnesses/buffered-indexOf-anchored.ts
+++ b/test/harnesses/buffered-indexOf-anchored.ts
@@ -1,6 +1,7 @@
 import { ReplaceContentTransformer } from "../../src/adapters/web/sync-transformer.ts";
 import { FunctionReplacementProcessor } from "../../src/index.ts";
 import { BufferedIndexOfAnchoredSearchStrategy } from "../../src/search-strategies/benchmarking/buffered-indexOf-anchored/search-strategy.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const BufferedIndexOfAnchoredHarness = {
   name: "Buffered IndexOf Anchored",
@@ -9,7 +10,7 @@ export const BufferedIndexOfAnchoredHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) => {
     return new BufferedIndexOfAnchoredSearchStrategy(tokens);
   },
@@ -18,7 +19,7 @@ export const BufferedIndexOfAnchoredHarness = {
     replacement
   }: {
     strategy: BufferedIndexOfAnchoredSearchStrategy;
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) =>
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({

--- a/test/harnesses/buffered-indexOf-callback.ts
+++ b/test/harnesses/buffered-indexOf-callback.ts
@@ -1,5 +1,6 @@
 import { ReplaceContentTransformerCallback } from "../../src/adapters/web/benchmarking/sync-transformer-callback.ts";
 import { BufferedIndexOfCallbackSearchStrategy } from "../../src/search-strategies/benchmarking/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const BufferedIndexOfCallbackHarness = {
   name: "Buffered IndexOf Callback",
@@ -10,7 +11,7 @@ export const BufferedIndexOfCallbackHarness = {
     replacement
   }: {
     tokens: string[];
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) => {
     return new BufferedIndexOfCallbackSearchStrategy(replacement, tokens);
   },

--- a/test/harnesses/buffered-indexOf-canonical.ts
+++ b/test/harnesses/buffered-indexOf-canonical.ts
@@ -1,4 +1,5 @@
 import { BufferedIndexOfReplaceContentTransformer } from "../../src/search-strategies/benchmarking/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const BufferedIndexOfCanonicalHarness = {
   name: "Buffered IndexOf Canonical",
@@ -9,7 +10,7 @@ export const BufferedIndexOfCanonicalHarness = {
     replacement
   }: {
     tokens: string[];
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) => {
     return { tokens, replacement };
   },
@@ -18,7 +19,7 @@ export const BufferedIndexOfCanonicalHarness = {
   }: {
     strategy: {
       tokens: string[];
-      replacement: (match: string, index: number) => string;
+      replacement: (match: string, context: ReplacementContext) => string;
     };
   }) =>
     new BufferedIndexOfReplaceContentTransformer(

--- a/test/harnesses/buffered-indexOf-generator.ts
+++ b/test/harnesses/buffered-indexOf-generator.ts
@@ -1,5 +1,6 @@
 import { ReplaceContentTransformer } from "../../src/adapters/web/index.ts";
 import { BufferedIndexOfCanonicalAsGeneratorSearchStrategy } from "../../src/search-strategies/benchmarking/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const BufferedIndexOfGeneratorHarness = {
   name: "Buffered IndexOf Generator Canonical",
@@ -10,7 +11,7 @@ export const BufferedIndexOfGeneratorHarness = {
     replacement
   }: {
     tokens: string[];
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) => {
     return new BufferedIndexOfCanonicalAsGeneratorSearchStrategy(
       replacement,

--- a/test/harnesses/indexOf-knuth-morris-pratt.ts
+++ b/test/harnesses/indexOf-knuth-morris-pratt.ts
@@ -1,5 +1,6 @@
 import { FunctionReplacementProcessor } from "../../src/index.ts";
 import { ReplaceContentTransformer } from "../../src/adapters/web/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 import {
   AnchorSequenceSearchStrategy,
   IndexOfKnuthMorrisPrattSearchStrategy,
@@ -13,7 +14,7 @@ export const KMPAnchorSequenceHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) =>
     new AnchorSequenceSearchStrategy<IndexOfKnuthMorrisPrattSearchState>(
       tokens.map((token) => new IndexOfKnuthMorrisPrattSearchStrategy(token))
@@ -23,7 +24,7 @@ export const KMPAnchorSequenceHarness = {
     replacement
   }: {
     strategy: AnchorSequenceSearchStrategy<IndexOfKnuthMorrisPrattSearchState>;
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) =>
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({

--- a/test/harnesses/looped-indexOf-anchored.ts
+++ b/test/harnesses/looped-indexOf-anchored.ts
@@ -1,6 +1,7 @@
 import { ReplaceContentTransformer } from "../../src/adapters/web/sync-transformer.ts";
 import { FunctionReplacementProcessor } from "../../src/index.ts";
 import { LoopedIndexOfAnchoredSearchStrategy } from "../../src/search-strategies/looped-indexOf-anchored/search-strategy.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const LoopedIndexOfAnchoredHarness = {
   name: "Looped IndexOf Anchored",
@@ -9,7 +10,7 @@ export const LoopedIndexOfAnchoredHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) => {
     return new LoopedIndexOfAnchoredSearchStrategy(tokens);
   },
@@ -18,7 +19,7 @@ export const LoopedIndexOfAnchoredHarness = {
     replacement
   }: {
     strategy: LoopedIndexOfAnchoredSearchStrategy;
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) =>
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({

--- a/test/harnesses/looped-indexOf-callback.ts
+++ b/test/harnesses/looped-indexOf-callback.ts
@@ -1,5 +1,6 @@
 import { ReplaceContentTransformerCallback } from "../../src/adapters/web/benchmarking/sync-transformer-callback.ts";
 import { LoopedIndexOfCallbackSearchStrategy } from "../../src/search-strategies/benchmarking/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const LoopedIndexOfCallbackHarness = {
   name: "Looped IndexOf Callback",
@@ -10,7 +11,7 @@ export const LoopedIndexOfCallbackHarness = {
     replacement
   }: {
     tokens: string[];
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) => {
     return new LoopedIndexOfCallbackSearchStrategy(replacement, tokens);
   },

--- a/test/harnesses/looped-indexOf-cancellable.ts
+++ b/test/harnesses/looped-indexOf-cancellable.ts
@@ -1,5 +1,6 @@
 import { FunctionReplacementProcessor } from "../../src/index.ts";
 import { ReplaceContentTransformer } from "../../src/adapters/web/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 import {
   AnchorSequenceSearchStrategy,
   LoopedIndexOfCancellableSearchStrategy,
@@ -13,7 +14,7 @@ export const LoopedIndexOfAnchorSequenceHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) =>
     new AnchorSequenceSearchStrategy<LoopedIndexOfCancellableSearchState>(
       tokens.map((token) => new LoopedIndexOfCancellableSearchStrategy(token))
@@ -23,7 +24,7 @@ export const LoopedIndexOfAnchorSequenceHarness = {
     replacement
   }: {
     strategy: AnchorSequenceSearchStrategy<LoopedIndexOfCancellableSearchState>;
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) =>
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({

--- a/test/harnesses/regex-anchor-sequence.ts
+++ b/test/harnesses/regex-anchor-sequence.ts
@@ -3,6 +3,7 @@ import { RegexSearchStrategy } from "../../src/search-strategies/regex/search-st
 import { AnchorSequenceSearchStrategy } from "../../src/search-strategies/benchmarking/index.ts";
 import { ReplaceContentTransformer } from "../../src/adapters/web/index.ts";
 import type { StringBufferState } from "../../src/search-strategies/string-buffer-strategy-base.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const RegexAnchorSequenceHarness = {
   name: "Regex + Anchor Sequence",
@@ -11,7 +12,7 @@ export const RegexAnchorSequenceHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) =>
     new AnchorSequenceSearchStrategy<StringBufferState, RegExpExecArray>(
       tokens.map(
@@ -23,7 +24,7 @@ export const RegexAnchorSequenceHarness = {
     replacement
   }: {
     strategy: AnchorSequenceSearchStrategy<StringBufferState, RegExpExecArray>;
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) =>
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({

--- a/test/harnesses/regex-callback.ts
+++ b/test/harnesses/regex-callback.ts
@@ -1,5 +1,6 @@
 import { ReplaceContentTransformerCallback } from "../../src/adapters/web/benchmarking/sync-transformer-callback.ts";
 import { RegexCallbackSearchStrategy } from "../../src/search-strategies/benchmarking/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const RegexCallbackHarness = {
   name: "Regex Callback",
@@ -10,7 +11,7 @@ export const RegexCallbackHarness = {
     replacement
   }: {
     tokens: string[];
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) => {
     const needle = new RegExp(
       `${RegExp.escape(startToken)}.*?${RegExp.escape(endToken)}`,

--- a/test/harnesses/regex-canonical.ts
+++ b/test/harnesses/regex-canonical.ts
@@ -1,5 +1,6 @@
 import { RegexReplaceContentTransformer } from "../../src/search-strategies/benchmarking/index.ts";
 import createPartialMatchRegex from "regex-partial-match";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const RegexCanonicalHarness = {
   name: "Regex Canonical",
@@ -10,7 +11,7 @@ export const RegexCanonicalHarness = {
     replacement
   }: {
     tokens: string[];
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) => {
     // contrived, to ensure one-time construction overhead of regexes
     return {
@@ -28,7 +29,7 @@ export const RegexCanonicalHarness = {
     strategy
   }: {
     strategy: {
-      replacement: (match: string, index: number) => string;
+      replacement: (match: string, context: ReplacementContext) => string;
       openRegex: RegExp;
       partialAtEndRegex: RegExp;
     };

--- a/test/harnesses/regex.ts
+++ b/test/harnesses/regex.ts
@@ -3,6 +3,7 @@ import {
   RegexSearchStrategy
 } from "../../src/index.ts";
 import { ReplaceContentTransformer } from "../../src/adapters/web/index.ts";
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
 
 export const RegexHarness = {
   name: "Regex",
@@ -11,7 +12,7 @@ export const RegexHarness = {
     tokens
   }: {
     tokens: string[];
-    replacement?: (match: string, index: number) => string;
+    replacement?: (match: string, context: ReplacementContext) => string;
   }) =>
     new RegexSearchStrategy(
       new RegExp(tokens.map(RegExp.escape).join(".*?"), "s")
@@ -21,12 +22,12 @@ export const RegexHarness = {
     replacement
   }: {
     strategy: RegexSearchStrategy;
-    replacement: (match: string, index: number) => string;
+    replacement: (match: string, context: ReplacementContext) => string;
   }) =>
     new ReplaceContentTransformer(
       new FunctionReplacementProcessor({
         searchStrategy: strategy,
-        replacement: (match, index) => replacement(match[0], index)
+        replacement: (match, context) => replacement(match[0], context)
       })
     )
 };

--- a/test/harnesses/types.ts
+++ b/test/harnesses/types.ts
@@ -1,6 +1,8 @@
+import type { ReplacementContext } from "../../src/replacement-processors/replacement-processor.base.ts";
+
 type ReplacementFunction = (
   match: string,
-  index: number
+  context: ReplacementContext
 ) => string | Promise<string>;
 
 export type BaseHarness = {

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,
-    "outDir": "./lib-cjs"
+    "outDir": "./lib/cjs"
   }
 }

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./lib-cjs"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,7 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "declaration": true,
-    "outDir": "./lib",
+    "outDir": "./lib/esm",
     "rootDir": "./src"
   }
 }


### PR DESCRIPTION
## Details

Update replacement functions to have an extensible context object as a second argument.  Enabler for https://github.com/TomStrepsil/replace-content-transformer/issues/32, which requires contextual cues for concurrency strategies.

Confirmed no change in performance (due to boxing as object?) via algorithm benchmarks.

## Scout rule

- Added explicit cjs build step / exports, and [`@arethetypeswrong`](https://github.com/arethetypeswrong/arethetypeswrong.github.io) validation
- Updated to latest [`regex-partial-match`](https://github.com/TomStrepsil/regex-partial-match)
- Added `bench:compare-runtimes` script, hooking up previously undocumented `runtime/compare.ts`
- Added stream indices support to benchmark search strategies, to provide a consistent comparison
- Fix up some (benchmark only) search strategies to avoid emitting empty chunks when no gap between consecutive matches - and updated the basic functionality validation test to cover this
- Clarify that `AsyncIterableReplacementProcessor` can replace with `AsyncIterable<string>` as well as the existing `Promise<AsyncIterable<string>>`
 
## Semantic Version Impact

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [x] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
