### PR TITLE
[NO ISSUE] Various documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ const searchStrategy = new StringAnchorSearchStrategy(["{{", "}}"]); // 2+ "anch
 ...or:
 
 ```ts
+import { BalancedPairSearchStrategy } from "replace-content-transformer";
 const searchStrategy = new BalancedPairSearchStrategy("{{", "}}"); // delimiter pair, nesting aware
 ```
 

--- a/README.md
+++ b/README.md
@@ -538,8 +538,6 @@ import { RegexSearchStrategy } from "replace-content-transformer";
 const searchStrategy = new RegexSearchStrategy(/<div>.+?<\/div>/s); // regular expression for complete match
 ```
 
-
-
 ### 🦾 Engines
 
 Engines process chunks from the `Transformer` (web) / `stream.Transform` (node), orchestrating replacement using a search strategy. They implement one of two interfaces:

--- a/README.md
+++ b/README.md
@@ -509,6 +509,9 @@ const searchStrategy =
   searchStrategyFactory(input: string | string[] | RegExp);
 ```
 
+> [!IMPORTANT]
+> The `BalancedPairSearchStrategy` is not returned by this factory, since it cannot be determined from input, so import this directly, as described below.
+
 However, if choice of string vs regular expression requirement is known at design time, a smaller bundle will be afforded by importing a strategy directly:
 
 ```ts
@@ -525,12 +528,17 @@ const searchStrategy = new StringAnchorSearchStrategy(["{{", "}}"]); // 2+ "anch
 ...or:
 
 ```ts
