### PR TITLE
[NO ISSUE] update @types/node to 25.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,6 @@ const syncTransformer = new ReplaceContentTransformer(engine: SyncTransformEngin
 const asyncTransformer = new AsyncReplaceContentTransformer(engine: AsyncTransformEngine);
 ```
 
-> [!NOTE]
-> The WHATWG spec includes `Transformer.cancel` with an optional `reason` parameter for async transformers.
-> Some TypeScript type sources still lag this part of the spec (including current Node docs/types), so the public
-> TypeScript signatures in this project focus on matching widely-available types while keeping runtime behaviour
-> spec-aligned across runtimes. Tracking issue: https://github.com/nodejs/node/issues/62540
-
 The transformer acts on decoded text streams, and should be plugged into a stream pipeline appropriately. e.g.
 
 ```typescript
@@ -215,7 +209,8 @@ const transformer = new AsyncReplaceContentTransformer(
 );
 ```
 
-> [!TIP] For **pipelined** async replacement — where later matches should be discovered and their async work started while earlier replacements are still in flight, without sacrificing in-order output or letting concurrency run away — use [`AsyncLookaheadTransformEngine`](#-pipelined-async-replacement-with-asynclookaheadtransformengine) (see below).
+> [!TIP] 
+> For **pipelined** async replacement — where later matches should be discovered and their async work started while earlier replacements are still in flight, without sacrificing in-order output or letting concurrency run away — use [`AsyncLookaheadTransformEngine`](#-pipelined-async-replacement-with-asynclookaheadtransformengine) (see below).
 
 #### Iterable Replacement
 
@@ -241,8 +236,6 @@ You can return either form:
 - a `Promise<AsyncIterable<string>>` (for example an `async` function returning a stream)
 
 ```typescript
-import { AsyncSerialReplacementTransformEngine } from "replace-content-transformer";
-
 // `<div><esi:include src="https://example.com/foo" /></div>` fills the `<div>` with content fetched from https://example.com/foo
 const transformer = new AsyncReplaceContentTransformer(
   new AsyncSerialReplacementTransformEngine({
@@ -276,7 +269,6 @@ For I/O-bound replacements (fragment fetches, KV lookups, etc.) the `AsyncSerial
 `AsyncLookaheadTransformEngine` scans ahead and **initiates** later matches' replacement work while earlier ones are still in flight, preserving in-order output. A pluggable `ConcurrencyStrategy` controls when and in what order work is dispatched (including explicit unfettered dispatch via `new SemaphoreStrategy(Infinity)`), and replacements can opt in to recursive re-scanning via the `nested()` sentinel.
 
 ```typescript
-import { AsyncReplaceContentTransformer } from "replace-content-transformer/web";
 import {
   AsyncLookaheadTransformEngine,
   SemaphoreStrategy,
@@ -397,55 +389,41 @@ This should ensure in-flight requests are cancelled along with ongoing replaceme
 
 Use the Node adapters (`ReplaceContentTransform`, `AsyncReplaceContentTransform`) for a native [`stream.Transform`](https://nodejs.org/api/stream.html#class-streamtransform) implementation, if performance cost of [`toWeb`](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options) / [`fromWeb`](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options) conversion is a concern.
 
+> **Encoding**: these adapters assume UTF-8 input. Node's default `decodeStrings: true` behaviour re-encodes any string written to the writable side as a UTF-8 `Buffer`; non-UTF-8 byte streams will be mis-decoded silently.
+
 `AsyncReplaceContentTransform` accepts any `AsyncTransformEngine`, including `AsyncLookaheadTransformEngine`. It shares the same engine and options as its web counterpart, so pipelined in-order async replacement, nested `nested()` re-scanning, bounded concurrency, and `highWaterMark` backpressure behave identically across runtimes. The standard `TransformOptions.highWaterMark` controls Node-stream backpressure independently of the engine's own `highWaterMark`.
-
-```typescript
-import { AsyncReplaceContentTransform } from "replace-content-transformer/node";
-import {
-  AsyncLookaheadTransformEngine,
-  SemaphoreStrategy,
-  searchStrategyFactory
-} from "replace-content-transformer";
-
-const transform = new AsyncReplaceContentTransform(
-  new AsyncLookaheadTransformEngine({
-    searchStrategy: searchStrategyFactory(["<esi:include", "/>"]),
-    concurrencyStrategy: new SemaphoreStrategy(8),
-    replacement: async (match) => {
-      const { groups: { url } } = /src="(?<url>[^"]+)"/.exec(match)!;
-      const res = await fetch(url);
-      return res.body!.pipeThrough(new TextDecoderStream());
-    }
-  })
-);
-
-readable.pipe(transform).pipe(writable);
-```
 
 ```typescript
 // streaming esi middleware for express.js, using native NodeJs stream.Transform
 import { responseHandler } from "express-intercept";
 import { AsyncReplaceContentTransform } from "replace-content-transformer/node";
-import { AsyncSerialReplacementTransformEngine, searchStrategyFactory } from "replace-content-transformer";
+import {
+  AsyncLookaheadTransformEngine,
+  SemaphoreStrategy,
+  searchStrategyFactory,
+  nested
+} from "replace-content-transformer";
 import type { Readable } from "node:stream";
 import { get } from "node:https";
 
 const searchStrategy = searchStrategyFactory(["<esi:include", "/>"]);
 const maxDepth = 3;
-function transformFactory(currentDepth: number) {
+function transformFactory() {
   return new AsyncReplaceContentTransform(
-    new AsyncSerialReplacementTransformEngine({
+    new AsyncLookaheadTransformEngine({
       searchStrategy,
-      replacement: async (match: string) => {
+      concurrencyStrategy: new SemaphoreStrategy(8),
+      replacement: async (match, { depth }) => {
         const {
           groups: { url }
         } = /src="(?<url>[^"]+)"/.exec(match)!;
         const nodeStream = await new Promise<Readable>((resolve, reject) => {
-          get(url, (res) => resolve(res)).on("error", reject);
+          get(url, (res) => {
+            res.setEncoding("utf8");
+            resolve(res);
+          }).on("error", reject);
         });
-        return currentDepth < maxDepth
-          ? nodeStream.pipe(transformFactory(currentDepth + 1))
-          : nodeStream;
+        return depth < maxDepth ? nested(nodeStream) : nodeStream;
       }
     })
   );
@@ -454,7 +432,7 @@ const expressMiddleware = responseHandler()
   .if((res) => /html/i.test(res.getHeader("content-type")))
   .interceptStream((upstream: Readable, _, res) => {
     res.removeHeader("content-length");
-    return upstream.pipe(transformFactory(0));
+    return upstream.pipe(transformFactory());
   });
 ```
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ const transformer = new AsyncReplaceContentTransformer(
       } = /src="(?<url>[^"]+)"/.exec(match)!;
       const response = await fetch(url);
       if (response.ok) {
-        return response.body.pipeThrough(new TextDecoderStream());
+        return response.body!.pipeThrough(new TextDecoderStream());
       }
       if (matchIndex === 1) {
         abortController.abort(); // after two replacements, stop replacing
@@ -394,7 +394,7 @@ Use the Node adapters (`ReplaceContentTransform`, `AsyncReplaceContentTransform`
 `AsyncReplaceContentTransform` accepts any `AsyncTransformEngine`, including `AsyncLookaheadTransformEngine`. It shares the same engine and options as its web counterpart, so pipelined in-order async replacement, nested `nested()` re-scanning, bounded concurrency, and `highWaterMark` backpressure behave identically across runtimes. The standard `TransformOptions.highWaterMark` controls Node-stream backpressure independently of the engine's own `highWaterMark`.
 
 ```typescript
-// streaming esi middleware for express.js, using native NodeJs stream.Transform
+// streaming esi middleware for express.js, using native Node.js stream.Transform
 import { responseHandler } from "express-intercept";
 import { AsyncReplaceContentTransform } from "replace-content-transformer/node";
 import {

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.13",
         "@types/deno": "^2.5.0",
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.7.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
         "@vitest/coverage-v8": "^4.1.2",
@@ -297,7 +297,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
@@ -777,7 +777,7 @@
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
 
@@ -835,6 +835,8 @@
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "bun-types/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
     "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -872,6 +874,8 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@babel/register/make-dir/semver": ["semver@5.7.2", "", { "bin": "bin/semver" }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 

--- a/deno.lock
+++ b/deno.lock
@@ -5,10 +5,10 @@
     "npm:@eslint/js@^10.0.1": "10.0.1_eslint@10.3.0",
     "npm:@types/bun@^1.3.13": "1.3.13",
     "npm:@types/deno@^2.5.0": "2.5.0",
-    "npm:@types/node@^25.5.0": "25.6.0",
+    "npm:@types/node@^25.7.0": "25.7.0",
     "npm:@typescript-eslint/eslint-plugin@^8.58.0": "8.59.1_@typescript-eslint+parser@8.59.1__eslint@10.3.0__typescript@6.0.3_eslint@10.3.0_typescript@6.0.3",
     "npm:@typescript-eslint/parser@^8.58.0": "8.59.1_eslint@10.3.0_typescript@6.0.3",
-    "npm:@vitest/coverage-v8@^4.1.2": "4.1.5_vitest@4.1.5_@types+node@25.6.0_msw@2.14.2__typescript@6.0.3__@types+node@25.6.0_tsx@4.21.0_typescript@6.0.3_vite@8.0.10__@types+node@25.6.0__tsx@4.21.0",
+    "npm:@vitest/coverage-v8@^4.1.2": "4.1.5_vitest@4.1.5_@types+node@25.7.0",
     "npm:eslint-plugin-vitest-globals@^1.6.1": "1.6.1",
     "npm:eslint@^10.1.0": "10.3.0",
     "npm:globals@^17.4.0": "17.6.0",
@@ -20,7 +20,7 @@
     "npm:simple-git-hooks@^2.13.1": "2.13.1",
     "npm:tsx@^4.21.0": "4.21.0",
     "npm:typescript@^6.0.2": "6.0.3",
-    "npm:vitest@^4.1.5": "4.1.5_@types+node@25.6.0_@vitest+coverage-v8@4.1.5_vite@8.0.10__@types+node@25.6.0__tsx@4.21.0_msw@2.14.2__typescript@6.0.3__@types+node@25.6.0_tsx@4.21.0_typescript@6.0.3"
+    "npm:vitest@^4.1.5": "4.1.5_@types+node@25.7.0_@vitest+coverage-v8@4.1.5"
   },
   "npm": {
     "@andrewbranch/untar.js@1.0.3": {
@@ -566,7 +566,7 @@
     "@inquirer/ansi@2.0.5": {
       "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="
     },
-    "@inquirer/confirm@6.0.12_@types+node@25.6.0": {
+    "@inquirer/confirm@6.0.12_@types+node@25.7.0": {
       "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
       "dependencies": [
         "@inquirer/core",
@@ -577,7 +577,7 @@
         "@types/node"
       ]
     },
-    "@inquirer/core@11.1.9_@types+node@25.6.0": {
+    "@inquirer/core@11.1.9_@types+node@25.7.0": {
       "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
       "dependencies": [
         "@inquirer/ansi",
@@ -596,7 +596,7 @@
     "@inquirer/figures@2.0.5": {
       "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="
     },
-    "@inquirer/type@4.0.5_@types+node@25.6.0": {
+    "@inquirer/type@4.0.5_@types+node@25.7.0": {
       "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
       "dependencies": [
         "@types/node"
@@ -798,17 +798,14 @@
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
-    "@types/node@25.6.0": {
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+    "@types/node@25.7.0": {
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dependencies": [
         "undici-types"
       ]
     },
     "@types/set-cookie-parser@2.4.10": {
-      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
-      "dependencies": [
-        "@types/node"
-      ]
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="
     },
     "@types/statuses@2.0.6": {
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="
@@ -911,7 +908,7 @@
         "eslint-visitor-keys@5.0.1"
       ]
     },
-    "@vitest/coverage-v8@4.1.5_vitest@4.1.5_@types+node@25.6.0_msw@2.14.2__typescript@6.0.3__@types+node@25.6.0_tsx@4.21.0_typescript@6.0.3_vite@8.0.10__@types+node@25.6.0__tsx@4.21.0": {
+    "@vitest/coverage-v8@4.1.5_vitest@4.1.5_@types+node@25.7.0": {
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dependencies": [
         "@bcoe/v8-coverage",
@@ -938,7 +935,7 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@4.1.5_msw@2.14.2__typescript@6.0.3__@types+node@25.6.0_vite@8.0.10__@types+node@25.6.0__tsx@4.21.0_@types+node@25.6.0_tsx@4.21.0_typescript@6.0.3": {
+    "@vitest/mocker@4.1.5_vite@8.0.10__@types+node@25.7.0__tsx@4.21.0_@types+node@25.7.0": {
       "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dependencies": [
         "@vitest/spy",
@@ -1832,7 +1829,7 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "msw@2.14.2_typescript@6.0.3_@types+node@25.6.0": {
+    "msw@2.14.2_typescript@6.0.3_@types+node@25.7.0": {
       "integrity": "sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg==",
       "dependencies": [
         "@inquirer/confirm",
@@ -2320,8 +2317,8 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "bin": true
     },
-    "undici-types@7.19.2": {
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    "undici-types@7.21.0": {
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="
     },
     "unicode-emoji-modifier-base@1.0.0": {
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="
@@ -2347,7 +2344,7 @@
     "validate-npm-package-name@5.0.1": {
       "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="
     },
-    "vite@8.0.10_@types+node@25.6.0_tsx@4.21.0": {
+    "vite@8.0.10_@types+node@25.7.0_tsx@4.21.0": {
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dependencies": [
         "@types/node",
@@ -2367,7 +2364,7 @@
       ],
       "bin": true
     },
-    "vitest@4.1.5_@types+node@25.6.0_@vitest+coverage-v8@4.1.5_vite@8.0.10__@types+node@25.6.0__tsx@4.21.0_msw@2.14.2__typescript@6.0.3__@types+node@25.6.0_tsx@4.21.0_typescript@6.0.3": {
+    "vitest@4.1.5_@types+node@25.7.0_@vitest+coverage-v8@4.1.5": {
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dependencies": [
         "@types/node",
@@ -2491,7 +2488,7 @@
         "npm:@eslint/js@^10.0.1",
         "npm:@types/bun@^1.3.13",
         "npm:@types/deno@^2.5.0",
-        "npm:@types/node@^25.5.0",
+        "npm:@types/node@^25.7.0",
         "npm:@typescript-eslint/eslint-plugin@^8.58.0",
         "npm:@typescript-eslint/parser@^8.58.0",
         "npm:@vitest/coverage-v8@^4.1.2",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed note regarding lack of `cancel?` in the `TransformStream/transformer` type after resolution of https://github.com/nodejs/node/issues/62540
-  - Explicitly extend `Transformer` from `node:stream/web` in `TransformerBase`, now that it's fully compatible
 - Ensured utf-8 note referenced in public Node adapter jsdocs
 - Ensured `TextDecoderStream` recommendation in jsdoc notes for web adapters
 - Node examples in [main `README.md`](../README.md) consolidated to single example, and added belt & braces integration test using `nested`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed note regarding lack of `cancel?` in the `TransformStream/transformer` type after resolution of https://github.com/nodejs/node/issues/62540
+  - Explicitly extend `Transformer` from `node:stream/web` in `TransformerBase`, now that it's fully compatible
+- Ensured utf-8 note referenced in public Node adapter jsdocs
+- Ensured `TextDecoderStream` recommendation in jsdoc notes for web adapters
+
+### Fixed
+
+- Path in lookahead transformer [`README.md`](../src/engines/async-lookahead-transform-engine/README.md) back to [main `README.md`](../README.md)
+
 ## [2.0.0] - 2026-05-11
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Explicitly extend `Transformer` from `node:stream/web` in `TransformerBase`, now that it's fully compatible
 - Ensured utf-8 note referenced in public Node adapter jsdocs
 - Ensured `TextDecoderStream` recommendation in jsdoc notes for web adapters
+- Node examples in [main `README.md`](../README.md) consolidated to single example
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Explicitly extend `Transformer` from `node:stream/web` in `TransformerBase`, now that it's fully compatible
 - Ensured utf-8 note referenced in public Node adapter jsdocs
 - Ensured `TextDecoderStream` recommendation in jsdoc notes for web adapters
-- Node examples in [main `README.md`](../README.md) consolidated to single example
+- Node examples in [main `README.md`](../README.md) consolidated to single example, and added belt & braces integration test using `nested`
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.13",
         "@types/deno": "^2.5.0",
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.7.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
         "@vitest/coverage-v8": "^4.1.2",
@@ -1893,13 +1893,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5326,9 +5326,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@eslint/js": "^10.0.1",
     "@types/bun": "^1.3.13",
     "@types/deno": "^2.5.0",
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.7.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "@vitest/coverage-v8": "^4.1.2",

--- a/src/adapters/node/async-transform.integration.test.ts
+++ b/src/adapters/node/async-transform.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { Readable } from "node:stream";
 import { text } from "node:stream/consumers";
 import { AsyncReplaceContentTransform } from "./async-transform.js";
-import { AsyncLookaheadTransformEngine, SemaphoreStrategy } from "../../engines/index.js";
+import { AsyncLookaheadTransformEngine, SemaphoreStrategy, nested } from "../../engines/index.js";
 import { StringAnchorSearchStrategy } from "../../search-strategies/index.js";
 
 // Engine behaviour (scan/schedule/drain, nested re-scanning, backpressure,
@@ -73,5 +73,29 @@ describe("AsyncReplaceContentTransform + AsyncLookaheadTransformEngine (Node ada
     );
     expect(transform.writableHighWaterMark).toBe(7);
     expect(transform.readableHighWaterMark).toBe(7);
+  });
+
+  it("recursively re-scans nested() content fed through a Node Readable", async () => {
+    const fragments: Record<string, string> = {
+      outer: "<o>{{inner}}</o>",
+      inner: "<i>{{leaf}}</i>",
+      leaf: "leaf!"
+    };
+
+    const transform = new AsyncReplaceContentTransform(
+      new AsyncLookaheadTransformEngine({
+        searchStrategy: new StringAnchorSearchStrategy(["{{", "}}"]),
+        concurrencyStrategy: new SemaphoreStrategy(4),
+        replacement: async (match, { depth }) => {
+          const key = match.slice(2, -2);
+          const content = fragments[key] ?? "";
+          const source = Readable.from([content]);
+          return depth < 2 ? nested(source) : source;
+        }
+      })
+    );
+
+    const out = await text(sourceOf("{{outer}}").pipe(transform));
+    expect(out).toBe("<o><i>leaf!</i></o>");
   });
 });

--- a/src/adapters/node/async-transform.ts
+++ b/src/adapters/node/async-transform.ts
@@ -24,6 +24,9 @@ import type { AsyncTransformEngine } from "../../engines/types.js";
  * readableStream.pipe(transform).pipe(writableStream);
  * ```
  *
+ * @remarks **Encoding**: all text is processed as UTF-8. See {@link TransformBase}
+ * for details.
+ *
  * @example Lookahead replacement
  * ```typescript
  * const transform = new AsyncReplaceContentTransform(

--- a/src/adapters/node/sync-transform.ts
+++ b/src/adapters/node/sync-transform.ts
@@ -19,6 +19,9 @@ import type { SyncTransformEngine } from "../../engines/types.js";
  *
  * readableStream.pipe(transform).pipe(writableStream);
  * ```
+ *
+ * @remarks **Encoding**: all text is processed as UTF-8. See {@link TransformBase}
+ * for details.
  */
 export class ReplaceContentTransform extends TransformBase<void> {
   readonly #engine: SyncTransformEngine;

--- a/src/adapters/web/async-transformer.ts
+++ b/src/adapters/web/async-transformer.ts
@@ -10,6 +10,8 @@ import { TransformerBase } from "./transformer-base.js";
  * or {@link AsyncLookaheadTransformEngine} for concurrent pipelined replacements
  * with pluggable concurrency control.
  *
+ * @remarks **Encoding**: see {@link TransformerBase}.
+ *
  * @example Serial async replacement
  * ```typescript
  * const transformer = new AsyncReplaceContentTransformer(

--- a/src/adapters/web/sync-transformer.ts
+++ b/src/adapters/web/sync-transformer.ts
@@ -21,6 +21,8 @@ import { TransformerBase } from "./transformer-base.js";
  * );
  * const stream = new TransformStream(transformer);
  * ```
+ *
+ * @remarks **Encoding**: see {@link TransformerBase}.
  */
 export class ReplaceContentTransformer extends TransformerBase<
   void,

--- a/src/adapters/web/transformer-base.ts
+++ b/src/adapters/web/transformer-base.ts
@@ -9,7 +9,7 @@ import type { TransformEngine } from "../../engines/types.js";
  * pipe it through {@link TextDecoderStream} before wrapping with
  * {@link TransformStream}:
  * ```typescript
- * response.body
+ * response.body!
  *   .pipeThrough(new TextDecoderStream())
  *   .pipeThrough(new TransformStream(transformer));
  * ```

--- a/src/adapters/web/transformer-base.ts
+++ b/src/adapters/web/transformer-base.ts
@@ -1,5 +1,4 @@
 import type { TransformEngine } from "../../engines/types.js";
-import type { Transformer } from "node:stream/web";
 
 /**
  * Base class for the WHATWG Streams `Transformer` adapters in this package.

--- a/src/adapters/web/transformer-base.ts
+++ b/src/adapters/web/transformer-base.ts
@@ -1,6 +1,24 @@
 import type { TransformEngine } from "../../engines/types.js";
+import type { Transformer } from "node:stream/web";
 
-export abstract class TransformerBase<T, U extends TransformEngine<T>> {
+/**
+ * Base class for the WHATWG Streams `Transformer` adapters in this package.
+ *
+ * **Encoding**: this transformer operates on the decoded strings supplied
+ * by the {@link https://streams.spec.whatwg.org/ WHATWG Streams} infrastructure.
+ * If the source is a binary `ReadableStream<Uint8Array>` (e.g. `Response.body`),
+ * pipe it through {@link TextDecoderStream} before wrapping with
+ * {@link TransformStream}:
+ * ```typescript
+ * response.body
+ *   .pipeThrough(new TextDecoderStream())
+ *   .pipeThrough(new TransformStream(transformer));
+ * ```
+ */
+export abstract class TransformerBase<
+  T extends void | PromiseLike<void>,
+  U extends TransformEngine<T>
+> implements Transformer<string, string> {
   protected readonly _engine: U;
 
   constructor(engine: U) {

--- a/src/engines/async-lookahead-transform-engine/README.md
+++ b/src/engines/async-lookahead-transform-engine/README.md
@@ -49,7 +49,7 @@ const transformer = new AsyncReplaceContentTransformer(
 );
 ```
 
-See the [full usage examples](../../README.md#-pipelined-async-replacement-with-asynclookaheadtransformengine) in the main README.
+See the [full usage examples](../../../README.md#-pipelined-async-replacement-with-asynclookaheadtransformengine) in the main README.
 
 > [!IMPORTANT]
 > When a child engine errors, any chunks it had already enqueued into its internal buffer are yielded to the outer drain loop before the error is thrown. The outer stream may therefore emit partial output before the rejection surfaces — this is intentional, preserving the "emit what you have" semantics consistent with the rest of the drain loop.


### PR DESCRIPTION
## Details

- https://github.com/nodejs/node/issues/62540 is now resolved, adding [cancel: TransformerCancelCallback](https://streams.spec.whatwg.org/#transformer-api) to `@types/node` for the `TransformStream` `transformer` interface, so the type from `WebWorker` lib can be used directly, and the note in the README about not aligning to public types can be removed

## Scout rule

- Consolidated `Node` adapter example to one based on the lookahead transformer
- Ensured utf-8 note referenced in public Node adapter jsdocs
- Ensured `TextDecoderStream` recommendation in jsdoc notes for web adapters
- Fixed path in lookahead transformer `README.md` back to main `README.md`

## Semantic Version Impact

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
