### PR TITLE
[NO ISSUE] update jcodeshift instructions for security & mac compatibility

### DIFF
--- a/codemods/transforms/v1-v2/README.md
+++ b/codemods/transforms/v1-v2/README.md
@@ -20,29 +20,17 @@ replacement: (match, { matchIndex }) => `#${matchIndex}: ${match}`
 replacement: (match, { matchIndex, streamIndices }) => `${streamIndices[0]}-${streamIndices[1]}`
 ```
 
-Dry run:
-
 ```bash
-npx jscodeshift \
-  -t <(curl -fsSL https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js) \
-  --parser=tsx --extensions=js,jsx,ts,tsx,mjs \
-  --dry --print ./src
+curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js
+
+# Dry run
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --dry --print ./src
+
+# Apply
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
+
+rm rct-codemod.js
 ```
-
-Apply changes:
-
-```bash
-npx jscodeshift \
-  -t <(curl -fsSL https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js) \
-  --parser=tsx --extensions=js,jsx,ts,tsx,mjs \
-  ./src
-```
-
-> **Windows / non-bash users:** process substitution (`<(...)`) is not supported outside bash/zsh. Download the transform first, then run:
-> ```
-> curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js
-> npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
-> ```
 
 ### Notes
 
@@ -106,29 +94,17 @@ const transformer = new ReplaceContentTransformer(
 );
 ```
 
-Dry run:
-
 ```bash
-npx jscodeshift \
-  -t <(curl -fsSL https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js) \
-  --parser=tsx --extensions=js,jsx,ts,tsx,mjs \
-  --dry --print ./src
+curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js
+
+# Dry run
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --dry --print ./src
+
+# Apply
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
+
+rm rct-codemod.js
 ```
-
-Apply changes:
-
-```bash
-npx jscodeshift \
-  -t <(curl -fsSL https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js) \
-  --parser=tsx --extensions=js,jsx,ts,tsx,mjs \
-  ./src
-```
-
-> **Windows / non-bash users:** process substitution (`<(...)`) is not supported outside bash/zsh. Download the transform first, then run:
-> ```
-> curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js
-> npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
-> ```
 
 ### Notes
 

--- a/codemods/transforms/v1-v2/README.md
+++ b/codemods/transforms/v1-v2/README.md
@@ -29,7 +29,8 @@ npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --
 # Apply
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
 
-rm rct-codemod.js
+# Cleanup
+rm rct-codemod.js # Or platform-compatible equivalent...
 ```
 
 ### Notes
@@ -103,7 +104,8 @@ npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --
 # Apply
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
 
-rm rct-codemod.js
+# Cleanup
+rm rct-codemod.js # Or platform-compatible equivalent...
 ```
 
 ### Notes

--- a/codemods/transforms/v1-v2/README.md
+++ b/codemods/transforms/v1-v2/README.md
@@ -20,11 +20,23 @@ replacement: (match, { matchIndex }) => `#${matchIndex}: ${match}`
 replacement: (match, { matchIndex, streamIndices }) => `${streamIndices[0]}-${streamIndices[1]}`
 ```
 
+**Unix/macOS**
+
 ```bash
-# Download (Unix/macOS)
 curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js
 
-# Download (Windows — PowerShell)
+# Dry run
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --dry --print ./src
+
+# Apply
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
+
+rm rct-codemod.js
+```
+
+**Windows (PowerShell)**
+
+```powershell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js" -OutFile rct-codemod.js
 
 # Dry run
@@ -33,10 +45,6 @@ npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --
 # Apply
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
 
-# Cleanup (Unix/macOS)
-rm rct-codemod.js
-
-# Cleanup (Windows)
 del rct-codemod.js
 ```
 
@@ -102,11 +110,23 @@ const transformer = new ReplaceContentTransformer(
 );
 ```
 
+**Unix/macOS**
+
 ```bash
-# Download (Unix/macOS)
 curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js
 
-# Download (Windows — PowerShell)
+# Dry run
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --dry --print ./src
+
+# Apply
+npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
+
+rm rct-codemod.js
+```
+
+**Windows (PowerShell)**
+
+```powershell
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js" -OutFile rct-codemod.js
 
 # Dry run
@@ -115,10 +135,6 @@ npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --
 # Apply
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
 
-# Cleanup (Unix/macOS)
-rm rct-codemod.js
-
-# Cleanup (Windows)
 del rct-codemod.js
 ```
 

--- a/codemods/transforms/v1-v2/README.md
+++ b/codemods/transforms/v1-v2/README.md
@@ -21,7 +21,11 @@ replacement: (match, { matchIndex, streamIndices }) => `${streamIndices[0]}-${st
 ```
 
 ```bash
+# Download (Unix/macOS)
 curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js
+
+# Download (Windows — PowerShell)
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/replacement-callback-positional-to-context.js" -OutFile rct-codemod.js
 
 # Dry run
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --dry --print ./src
@@ -29,8 +33,11 @@ npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --
 # Apply
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
 
-# Cleanup
-rm rct-codemod.js # Or platform-compatible equivalent...
+# Cleanup (Unix/macOS)
+rm rct-codemod.js
+
+# Cleanup (Windows)
+del rct-codemod.js
 ```
 
 ### Notes
@@ -96,7 +103,11 @@ const transformer = new ReplaceContentTransformer(
 ```
 
 ```bash
+# Download (Unix/macOS)
 curl -fsSL -o rct-codemod.js https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js
+
+# Download (Windows — PowerShell)
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/TomStrepsil/replace-content-transformer/v2.0.0/codemods/transforms/v1-v2/processor-to-engine.js" -OutFile rct-codemod.js
 
 # Dry run
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --dry --print ./src
@@ -104,8 +115,11 @@ npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs --
 # Apply
 npx jscodeshift -t rct-codemod.js --parser=tsx --extensions=js,jsx,ts,tsx,mjs ./src
 
-# Cleanup
-rm rct-codemod.js # Or platform-compatible equivalent...
+# Cleanup (Unix/macOS)
+rm rct-codemod.js
+
+# Cleanup (Windows)
+del rct-codemod.js
 ```
 
 ### Notes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A `"codemods"` workspace, plus a `jscodeshift` codemod, `npx jscodeshift` instructions (plus in-repo scripts, for completeness), to migrate replacement callbacks from positional arguments to `(match, context)` form, plus one for processor-to-engine refactor
+- A `"codemods"` workspace, plus a `jscodeshift` codemod, `npx jscodeshift` download-then-run instructions (plus in-repo scripts, for completeness), to migrate replacement callbacks from positional arguments to `(match, context)` form, plus one for processor-to-engine refactor
 - `bench:compare-runtimes` package script, enacting the `runtime/compare.ts` script previously undocumented
 - Updated benchmark search strategies to include proper stream indices, to support parity of functionality
 - Explicit CJS build step / exports, and add [`@arethetypeswrong`](https://github.com/arethetypeswrong/arethetypeswrong.github.io) validation


### PR DESCRIPTION
## Details

https://github.com/TomStrepsil/replace-content-transformer/pull/39 added details about running codemods without pulling fown the whole repo.  But, wasn't compatible with Mac. And probably safer to download first, to allow scrutiny.

Update the instructions for all platforms, and recommend download-then-execute.

## Semantic Version Impact

<!-- Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/ -->

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [ ] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