+const searchStrategy = new BalancedPairSearchStrategy("{{", "}}"); // delimiter pair, nesting aware
+```
+
+...or:
+
+```ts
 import { RegexSearchStrategy } from "replace-content-transformer";
 const searchStrategy = new RegexSearchStrategy(/<div>.+?<\/div>/s); // regular expression for complete match
 ```
 
-> [!IMPORTANT]
-> The `BalancedPairSearchStrategy` is not returned by this factory, since it cannot be determined from input, so import this directly, as described above.
+
 
 ### 🦾 Engines
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `BalancedPairSearchStrategy` search strategy for matching two string anchors, but respecting nesting levels so only matching where "balanced"
-- `BalancedPairRegexCountSearchStrategy` benchmarking search strategy, as above but using `str.match(openingRegex)` on the matched substring to count opening delimiter occurrences for nesting-level adjustment, for comparison to looped `indexOf`
+- `BalancedPairRegexCountSearchStrategy` benchmarking-only search strategy, as above but counting opening delimiter occurrences on each newly appended match segment via `newContent.match(openingRegex)` for nesting-level adjustment, for comparison to looped `indexOf`
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `BalancedPairSearchStrategy` search strategy for matching two string anchors, but respecting nesting levels so only matching where "balanced"
-- `BalancedPairRegexCountSearchStrategy` benchmarking search strategy, as above but with `string.match(/regex/)` to find orphan opening tags, for comparison to looped `indexOf`
+- `BalancedPairRegexCountSearchStrategy` benchmarking search strategy, as above but using `str.match(openingRegex)` on the matched substring to count opening delimiter occurrences for nesting-level adjustment, for comparison to looped `indexOf`
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `BalancedPairSearchStrategy` for matching two string anchors, but respecting nesting levels so only matching where "balanced"
+- `BalancedPairSearchStrategy` search strategy for matching two string anchors, but respecting nesting levels so only matching where "balanced"
+- `BalancedPairRegexCountSearchStrategy` benchmarking search strategy, as above but with `string.match(/regex/)` to find orphan opening tags, for comparison to looped `indexOf`
 
 ### Changed
 

--- a/src/search-strategies/README.md
+++ b/src/search-strategies/README.md
@@ -2,7 +2,7 @@
 
 This directory contains search strategies for finding and matching patterns in streaming content. Each strategy handles patterns that may span chunk boundaries.
 
-These strategies have been chosen from an array of alternatives based on performance (see [benchmarking](#benchmark-strategies)). The "string anchor" should be preferred, since slightly more performant, unless more complex matching is required.
+These strategies have been chosen from an array of alternatives based on performance (see [benchmarking](#benchmark-strategies)). The "string anchor" should be preferred, since most performant (slightly), unless more complex matching is required.
 
 ## 🪝 String Anchor (N-Token Sequential Matching)
 
@@ -19,7 +19,7 @@ Single or Multiple-token sequential matching using smart buffering (only when th
 
 **[balanced-pair](./balanced-pair/README.md)** - Nesting-aware delimiter matching strategy implementation
 
-Matches opening/closing delimiter pairs where nesting is meaningful: the match only completes once every inner opening has a corresponding closing. Built on top of `StringAnchorSearchStrategy`, adding a nesting-level counter that keeps the match open until the outermost pair is balanced.
+Matches opening/closing delimiters where nesting is meaningful: the match only completes once every inner opening has a corresponding closing. Built on top of `StringAnchorSearchStrategy`, adding a nesting-level counter that keeps the match open until the outermost pair is balanced.
 
 - **Algorithm**: Nesting-level tracking over sequential anchor matching
 - **Performance**: O(n+m) for scanning + O(k) per match increment to count inner openings (k = length of new match content)

--- a/src/search-strategies/README.md
+++ b/src/search-strategies/README.md
@@ -2,7 +2,7 @@
 
 This directory contains search strategies for finding and matching patterns in streaming content. Each strategy handles patterns that may span chunk boundaries.
 
-These strategies have been chosen from an array of alternatives based on performance (see [benchmarking](#benchmark-strategies)). The "string anchor" should be preferred, since most performant (slightly), unless more complex matching is required.
+These strategies have been chosen from an array of alternatives based on performance (see [benchmarking](#benchmark-strategies)). The "string anchor" is most performant (marginally), so should be preferred unless more complex matching is required.
 
 ## 🪝 String Anchor (N-Token Sequential Matching)
 

--- a/src/search-strategies/benchmarking/README.md
+++ b/src/search-strategies/benchmarking/README.md
@@ -43,11 +43,12 @@ Pattern matching using **regular expressions**, with partial match detection for
 - **[regex-callback](./regex-callback/README.md)** - Callback-based variant.
 - **[regex-canonical](./regex-canonical/README.md)** - Direct `Transformer` implementation based on WHATWG Streams specification example.
 
-### Meta-Strategy
+### Meta-Strategies
 
 Composable strategy for sequential pattern matching across multiple sub-strategies.
 
 - **[anchor-sequence](./anchor-sequence/README.md)** - Composes multiple "cancellable" strategies for sequential matching.
+- **[balanced-pair-regex-count](./balanced-pair-regex-count/README.md)** -  Like the publically exported [`balanced-pair`](../balanced-pair/README.md) strategy, this composes the [`looped-indexof-anchored`](../looped-indexOf-anchored/README.md) with a short-circuit preventing complete match if opening tags are found within a match, adjusting a nesting level. This benchmarking strategy uses [`String.match(regex)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#regexp) to count these opening tags, as a comparison to a manual looped-`indexOf`.
 
 ## 📊 Algorithm Comparison
 

--- a/src/search-strategies/benchmarking/README.md
+++ b/src/search-strategies/benchmarking/README.md
@@ -48,7 +48,7 @@ Pattern matching using **regular expressions**, with partial match detection for
 Composable strategy for sequential pattern matching across multiple sub-strategies.
 
 - **[anchor-sequence](./anchor-sequence/README.md)** - Composes multiple "cancellable" strategies for sequential matching.
