### PR TITLE
[31] Balanced Search Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,23 @@ const transformer = new ReplaceContentTransformer(
 > [!CAUTION]
 > The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src/search-strategies/regex/README.md#limitations).
 
+#### Replacing Balanced Pairs (with Nesting Support)
+
+Match and replace delimiter pairs that may be nested, using `BalancedPairSearchStrategy`. The match only completes when the outermost pair is fully balanced:
+
+```typescript
+import { BalancedPairSearchStrategy } from "replace-content-transformer";
+
+// "(a (b) c)" becomes "[a (b) c]"
+// "(d)" becomes "[d]"
+const transformer = new ReplaceContentTransformer(
+  new SyncReplacementTransformEngine({
+    searchStrategy: new BalancedPairSearchStrategy("(", ")"),
+    replacement: (match: string) => `[${match.slice(1, -1)}]`
+  })
+);
+```
+
 #### Async Replacement
 
 Replace with asynchronous content. Ensures each async replacement completes before the next starts.
@@ -389,6 +406,7 @@ This should ensure in-flight requests are cancelled along with ongoing replaceme
 
 Use the Node adapters (`ReplaceContentTransform`, `AsyncReplaceContentTransform`) for a native [`stream.Transform`](https://nodejs.org/api/stream.html#class-streamtransform) implementation, if performance cost of [`toWeb`](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options) / [`fromWeb`](https://nodejs.org/api/stream.html#streamreadabletowebstreamreadable-options) conversion is a concern.
 
+> [!CAUTION]
 > **Encoding**: these adapters assume UTF-8 input. Node's default `decodeStrings: true` behaviour re-encodes any string written to the writable side as a UTF-8 `Buffer`; non-UTF-8 byte streams will be mis-decoded silently.
 
 `AsyncReplaceContentTransform` accepts any `AsyncTransformEngine`, including `AsyncLookaheadTransformEngine`. It shares the same engine and options as its web counterpart, so pipelined in-order async replacement, nested `nested()` re-scanning, bounded concurrency, and `highWaterMark` backpressure behave identically across runtimes. The standard `TransformOptions.highWaterMark` controls Node-stream backpressure independently of the engine's own `highWaterMark`.
@@ -476,6 +494,7 @@ The `flush` is called by the engine to extract anything buffered from the search
 Each strategy contains the pattern-matching logic for a specific use case:
 
 - **[`StringAnchorSearchStrategy`](./src/search-strategies/looped-indexOf-anchored/README.md)** - finds either single tokens, or "anchor" tokens delimiting start/end (or in sequence in-between) of a match
+- **[`BalancedPairSearchStrategy`](./src/search-strategies/balanced-pair/README.md)** - Matches balanced delimiter pairs, correctly handling arbitrary nesting depth (e.g. `(outer (inner) rest)`)
 - **[`RegexSearchStrategy`](./src/search-strategies/regex/README.md)** - Matches against regular expressions (with some caveats)
 
 See [search strategies](./src/search-strategies/README.md) for detail of functionality, and development of the strategies.
@@ -509,6 +528,9 @@ const searchStrategy = new StringAnchorSearchStrategy(["{{", "}}"]); // 2+ "anch
 import { RegexSearchStrategy } from "replace-content-transformer";
 const searchStrategy = new RegexSearchStrategy(/<div>.+?<\/div>/s); // regular expression for complete match
 ```
+
+>[!IMPORTANT]
+>The `BalancedPairSearchStrategy` is not returned by this factory, since it cannot be determined from input, so import this directly, as described above 
 
 ### 🦾 Engines
 
@@ -673,3 +695,4 @@ Please feel free to raise an [Issue](https://github.com/TomStrepsil/replace-cont
 - [stream-replace-string](https://github.com/ChocolateLoverRaj/stream-replace-string) - A Node stream transform (abandoned)
 - [replacestream](https://github.com/eugeneware/replacestream) - a Node stream transform, supporting regex matching (last update 2016)
 - [string-searching](https://github.com/string-searching) - various string searching algorithms in javascript
+- [balanced-match](https://github.com/juliangruber/balanced-match/) - balanced string matching

--- a/README.md
+++ b/README.md
@@ -529,8 +529,8 @@ import { RegexSearchStrategy } from "replace-content-transformer";
 const searchStrategy = new RegexSearchStrategy(/<div>.+?<\/div>/s); // regular expression for complete match
 ```
 
->[!IMPORTANT]
->The `BalancedPairSearchStrategy` is not returned by this factory, since it cannot be determined from input, so import this directly, as described above 
+> [!IMPORTANT]
+> The `BalancedPairSearchStrategy` is not returned by this factory, since it cannot be determined from input, so import this directly, as described above.
 
 ### 🦾 Engines
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ const transformer = new ReplaceContentTransformer(
 > [!CAUTION]
 > The `regex` search strategy is marginally less performant than static string anchors, and does not support all regular expression features. See [limitations](./src/search-strategies/regex/README.md#limitations).
 
-#### Replacing Balanced Pairs (with Nesting Support)
+#### Replacing Balanced Pairs (respecting nesting)
 
 Match and replace delimiter pairs that may be nested, using `BalancedPairSearchStrategy`. The match only completes when the outermost pair is fully balanced:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Path in lookahead transformer [`README.md`](../src/engines/async-lookahead-transform-engine/README.md) back to [main `README.md`](../README.md)
-- Added `[!CAUTION]` to `README.md` re: `utf8`
+- Added `[!CAUTION]` to `README.md` re: `UTF-8`
 
 ## [2.0.0] - 2026-05-11
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Path in lookahead transformer [`README.md`](../src/engines/async-lookahead-transform-engine/README.md) back to [main `README.md`](../README.md)
+- Added `[!CAUTION]` to `README.md` re: `utf8`
 
 ## [2.0.0] - 2026-05-11
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `BalancedPairSearchStrategy` for matching two string anchors, but respecting nesting levels so only matching where "balanced"
+
 ### Changed
 
 - Removed note regarding lack of `cancel?` in the `TransformStream/transformer` type after resolution of https://github.com/nodejs/node/issues/62540

--- a/src/search-strategies/README.md
+++ b/src/search-strategies/README.md
@@ -17,7 +17,7 @@ Single or Multiple-token sequential matching using smart buffering (only when th
 
 ## ⚖️ Balanced Pair (Nesting-Aware Matching)
 
-**[balanced-pair](./balanced-pair/README.md)** - Exported as `BalancedPairSearchStrategy`
+**[balanced-pair](./balanced-pair/README.md)** - Nesting-aware delimiter matching strategy implementation
 
 Matches opening/closing delimiter pairs where nesting is meaningful: the match only completes once every inner opening has a corresponding closing. Built on top of `StringAnchorSearchStrategy`, adding a nesting-level counter that keeps the match open until the outermost pair is balanced.
 

--- a/src/search-strategies/README.md
+++ b/src/search-strategies/README.md
@@ -15,6 +15,17 @@ Single or Multiple-token sequential matching using smart buffering (only when th
 - **Use Case**: Single or Sequential multi-delimiter patterns in streaming content
 - **Exported As**: `StringAnchorSearchStrategy`
 
+## ⚖️ Balanced Pair (Nesting-Aware Matching)
+
+**[balanced-pair](./balanced-pair/README.md)** - Exported as `BalancedPairSearchStrategy`
+
+Matches opening/closing delimiter pairs where nesting is meaningful: the match only completes once every inner opening has a corresponding closing. Built on top of `StringAnchorSearchStrategy`, adding a nesting-level counter that keeps the match open until the outermost pair is balanced.
+
+- **Algorithm**: Nesting-level tracking over sequential anchor matching
+- **Performance**: O(n+m) for scanning + O(k) per match increment to count inner openings (k = length of new match content)
+- **Use Case**: Balanced/nested structures — parentheses, braces, custom multi-character delimiters
+- **Exported As**: `BalancedPairSearchStrategy`
+
 ## 🧠 Regex
 
 **[regex](./regex/README.md)** - Pattern matching using regular expressions

--- a/src/search-strategies/balanced-pair/README.md
+++ b/src/search-strategies/balanced-pair/README.md
@@ -1,0 +1,238 @@
+# Balanced Pair Search Strategy
+
+A search strategy for matching **balanced delimiter pairs** — including nested occurrences — by layering nesting-level tracking on top of the [`StringAnchorSearchStrategy`](../looped-indexOf-anchored/README.md).
+
+## Algorithm Overview
+
+This strategy finds opening/closing delimiter pairs where nesting is meaningful: the match only completes when every opening delimiter inside it has a corresponding closing delimiter. For example:
+
+- `(`, `)` matches `(content)`, `((a) b)`, `(((deep)))`
+- `{{`, `}}` matches `{{value}}`, `{{{{nested}}}}`
+- `[`, `]` matches `[outer [inner] rest]`
+
+A simple anchor search would match the _first_ closing delimiter after the opening, producing incomplete matches in nested input. `BalancedPairSearchStrategy` extends that underlying search so every inner pair is counted and the match only closes when the depth returns to zero.
+
+### Nesting Detection
+
+```
+Opening: "("   Closing: ")"
+Input:   "((inner) outer)"
+
+ Position:  0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
+ Char:      ( ( i n n e r )   o  u  t  e  r  )
+            ↑             ↑                  ↑
+     match starts       first )          outer )
+     nestingLevel=0     found             found
+
+ On first ) at position 7:
+   nestingLevel-- → -1
+   Count "(" in "((inner)": two openings → nestingLevel = -1 + 2 = 1
+   Not yet balanced (nestingLevel > 0) — keep looking for more ")"
+
+ On outer ) at position 14:
+   nestingLevel-- → 0
+   Count "(" in " outer)": zero openings → nestingLevel = 0
+   Balanced! Yield "((inner) outer)" as a match
+```
+
+**Without nesting awareness:**
+
+```
+Anchor strategy alone:
+  Input:  "((inner) outer)"
+  Match:  "((inner)"    ← stops at first ), incomplete!
+```
+
+## Implementation Details
+
+`BalancedPairSearchStrategy` wraps `LoopedIndexOfAnchoredSearchStrategy` and post-processes each match it yields:
+
+```typescript
+class BalancedPairSearchStrategy implements SearchStrategy<
+  BalancedPairSearchState,
+  string
+> {
+  private anchorStringSearchStrategy: LoopedIndexOfAnchoredSearchStrategy;
+
+  constructor(opening: string, closing: string) {
+    this.anchorStringSearchStrategy = new LoopedIndexOfAnchoredSearchStrategy([
+      opening,
+      closing
+    ]);
+  }
+}
+```
+
+When the underlying anchor strategy yields a match (opening–closing pair found), the balanced pair strategy:
+
+1. Counts any additional opening delimiters within the new match content
+2. Adjusts `nestingLevel` accordingly
+3. If `nestingLevel > 0`, resets `currentNeedleIndex = 1` on the shared state so the anchor strategy resumes scanning for the next closing delimiter — without discarding already-accumulated match content
+4. Accumulates content in `balancedBuffer` until `nestingLevel` returns to zero, then yields the whole span as a single match
+
+### Incremental Content Tracking
+
+The underlying anchor strategy's match content grows cumulatively (from the first opening needle to each subsequent closing needle). The balanced pair strategy slices only the _new_ portion of each yielded match to count openings in it:
+
+```typescript
+const newContent = matchResult.content.slice(prevMatchLength);
+prevMatchLength = matchResult.content.length;
+// ...
+state.nestingLevel--;
+let cursor = 0;
+while ((cursor = newContent.indexOf(this.opening, cursor)) !== -1) {
+  state.nestingLevel++;
+  cursor += this.opening.length;
+}
+```
+
+This ensures each opening is counted exactly once, regardless of how many intermediate closing delimiters were found.
+
+### Inner Buffer Adjustment
+
+When `nestingLevel > 0` and the underlying strategy's buffer still holds in-flight content, the balanced pair strategy trims the anchor strategy's buffer to exclude content already accounted for in `balancedBuffer`:
+
+```typescript
+if (state.nestingLevel > 0) {
+  state.buffer = state.buffer.slice(state.balancedBuffer.length);
+}
+```
+
+This prevents double-counting when the anchor strategy's cross-chunk buffer is combined with the next chunk.
+
+## State Management
+
+`BalancedPairSearchState` extends `LoopedIndexOfAnchoredSearchState`:
+
+```typescript
+interface BalancedPairSearchState extends LoopedIndexOfAnchoredSearchState {
+  /** How many unmatched opening delimiters have been seen inside the current match */
+  nestingLevel: number;
+  /** Accumulated content of the outermost balanced match in progress */
+  balancedBuffer: string;
+  /** Absolute stream offset at which the outermost opening delimiter was found */
+  balancedBufferStart: number;
+}
+```
+
+**State transitions:**
+
+| Condition                         | `nestingLevel`        | `balancedBuffer`           | Action                              |
+| --------------------------------- | --------------------- | -------------------------- | ----------------------------------- |
+| No match found                    | unchanged (0)         | `""`                       | Pass through as non-match           |
+| Opening found, no inner opens     | `0` (after `--` + 0)  | accumulated → cleared      | Yield as complete match             |
+| Opening found, inner opens exist  | `> 0`                 | accumulating               | Set `currentNeedleIndex = 1`, continue |
+| Subsequent close balances depth   | decrements toward `0` | accumulating               | Continue or yield when reaching `0` |
+| Flush mid-match                   | reset to `0`          | cleared (returned as-is)   | Return buffered content unflushed   |
+
+**Flush behaviour:**
+
+If a stream ends while a balanced match is in progress (e.g. `((inner)` with no outer `)`), `flush` returns all accumulated content in `balancedBuffer` plus any remaining content in the anchor strategy's buffer:
+
+```typescript
+flush(state: BalancedPairSearchState): string {
+  const flushed = state.balancedBuffer;
+  state.balancedBuffer = "";
+  state.balancedBufferStart = 0;
+  state.nestingLevel = 0;
+  return flushed + this.anchorStringSearchStrategy.flush(state);
+}
+```
+
+## Cross-Chunk Matching
+
+The strategy correctly handles matches that span chunk boundaries at every level:
+
+```
+Opening: "("   Closing: ")"
+Chunk 1: "((inner)"
+Chunk 2: " outer)"
+
+Process Chunk 1:
+  - Anchor strategy finds "((inner)" as match
+  - nestingLevel: 0 − 1 + 2 = 1 (two "(" inside, one ")" closes)
+  - currentNeedleIndex reset to 1 — continue scanning for ")"
+  - balancedBuffer: "((inner)"
+
+Process Chunk 2:
+  - Anchor strategy finds " outer)" as the continuation
+  - nestingLevel: 1 − 1 = 0 (no new "(" in " outer)")
+  - Balanced! Yield "((inner) outer)", streamIndices: [0, 15]
+```
+
+## Stream Indices
+
+Matches report `streamIndices` as absolute offsets into the full stream, not relative to the current chunk:
+
+```
+Stream:       "prefix ((inner) outer) suffix"
+               0      7       15      22
+
+Match yields: { isMatch: true, content: "((inner) outer)", streamIndices: [7, 22] }
+```
+
+`streamIndices[0]` is the start of the outermost opening delimiter; `streamIndices[1]` is the end of the outermost closing delimiter (exclusive, following the same convention as [`String.prototype.slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice)).
+
+## Performance Characteristics
+
+`BalancedPairSearchStrategy` inherits the smart partial-match buffering of `LoopedIndexOfAnchoredSearchStrategy`. The nesting layer adds a linear scan of each new match increment to count opening delimiters, which is proportional to match content size rather than stream size.
+
+| Scenario                         | Characteristic                                                      |
+| -------------------------------- | ------------------------------------------------------------------- |
+| No matches in stream             | Same cost as anchor strategy — near-zero buffering overhead         |
+| Flat (non-nested) matches        | Minimal overhead over anchor strategy — one scan per match          |
+| Deeply nested matches            | Proportional to depth × average inner-match size                    |
+| Partial matches at boundaries    | Inherits smart buffering — only buffers on genuine partial matches  |
+
+## Usage Examples
+
+### Single-Character Delimiters
+
+```typescript
+import { BalancedPairSearchStrategy } from "replace-content-transformer";
+
+const strategy = new BalancedPairSearchStrategy("(", ")");
+```
+
+### Multi-Character Delimiters
+
+```typescript
+// Matches {{value}}, {{{{doubly nested}}}}, etc.
+const strategy = new BalancedPairSearchStrategy("{{", "}}");
+```
+
+### With an Engine
+
+```typescript
+import {
+  BalancedPairSearchStrategy,
+  SyncReplacementTransformEngine
+} from "replace-content-transformer";
+import { ReplaceContentTransformer } from "replace-content-transformer/web";
+
+// Replace every top-level balanced `(...)` expression, including nested ones
+const transformer = new ReplaceContentTransformer(
+  new SyncReplacementTransformEngine({
+    searchStrategy: new BalancedPairSearchStrategy("(", ")"),
+    replacement: (match: string) => `[${match.slice(1, -1)}]`
+  })
+);
+```
+
+### Detecting Nesting Depth
+
+Since the full matched content is available in the replacement function, nesting depth can be calculated from the match itself:
+
+```typescript
+const strategy = new BalancedPairSearchStrategy("(", ")");
+
+const transformer = new ReplaceContentTransformer(
+  new SyncReplacementTransformEngine({
+    searchStrategy: strategy,
+    replacement: (match: string) => {
+      const depth = (match.match(/\(/g) ?? []).length;
+      return `/* depth ${depth} */${match}`;
+    }
+  })
+);
+```

--- a/src/search-strategies/balanced-pair/index.ts
+++ b/src/search-strategies/balanced-pair/index.ts
@@ -1,0 +1,1 @@
+export { BalancedPairSearchStrategy } from "./search-strategy.js";

--- a/src/search-strategies/balanced-pair/search-strategy.test.ts
+++ b/src/search-strategies/balanced-pair/search-strategy.test.ts
@@ -1,0 +1,345 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { describe, it, expect } from "vitest";
+import { BalancedPairSearchStrategy } from "./search-strategy.js";
+
+describe("BalancedPairSearchStrategy", () => {
+  describe("simple (non-nested) matches", () => {
+    it("yields a simple balanced match", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("(content)", state)];
+      const flushed = strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "(content)", streamIndices: [0, 9] }
+      ]);
+      expect(flushed).toBe("");
+    });
+
+    it("yields non-match content before and after a simple match", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("before (content) after", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: false, content: "before " },
+        { isMatch: true, content: "(content)", streamIndices: [7, 16] },
+        { isMatch: false, content: " after" }
+      ]);
+    });
+
+    it("yields multiple adjacent simple matches", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("(a)(b)(c)", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "(a)", streamIndices: [0, 3] },
+        { isMatch: true, content: "(b)", streamIndices: [3, 6] },
+        { isMatch: true, content: "(c)", streamIndices: [6, 9] }
+      ]);
+    });
+
+    it("yields no matches when content has none", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("no matches here", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: false, content: "no matches here" }
+      ]);
+    });
+  });
+
+  describe("nested matches", () => {
+    it("matches one level of nesting", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("((inner) outer)", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "((inner) outer)", streamIndices: [0, 15] }
+      ]);
+    });
+
+    it("matches two levels of nesting", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("(((deep)))", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "(((deep)))", streamIndices: [0, 10] }
+      ]);
+    });
+
+    it("matches content where multiple opens appear before first close", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      // ((a) (b)) — each inner pair is balanced (net 0 per increment), only the
+      // surplus opening at position 0 drives nestingLevel to 1 until the final )
+      const results = [...strategy.processChunk("((a) (b))", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "((a) (b))", streamIndices: [0, 9] }
+      ]);
+    });
+
+    it("handles multiple balanced inner pairs before the outer close", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      // Each increment " (b)" and " (c)" contributes net 0 (1 open, 1 close),
+      // so only the extra ( at position 0 keeps nestingLevel at 1 until the final )
+      const results = [...strategy.processChunk("((a) (b) (c))", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "((a) (b) (c))", streamIndices: [0, 13] }
+      ]);
+    });
+
+    it("yields non-match content surrounding a nested match", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix ((inner) outer) suffix", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: false, content: "prefix " },
+        { isMatch: true, content: "((inner) outer)", streamIndices: [7, 22] },
+        { isMatch: false, content: " suffix" }
+      ]);
+    });
+
+    it("yields a nested match followed by a simple match", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("((a) b)(c)", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "((a) b)", streamIndices: [0, 7] },
+        { isMatch: true, content: "(c)", streamIndices: [7, 10] }
+      ]);
+    });
+
+    it("works with multi-character opening and closing anchors", () => {
+      const strategy = new BalancedPairSearchStrategy("{{", "}}");
+      const state = strategy.createState();
+
+      // {{{{inner}}}} — two opening {{ before first closing }}
+      const results = [...strategy.processChunk("{{{{inner}}}}", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "{{{{inner}}}}", streamIndices: [0, 13] }
+      ]);
+    });
+
+    it("resets balancedBuffer after yielding a match so subsequent matches start fresh", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      // First match: nested, accumulates into balancedBuffer during processing
+      const results1 = [...strategy.processChunk("((a) b)", state)];
+      expect(results1).toEqual([
+        { isMatch: true, content: "((a) b)", streamIndices: [0, 7] }
+      ]);
+      // balancedBuffer must be cleared so the next match accumulates independently
+      expect(state.balancedBuffer).toBe("");
+
+      // Second match must accumulate independently with the correct stream indices
+      const results2 = [...strategy.processChunk("((c) d)", state)];
+      expect(results2).toEqual([
+        { isMatch: true, content: "((c) d)", streamIndices: [7, 14] }
+      ]);
+      strategy.flush(state);
+    });
+  });
+
+  describe("cross-chunk processing", () => {
+    it("matches a simple match split across chunks", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [
+        ...strategy.processChunk("(cont", state),
+        ...strategy.processChunk("ent)", state)
+      ];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "(content)", streamIndices: [0, 9] }
+      ]);
+    });
+
+    it("matches a nested match when the outer closing is in the next chunk", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [
+        ...strategy.processChunk("((inner)", state),
+        ...strategy.processChunk(" outer)", state)
+      ];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "((inner) outer)", streamIndices: [0, 15] }
+      ]);
+    });
+
+    it("matches a deeply nested match split across multiple chunks", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [
+        ...strategy.processChunk("(((deep))", state),
+        ...strategy.processChunk(")", state)
+      ];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "(((deep)))", streamIndices: [0, 10] }
+      ]);
+    });
+
+    it("yields correct content across chunks without duplicating the buffered portion", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+      const results = [
+        ...strategy.processChunk("((inner)", state),
+        ...strategy.processChunk(" outer)", state)
+      ];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "((inner) outer)", streamIndices: [0, 15] }
+      ]);
+    });
+
+    it("preserves non-match tail content from a chunk that ended mid-nesting", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      // Chunk 1 ends with " more" after the inner `)`, while still open at nesting level 1.
+      // That tail must survive into chunk 2, not be discarded.
+      const results = [
+        ...strategy.processChunk("((a) more", state),
+        ...strategy.processChunk(" content)", state)
+      ];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "((a) more content)", streamIndices: [0, 18] }
+      ]);
+    });
+
+    it("tracks stream offset correctly when non-match precedes a nested match in separate chunks", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [
+        ...strategy.processChunk("no match", state),
+        ...strategy.processChunk("((inner) outer)", state)
+      ];
+      strategy.flush(state);
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({ streamIndices: [8, 23] });
+    });
+
+    it("returns buffered content when flushed mid-nested-match", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      [...strategy.processChunk("((inner)", state)];
+      const flushed = strategy.flush(state);
+
+      expect(flushed).toBe("((inner)");
+    });
+
+    it("resets state after flush so the strategy can be reused", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      [...strategy.processChunk("((inner)", state)];
+      strategy.flush(state);
+
+      expect(state.nestingLevel).toBe(0);
+      expect(state.balancedBuffer).toBe("");
+
+      // After flush, the state is reset: a fresh simple match should yield correctly
+      const results = [...strategy.processChunk("(fresh)", state)];
+      strategy.flush(state);
+
+      expect(results).toEqual([
+        { isMatch: true, content: "(fresh)", streamIndices: [0, 7] }
+      ]);
+    });
+  });
+
+  describe("stream offset tracking", () => {
+    it("reports correct indices for a match following non-match content", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("prefix (match)", state)];
+      strategy.flush(state);
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({ streamIndices: [7, 14] });
+    });
+
+    it("reports correct indices for a nested match", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("text ((a) b) end", state)];
+      strategy.flush(state);
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({ streamIndices: [5, 12] });
+    });
+
+    it("tracks correct indices for a nested match across chunks", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [
+        ...strategy.processChunk("prefix ", state),
+        ...strategy.processChunk("((inner) outer)", state)
+      ];
+      strategy.flush(state);
+
+      const match = results.find((r) => r.isMatch);
+      expect(match).toMatchObject({ streamIndices: [7, 22] });
+    });
+  });
+
+  describe("matchToString", () => {
+    it("returns the matched content unchanged", () => {
+      const strategy = new BalancedPairSearchStrategy("(", ")");
+      const state = strategy.createState();
+
+      const results = [...strategy.processChunk("(content)", state)];
+      const match = results.find((r) => r.isMatch)!;
+
+      expect(strategy.matchToString(match.content)).toBe("(content)");
+    });
+  });
+});

--- a/src/search-strategies/balanced-pair/search-strategy.ts
+++ b/src/search-strategies/balanced-pair/search-strategy.ts
@@ -1,0 +1,97 @@
+import {
+  LoopedIndexOfAnchoredSearchState,
+  LoopedIndexOfAnchoredSearchStrategy
+} from "../looped-indexOf-anchored/search-strategy";
+import type { MatchResult, SearchStrategy } from "../types";
+
+export interface BalancedPairSearchState extends LoopedIndexOfAnchoredSearchState {
+  nestingLevel: number;
+  balancedBuffer: string;
+  balancedBufferStart: number;
+}
+
+export class BalancedPairSearchStrategy implements SearchStrategy<
+  BalancedPairSearchState,
+  string
+> {
+  private anchorStringSearchStrategy: LoopedIndexOfAnchoredSearchStrategy;
+  private readonly opening: string;
+
+  constructor(opening: string, closing: string) {
+    this.opening = opening;
+    this.anchorStringSearchStrategy = new LoopedIndexOfAnchoredSearchStrategy([
+      opening,
+      closing
+    ]);
+  }
+
+  createState(): BalancedPairSearchState {
+    return {
+      ...this.anchorStringSearchStrategy.createState(),
+      nestingLevel: 0,
+      balancedBuffer: "",
+      balancedBufferStart: 0
+    };
+  }
+
+  *processChunk(
+    haystack: string,
+    state: BalancedPairSearchState
+  ): Generator<MatchResult, void, undefined> {
+    let prevMatchLength = 0;
+    for (const matchResult of this.anchorStringSearchStrategy.processChunk(
+      haystack,
+      state
+    )) {
+      if (!matchResult.isMatch) {
+        yield matchResult;
+        continue;
+      }
+      const newContent = matchResult.content.slice(prevMatchLength);
+      prevMatchLength = matchResult.content.length;
+
+      if (state.balancedBuffer === "") {
+        state.balancedBufferStart = matchResult.streamIndices[0];
+      }
+      state.balancedBuffer += newContent;
+      state.nestingLevel--;
+      let cursor = 0;
+      while ((cursor = newContent.indexOf(this.opening, cursor)) !== -1) {
+        state.nestingLevel++;
+        cursor += this.opening.length;
+      }
+
+      if (state.nestingLevel > 0) {
+        state.currentNeedleIndex = 1;
+      } else {
+        state.nestingLevel = 0;
+        const content = state.balancedBuffer;
+        state.balancedBuffer = "";
+        prevMatchLength = 0;
+        yield {
+          isMatch: true,
+          content,
+          streamIndices: [
+            state.balancedBufferStart,
+            matchResult.streamIndices[1]
+          ]
+        };
+      }
+    }
+    if (state.nestingLevel > 0) {
+      state.buffer = state.buffer.slice(state.balancedBuffer.length);
+    }
+  }
+
+  flush(state: BalancedPairSearchState): string {
+    const flushed = state.balancedBuffer;
+    state.balancedBuffer = "";
+    state.balancedBufferStart = 0;
+    state.nestingLevel = 0;
+    return flushed + this.anchorStringSearchStrategy.flush(state);
+  }
+
+  matchToString(match: string): string {
+    return match;
+  }
+}

--- a/src/search-strategies/balanced-pair/search-strategy.ts
+++ b/src/search-strategies/balanced-pair/search-strategy.ts
@@ -1,8 +1,8 @@
 import {
   LoopedIndexOfAnchoredSearchState,
   LoopedIndexOfAnchoredSearchStrategy
-} from "../looped-indexOf-anchored/search-strategy";
-import type { MatchResult, SearchStrategy } from "../types";
+} from "../looped-indexOf-anchored/search-strategy.js";
+import type { MatchResult, SearchStrategy } from "../types.js";
 
 export interface BalancedPairSearchState extends LoopedIndexOfAnchoredSearchState {
   nestingLevel: number;

--- a/src/search-strategies/benchmarking/balanced-pair-regex-count/README.md
+++ b/src/search-strategies/benchmarking/balanced-pair-regex-count/README.md
@@ -1,0 +1,95 @@
+# Balanced Pair (Regex Count) Search Strategy
+
+A benchmarking variant of [`BalancedPairSearchStrategy`](../../balanced-pair/README.md) that replaces the `while`/`indexOf` loop used to count opening delimiters with a pre-compiled `RegExp` and `String.match()`.
+
+## Purpose
+
+This strategy exists as a **benchmarking proof-of-concept** to answer the question: _is a pre-compiled regex faster than a `while`/`indexOf` loop for counting opening delimiter occurrences within matched content?_
+
+The hypothesis is that:
+
+1. The `RegExp` object is compiled once at construction, amortising that cost across all matches
+2. `String.match()` delegates to native regex engine internals, potentially using SIMD-optimised string scanning
+
+**The answer is no** — see [Benchmark Findings](#benchmark-findings) below.
+
+## What Changes
+
+The only difference from `BalancedPairSearchStrategy` is the opening delimiter counter. The public strategy uses a `while`/`indexOf` loop with a cursor:
+
+```typescript
+// BalancedPairSearchStrategy (public)
+let cursor = 0;
+while ((cursor = newContent.indexOf(this.opening, cursor)) !== -1) {
+  state.nestingLevel++;
+  cursor += this.opening.length;
+}
+```
+
+This variant pre-compiles the opening delimiter into a `RegExp` at construction and counts with `match()`:
+
+```typescript
+// BalancedPairRegexCountSearchStrategy (this variant)
+// — constructor —
+this.openingRegex = new RegExp(escapeRegExp(opening), "g");
+
+// — processChunk —
+state.nestingLevel += newContent.match(this.openingRegex)?.length ?? 0;
+```
+
+Everything else — the anchor strategy delegation, nesting logic, buffer management, and state shape — is identical.
+
+## Benchmark Findings
+
+Benchmarked against the public `BalancedPairSearchStrategy` using `npm run bench:algorithms` (Node.js, mitata):
+
+### Construction cost
+
+| Strategy                    | Time/iter | vs indexOf loop |
+| --------------------------- | --------- | --------------- |
+| `Balanced Pair`             | ~167 ns   | baseline        |
+| `Balanced Pair (regex count)` | ~341 ns   | **~2× slower**  |
+
+`new RegExp(...)` compiles the pattern into an internal state machine even for a simple literal, which dominates construction time. The `indexOf` loop approach stores only a plain string reference — near zero overhead.
+
+### Runtime per-scenario
+
+Across all benchmark scenarios (no-match fast-path, dense matches, cross-chunk matches, large chunks, pathological cases), the two strategies are **within measurement noise** of each other. Representative samples:
+
+| Scenario                             | `Balanced Pair` | `Balanced Pair (regex count)` |
+| ------------------------------------ | --------------- | ----------------------------- |
+| Single chunk, multiple patterns      | ~1.45 µs        | ~1.49 µs                      |
+| Cross-chunk boundary (50/50 split)   | ~1.52 µs        | ~1.52 µs                      |
+| High match density (3 chunks×3)      | ~2.06 µs        | ~2.21 µs                      |
+| No matches (10 chunks)               | ~2.77 µs        | ~2.73 µs                      |
+| Pathological: repeated-prefix tokens | ~2.63 µs        | ~2.85 µs                      |
+
+No scenario showed a consistent runtime advantage for the regex variant.
+
+## Why the Regex Approach Does Not Win
+
+### Construction overhead is inherent
+
+Even a trivial literal pattern like `/(/)` must be compiled into a finite-state machine representation. `new RegExp(...)` is not free regardless of how simple the expression is, so the construction penalty is real and unavoidable.
+
+### `match()` allocates; `indexOf` does not
+
+`String.match()` with the `g` flag returns an `Array` of all matched substrings — strings we immediately discard, keeping only `.length`. That allocation and GC pressure is avoided entirely by the `indexOf` cursor loop, which only increments an integer counter.
+
+### `indexOf` is also runtime-optimised
+
+The key assumption behind the hypothesis — that `match()` can leverage SIMD string scanning unavailable to `indexOf` — does not hold. V8's `String.prototype.indexOf` implementation is also implemented in C++ and uses adaptive search strategies (linear search for short patterns, Boyer-Moore-Horspool for longer ones, with character frequency heuristics). For the short literal delimiters that `BalancedPairSearchStrategy` is typically constructed with, both paths hit the same fast native code path.
+
+### The counter runs only on match content
+
+Unlike the primary scan of the haystack (where SIMD search over a large string could in principle pay off), the opening-counter only runs over the matched content — typically a small string. The per-call overhead of entering the regex engine outweighs any benefit from SIMD for short inputs.
+
+## Conclusion
+
+Keep the `while`/`indexOf` loop in `BalancedPairSearchStrategy`. It is:
+
+- **~2× cheaper to construct** — no regex compilation
+- **Allocation-free** — increments an integer, no array created
+- **Equivalent at runtime** — native `indexOf` is comparably optimised to `String.match()` for short literal patterns
+
+This variant is retained here as evidence for that conclusion and for future re-evaluation under different runtimes or if the delimiter counting logic changes materially.

--- a/src/search-strategies/benchmarking/balanced-pair-regex-count/search-strategy.ts
+++ b/src/search-strategies/benchmarking/balanced-pair-regex-count/search-strategy.ts
@@ -1,8 +1,8 @@
 import {
   LoopedIndexOfAnchoredSearchStrategy
-} from "../../looped-indexOf-anchored/search-strategy";
-import type { BalancedPairSearchState } from "../../balanced-pair/search-strategy";
-import type { MatchResult, SearchStrategy } from "../../types";
+} from "../../looped-indexOf-anchored/search-strategy.ts";
+import type { BalancedPairSearchState } from "../../balanced-pair/search-strategy.ts";
+import type { MatchResult, SearchStrategy } from "../../types.ts";
 
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -18,11 +18,9 @@ export class BalancedPairRegexCountSearchStrategy implements SearchStrategy<
   string
 > {
   private anchorStringSearchStrategy: LoopedIndexOfAnchoredSearchStrategy;
-  private readonly opening: string;
   private readonly openingRegex: RegExp;
 
   constructor(opening: string, closing: string) {
-    this.opening = opening;
     this.openingRegex = new RegExp(escapeRegExp(opening), "g");
     this.anchorStringSearchStrategy = new LoopedIndexOfAnchoredSearchStrategy([
       opening,

--- a/src/search-strategies/benchmarking/balanced-pair-regex-count/search-strategy.ts
+++ b/src/search-strategies/benchmarking/balanced-pair-regex-count/search-strategy.ts
@@ -1,0 +1,98 @@
+import {
+  LoopedIndexOfAnchoredSearchStrategy
+} from "../../looped-indexOf-anchored/search-strategy";
+import type { BalancedPairSearchState } from "../../balanced-pair/search-strategy";
+import type { MatchResult, SearchStrategy } from "../../types";
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Variant of BalancedPairSearchStrategy that counts opening delimiters using
+ * a pre-compiled RegExp + String.match() instead of a while/indexOf loop.
+ * Exists only for benchmarking — not part of the public API.
+ */
+export class BalancedPairRegexCountSearchStrategy implements SearchStrategy<
+  BalancedPairSearchState,
+  string
+> {
+  private anchorStringSearchStrategy: LoopedIndexOfAnchoredSearchStrategy;
+  private readonly opening: string;
+  private readonly openingRegex: RegExp;
+
+  constructor(opening: string, closing: string) {
+    this.opening = opening;
+    this.openingRegex = new RegExp(escapeRegExp(opening), "g");
+    this.anchorStringSearchStrategy = new LoopedIndexOfAnchoredSearchStrategy([
+      opening,
+      closing
+    ]);
+  }
+
+  createState(): BalancedPairSearchState {
+    return {
+      ...this.anchorStringSearchStrategy.createState(),
+      nestingLevel: 0,
+      balancedBuffer: "",
+      balancedBufferStart: 0
+    };
+  }
+
+  *processChunk(
+    haystack: string,
+    state: BalancedPairSearchState
+  ): Generator<MatchResult, void, undefined> {
+    let prevMatchLength = 0;
+    for (const matchResult of this.anchorStringSearchStrategy.processChunk(
+      haystack,
+      state
+    )) {
+      if (!matchResult.isMatch) {
+        yield matchResult;
+        continue;
+      }
+      const newContent = matchResult.content.slice(prevMatchLength);
+      prevMatchLength = matchResult.content.length;
+
+      if (state.balancedBuffer === "") {
+        state.balancedBufferStart = matchResult.streamIndices[0];
+      }
+      state.balancedBuffer += newContent;
+      state.nestingLevel--;
+      state.nestingLevel += newContent.match(this.openingRegex)?.length ?? 0;
+
+      if (state.nestingLevel > 0) {
+        state.currentNeedleIndex = 1;
+      } else {
+        state.nestingLevel = 0;
+        const content = state.balancedBuffer;
+        state.balancedBuffer = "";
+        prevMatchLength = 0;
+        yield {
+          isMatch: true,
+          content,
+          streamIndices: [
+            state.balancedBufferStart,
+            matchResult.streamIndices[1]
+          ]
+        };
+      }
+    }
+    if (state.nestingLevel > 0) {
+      state.buffer = state.buffer.slice(state.balancedBuffer.length);
+    }
+  }
+
+  flush(state: BalancedPairSearchState): string {
+    const flushed = state.balancedBuffer;
+    state.balancedBuffer = "";
+    state.balancedBufferStart = 0;
+    state.nestingLevel = 0;
+    return flushed + this.anchorStringSearchStrategy.flush(state);
+  }
+
+  matchToString(match: string): string {
+    return match;
+  }
+}

--- a/src/search-strategies/index.ts
+++ b/src/search-strategies/index.ts
@@ -2,3 +2,4 @@ export {
   LoopedIndexOfAnchoredSearchStrategy as StringAnchorSearchStrategy
 } from "./looped-indexOf-anchored/index.js";
 export * from "./regex/index.js";
+export * from "./balanced-pair/index.js";

--- a/src/search-strategies/regex/index.ts
+++ b/src/search-strategies/regex/index.ts
@@ -1,1 +1,1 @@
-export * from "./search-strategy.js";
+export { RegexSearchStrategy } from "./search-strategy.js";

--- a/test/benchmarks/algorithm/validate-functionality.test.ts
+++ b/test/benchmarks/algorithm/validate-functionality.test.ts
@@ -115,7 +115,8 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         chunks: ["{{gre{{et", "in}g}} {{{n", "am}e}}!"],
         tokens: ["{{", "}}"],
         expected: "Hello World!",
-        replacement: indexedReplacement
+        replacement: indexedReplacement,
+        balanced: false
       },
       {
         chunks: ["{", " {{x}}"],
@@ -135,8 +136,8 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         expected: "{ y",
         replacement: () => "y"
       }
-    ].forEach(({ chunks, tokens, replacement, expected }) => {
-      test(`replaces content ("${chunks.join(
+    ].forEach(({ chunks, tokens, replacement, expected, balanced }) => {
+      test.skipIf(harness.supportsScenario?.({ balanced }) === false)(`replaces content ("${chunks.join(
         '", "'
       )}") -> ("${expected}")`, async () => {
         const outputs: string[] = [];
@@ -462,7 +463,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         expect(matchCount).toBe(2);
       });
 
-      it("False starts across chunk boundaries", async () => {
+      it.skipIf(harness.supportsScenario?.({ balanced: false }) === false)("False starts across chunk boundaries", async () => {
         const chunks = [
           "prefix { { { { {",
           "{ { { {{valid}}",
@@ -490,7 +491,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         expect(matchCount).toBe(2);
       });
 
-      it("Alternating single and double braces across chunks", async () => {
+      it.skipIf(harness.supportsScenario?.({ balanced: false }) === false)("Alternating single and double braces across chunks", async () => {
         const chunks = ["{ x: {", "{ z: {{val}", "} }"];
         const expected = "{ x: 42 }";
 

--- a/test/benchmarks/algorithm/validate-functionality.test.ts
+++ b/test/benchmarks/algorithm/validate-functionality.test.ts
@@ -137,7 +137,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         replacement: () => "y"
       }
     ].forEach(({ chunks, tokens, replacement, expected, balanced }) => {
-      test.skipIf(harness.supportsScenario?.({ balanced }) === false)(`replaces content ("${chunks.join(
+      test.skipIf(harness.skipScenario?.({ balanced }))(`replaces content ("${chunks.join(
         '", "'
       )}") -> ("${expected}")`, async () => {
         const outputs: string[] = [];
@@ -463,7 +463,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         expect(matchCount).toBe(2);
       });
 
-      it.skipIf(harness.supportsScenario?.({ balanced: false }) === false)("False starts across chunk boundaries", async () => {
+      it.skipIf(harness.skipScenario?.({ balanced: false }))("False starts across chunk boundaries", async () => {
         const chunks = [
           "prefix { { { { {",
           "{ { { {{valid}}",
@@ -491,7 +491,7 @@ for (const harness of Object.values(harnesses) as BaseHarness[]) {
         expect(matchCount).toBe(2);
       });
 
-      it.skipIf(harness.supportsScenario?.({ balanced: false }) === false)("Alternating single and double braces across chunks", async () => {
+      it.skipIf(harness.skipScenario?.({ balanced: false }))("Alternating single and double braces across chunks", async () => {
         const chunks = ["{ x: {", "{ z: {{val}", "} }"];
         const expected = "{ x: 42 }";
 

--- a/test/harnesses/balanced-pair-regex-count.ts
+++ b/test/harnesses/balanced-pair-regex-count.ts
@@ -27,5 +27,5 @@ export const BalancedPairRegexCountHarness = {
         replacement
       })
     ),
-  supportsScenario: ({ balanced }: { balanced?: boolean }) => balanced !== false
+  skipScenario: ({ balanced }: { balanced?: boolean }) => balanced === false
 };

--- a/test/harnesses/balanced-pair-regex-count.ts
+++ b/test/harnesses/balanced-pair-regex-count.ts
@@ -1,0 +1,31 @@
+import { SyncReplacementTransformEngine } from "../../src/engines/sync-transform-engine.ts";
+import { syncHarnessTransformer } from "./engine-harness.ts";
+import { BalancedPairRegexCountSearchStrategy } from "../../src/search-strategies/benchmarking/balanced-pair-regex-count/search-strategy.ts";
+import type { ReplacementContext } from "../../src/engines/types.ts";
+
+export const BalancedPairRegexCountHarness = {
+  name: "Balanced Pair (regex count)",
+  isAsync: false,
+  createSearchStrategy: ({
+    tokens
+  }: {
+    tokens: string[];
+    replacement?: (match: string, context: ReplacementContext) => string;
+  }) => {
+    return new BalancedPairRegexCountSearchStrategy(tokens[0], tokens[1]);
+  },
+  createTransformer: ({
+    strategy,
+    replacement
+  }: {
+    strategy: BalancedPairRegexCountSearchStrategy;
+    replacement: (match: string, context: ReplacementContext) => string;
+  }) =>
+    syncHarnessTransformer(
+      new SyncReplacementTransformEngine({
+        searchStrategy: strategy,
+        replacement
+      })
+    ),
+  supportsScenario: ({ balanced }: { balanced?: boolean }) => balanced !== false
+};

--- a/test/harnesses/balanced-pair.ts
+++ b/test/harnesses/balanced-pair.ts
@@ -1,0 +1,31 @@
+import { SyncReplacementTransformEngine } from "../../src/engines/sync-transform-engine.ts";
+import { syncHarnessTransformer } from "./engine-harness.ts";
+import { BalancedPairSearchStrategy } from "../../src/search-strategies/balanced-pair/search-strategy.ts";
+import type { ReplacementContext } from "../../src/engines/types.ts";
+
+export const BalancedPairHarness = {
+  name: "Balanced Pair",
+  isAsync: false,
+  createSearchStrategy: ({
+    tokens
+  }: {
+    tokens: string[];
+    replacement?: (match: string, context: ReplacementContext) => string;
+  }) => {
+    return new BalancedPairSearchStrategy(tokens[0], tokens[1]);
+  },
+  createTransformer: ({
+    strategy,
+    replacement
+  }: {
+    strategy: BalancedPairSearchStrategy;
+    replacement: (match: string, context: ReplacementContext) => string;
+  }) =>
+    syncHarnessTransformer(
+      new SyncReplacementTransformEngine({
+        searchStrategy: strategy,
+        replacement
+      })
+    ),
+  supportsScenario: ({ balanced }: { balanced?: boolean }) => balanced !== false
+};

--- a/test/harnesses/balanced-pair.ts
+++ b/test/harnesses/balanced-pair.ts
@@ -27,5 +27,5 @@ export const BalancedPairHarness = {
         replacement
       })
     ),
-  supportsScenario: ({ balanced }: { balanced?: boolean }) => balanced !== false
+  skipScenario: ({ balanced }: { balanced?: boolean }) => balanced === false
 };

--- a/test/harnesses/index.ts
+++ b/test/harnesses/index.ts
@@ -13,3 +13,5 @@ export * from "./regex.ts";
 export * from "./regex-callback.ts";
 export * from "./regex-canonical.ts";
 export * from "./regex-anchor-sequence.ts";
+export * from "./balanced-pair.ts";
+export * from "./balanced-pair-regex-count.ts";

--- a/test/harnesses/types.ts
+++ b/test/harnesses/types.ts
@@ -19,4 +19,6 @@ export type BaseHarness = {
     transform: (chunk: string, controller: unknown) => void | Promise<void>;
     flush: (controller: unknown) => void;
   };
+  /** When defined, a test scenario is skipped if this returns false. */
+  supportsScenario?: (meta: { balanced?: boolean }) => boolean;
 };

--- a/test/harnesses/types.ts
+++ b/test/harnesses/types.ts
@@ -19,6 +19,6 @@ export type BaseHarness = {
     transform: (chunk: string, controller: unknown) => void | Promise<void>;
     flush: (controller: unknown) => void;
   };
-  /** When defined, a test scenario is skipped if this returns false. */
-  supportsScenario?: (meta: { balanced?: boolean }) => boolean;
+  /** When defined, a test scenario is skipped if this returns true. */
+  skipScenario?: (meta: { balanced?: boolean }) => boolean;
 };


### PR DESCRIPTION
## Issue

resolves #31

## Details

Added a `BalancedPairSearchStrategy` for matching two string anchors, but respecting nesting levels so only matching where "balanced"

## Scout rule

Added `[!CAUTION]` to `README.md` re: `utf8`

## Semantic Version Impact

<!-- Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/ -->

- [ ] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [x] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