-- **[balanced-pair-regex-count](./balanced-pair-regex-count/README.md)** - Like the publicly exported [`balanced-pair`](../balanced-pair/README.md) strategy, this composes the [`looped-indexOf-anchored`](../looped-indexOf-anchored/README.md) with a short-circuit preventing complete match if opening tags are found within a match, adjusting a nesting level. This benchmarking strategy uses [`String.prototype.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#regexp) to count these opening tags, as a comparison to a manual looped-`indexOf`.
+ - **[balanced-pair-regex-count](./balanced-pair-regex-count/README.md)** - Like the publicly exported [`balanced-pair`](../balanced-pair/README.md) strategy, this composes the [`looped-indexof-anchored`](../looped-indexOf-anchored/README.md) and delays completion by tracking nesting level: decrementing on closing delimiters and incrementing by counting opening delimiters found within a match. This benchmarking strategy uses [`String.prototype.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#regexp) to count thes
 
 ## 📊 Algorithm Comparison
 

--- a/src/search-strategies/benchmarking/README.md
+++ b/src/search-strategies/benchmarking/README.md
@@ -48,7 +48,7 @@ Pattern matching using **regular expressions**, with partial match detection for
 Composable strategy for sequential pattern matching across multiple sub-strategies.
 
 - **[anchor-sequence](./anchor-sequence/README.md)** - Composes multiple "cancellable" strategies for sequential matching.
-- **[balanced-pair-regex-count](./balanced-pair-regex-count/README.md)** -  Like the publically exported [`balanced-pair`](../balanced-pair/README.md) strategy, this composes the [`looped-indexof-anchored`](../looped-indexOf-anchored/README.md) with a short-circuit preventing complete match if opening tags are found within a match, adjusting a nesting level. This benchmarking strategy uses [`String.match(regex)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#regexp) to count these opening tags, as a comparison to a manual looped-`indexOf`.
+- **[balanced-pair-regex-count](./balanced-pair-regex-count/README.md)** - Like the publicly exported [`balanced-pair`](../balanced-pair/README.md) strategy, this composes the [`looped-indexof-anchored`](../looped-indexOf-anchored/README.md) with a short-circuit preventing complete match if opening tags are found within a match, adjusting a nesting level. This benchmarking strategy uses [`String.prototype.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#regexp) to count these opening tags, as a comparison to a manual looped-`indexOf`.
 
 ## 📊 Algorithm Comparison
 

--- a/src/search-strategies/benchmarking/README.md
+++ b/src/search-strategies/benchmarking/README.md
@@ -48,7 +48,7 @@ Pattern matching using **regular expressions**, with partial match detection for
 Composable strategy for sequential pattern matching across multiple sub-strategies.
 
 - **[anchor-sequence](./anchor-sequence/README.md)** - Composes multiple "cancellable" strategies for sequential matching.
-- **[balanced-pair-regex-count](./balanced-pair-regex-count/README.md)** - Like the publicly exported [`balanced-pair`](../balanced-pair/README.md) strategy, this composes the [`looped-indexof-anchored`](../looped-indexOf-anchored/README.md) with a short-circuit preventing complete match if opening tags are found within a match, adjusting a nesting level. This benchmarking strategy uses [`String.prototype.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#regexp) to count these opening tags, as a comparison to a manual looped-`indexOf`.
+- **[balanced-pair-regex-count](./balanced-pair-regex-count/README.md)** - Like the publicly exported [`balanced-pair`](../balanced-pair/README.md) strategy, this composes the [`looped-indexOf-anchored`](../looped-indexOf-anchored/README.md) with a short-circuit preventing complete match if opening tags are found within a match, adjusting a nesting level. This benchmarking strategy uses [`String.prototype.match()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#regexp) to count these opening tags, as a comparison to a manual looped-`indexOf`.
 
 ## 📊 Algorithm Comparison
 


### PR DESCRIPTION
## Details

Added some missing details from https://github.com/TomStrepsil/replace-content-transformer/pull/42:
- explaining that `searchStrategyFactory` cannot return the balanced strategy
- added the variant balanced strategy to the "meta-strategies" section of the benchmarking `README.md`
- various syntactical fixes

## Semantic Version Impact

<!-- Select ONE checkbox to indicate the semver impact of this change. Learn more at https://semver.org/ -->

- [x] **PATCH** - Bug fixes and minor changes (backwards compatible)
- [ ] **MINOR** - New features (backwards compatible)
- [ ] **MAJOR** - Breaking changes (not backwards compatible)

## Checklist

- [x] I have added an entry to the `[Unreleased]` section in [`CHANGELOG.md`](../docs/CHANGELOG.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
